### PR TITLE
feat(doctor): add machine-actionable remediation

### DIFF
--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -35,6 +35,7 @@ No active tasks are currently queued. Add the next executable task contract in `
 | [qtx-0020](./tasks/qtx-0020-add-release-workflow-smoke-validation.md) | `done` | `high` | Add release workflow smoke validation | - |
 | [qtx-0021](./tasks/qtx-0021-write-release-and-self-upgrade-debugging-runbook.md) | `done` | `medium` | Write release and self-upgrade debugging runbook | - |
 | [qtx-0022](./tasks/qtx-0022-document-skill-installation-and-distribution-flow.md) | `done` | `low` | Document skill installation and distribution flow | - |
+| [qtx-0023](./tasks/qtx-0023-make-doctor-output-machine-actionable-remediation.md) | `done` | `high` | Make doctor output machine-actionable remediation | - |
 
 ## Intake rules
 

--- a/autonomy/tasks/qtx-0023-make-doctor-output-machine-actionable-remediation.md
+++ b/autonomy/tasks/qtx-0023-make-doctor-output-machine-actionable-remediation.md
@@ -1,0 +1,49 @@
+---
+id: qtx-0023
+title: Make doctor output machine-actionable remediation
+status: done
+priority: high
+area: surface
+depends_on: []
+human_review: required
+checks:
+  - bun run lint
+  - bun run typecheck
+docs_to_update:
+  - openspec/specs/self-upgrade/spec.md
+  - openspec/specs/agent-update/spec.md
+  - docs/runbooks/quantex-troubleshooting.md
+  - skills/quantex-cli/references/automation-playbook.md
+---
+
+# Task: Make doctor output machine-actionable remediation
+
+## Goal
+
+Make `quantex doctor --json` expose remediation data that another agent can consume directly instead of inferring next steps from warning prose alone.
+
+## Context
+
+The first project-memory round proved that Quantex can store and evolve durable knowledge. The next round should prove that Quantex itself can expose machine-actionable lifecycle guidance so a future agent can decide what to do next with less human interpretation.
+
+## Constraints
+
+- Keep Quantex within its lifecycle CLI scope. Do not turn `doctor` into a workflow engine.
+- Preserve current human-readable diagnosis value while strengthening the structured surface.
+
+## Implementation Notes
+
+- Relevant files: `src/commands/doctor.ts`, `src/commands/schema.ts`, `test/commands/doctor.test.ts`, `test/commands/schema.test.ts`
+- Relevant commands: `quantex doctor --json`, `quantex schema doctor --json`
+- Relevant specs: `openspec/specs/self-upgrade/spec.md`, `openspec/specs/agent-update/spec.md`
+
+## Done When
+
+- `doctor --json` issues include stable machine-actionable remediation fields.
+- The `schema` command exposes the doctor contract explicitly.
+- The troubleshooting and automation docs tell future agents to consume the structured doctor fields.
+
+## Non-Goals
+
+- Implementing automatic remediation execution inside `doctor`
+- Expanding Quantex into a workflow orchestration surface

--- a/docs/runbooks/quantex-troubleshooting.md
+++ b/docs/runbooks/quantex-troubleshooting.md
@@ -16,7 +16,7 @@ Provide a canonical diagnostic and recovery path when Quantex fails, behaves une
 - `quantex commands --json`
 - `quantex inspect <agent> --json`
 - `quantex resolve <agent> --json`
-- `quantex doctor`
+- `quantex doctor --json`
 
 ## Triage order
 
@@ -35,6 +35,15 @@ Why this order:
 - `inspect` tells you how Quantex sees the specific agent
 - `resolve` tells you what executable Quantex would actually launch
 - `doctor` is for diagnosing what is wrong and how to recover
+
+When consuming `doctor --json` in automation, prefer the structured issue fields over parsing prose:
+
+- `issues[].code`
+- `issues[].category`
+- `issues[].blocking`
+- `issues[].suggestedAction`
+- `issues[].suggestedCommands`
+- `issues[].docsRef`
 
 ## Common failure patterns
 

--- a/openspec/specs/agent-update/spec.md
+++ b/openspec/specs/agent-update/spec.md
@@ -72,3 +72,12 @@ Agent update behavior SHALL be inspectable through user-facing diagnostic comman
 - GIVEN the user runs `quantex list`, `quantex info <agent>`, or `quantex doctor`
 - WHEN Quantex renders the result
 - THEN the output includes enough install-source and recovery information to explain how update behavior will be chosen
+
+#### Scenario: Doctor JSON exposes machine-actionable agent remediation
+
+- GIVEN the user runs `quantex doctor --json`
+- AND Quantex emits an agent-related issue
+- WHEN the command returns structured data
+- THEN each agent-related issue includes a stable issue code
+- AND includes `subject`, `suggestedAction`, and `suggestedCommands`
+- AND allows an automation layer to distinguish between inspection, self-update, and manual-follow-up paths

--- a/openspec/specs/self-upgrade/spec.md
+++ b/openspec/specs/self-upgrade/spec.md
@@ -97,6 +97,15 @@ The self-upgrade system SHALL provide recovery hints when automatic upgrade is u
 - THEN the output includes an actionable warning that explains the mismatch
 - AND points the user toward reinstalling or restoring a supported install source
 
+#### Scenario: Doctor JSON exposes machine-actionable self remediation
+
+- GIVEN the user runs `quantex doctor --json`
+- AND Quantex emits a self-related issue
+- WHEN the command returns structured data
+- THEN each self-related issue includes a stable issue code
+- AND includes `blocking`, `category`, `suggestedAction`, and `suggestedCommands`
+- AND includes a docs reference that points to the relevant recovery guide
+
 #### Scenario: Upgrade failure surfaces a recovery path
 
 - GIVEN a self-upgrade attempt fails

--- a/skills/quantex-cli/references/automation-playbook.md
+++ b/skills/quantex-cli/references/automation-playbook.md
@@ -138,3 +138,4 @@ This avoids depending on stale assumptions about flags, schema refs, output mode
 - Prefer `inspect`, `ensure`, `resolve`, and `exec` over scraping `list` or `info`.
 - Prefer `exec` over shortcut commands in automation.
 - Use `doctor` when the question is "why is this environment broken?" rather than "what can I do?"
+- When using `quantex doctor --json`, prefer `data.issues[].suggestedAction`, `suggestedCommands`, and `docsRef` over scraping warning prose.

--- a/skills/quantex-cli/references/command-recipes.md
+++ b/skills/quantex-cli/references/command-recipes.md
@@ -80,14 +80,14 @@ Rules:
 quantex config
 quantex config get defaultPackageManager
 quantex config set defaultPackageManager npm
-quantex doctor
+quantex doctor --json
 quantex upgrade --check --json
 ```
 
 Use:
 
 - `config` for CLI policy and defaults
-- `doctor` for environment or recovery diagnosis
+- `doctor` for environment or recovery diagnosis, especially when another agent should consume structured remediation hints
 - `upgrade` for Quantex itself, not downstream agents
 
 ## High-value global flags

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,15 +1,36 @@
 import type { CommandResult } from '../output/types'
 import { getAgentUpdateFailureHint, getManualAgentUpdateMessage } from '../agent-update'
+import { BUILD_PACKAGE_NAME } from '../generated/build-meta'
 import { createSuccessResult, emitCommandResult } from '../output'
 import { getSelfUpgradeRecoveryHintForInspection, inspectSelf } from '../self'
 import { inspectRegisteredAgents } from '../services/agents'
 import { pc } from '../utils/color'
 import { isBrewAvailable, isBunAvailable, isNpmAvailable, isWingetAvailable } from '../utils/detect'
 
+type DoctorIssueCategory = 'agent' | 'installers' | 'self'
+type DoctorIssueSubjectKind = 'agent' | 'self' | 'system'
+type DoctorSuggestedAction
+  = 'follow-manual-agent-update'
+    | 'inspect-agent-install-source'
+    | 'reinstall-self-with-auto-update-source'
+    | 'restore-managed-installer'
+    | 'restore-self-installer'
+    | 'run-agent-self-update'
+    | 'run-self-upgrade'
+
 interface DoctorIssue {
+  blocking: boolean
+  category: DoctorIssueCategory
   code: string
+  docsRef?: string
   message: string
   severity: 'warning'
+  subject: {
+    kind: DoctorIssueSubjectKind
+    name?: string
+  }
+  suggestedAction: DoctorSuggestedAction
+  suggestedCommands: string[]
 }
 
 interface DoctorData {
@@ -58,48 +79,83 @@ export async function doctorCommand(): Promise<CommandResult<DoctorData>> {
       sourceLabel: inspection.sourceLabel,
     }))
   const issues: DoctorIssue[] = []
+  const troubleshootingDocsRef = 'docs/runbooks/quantex-troubleshooting.md'
+  const selfUpgradeDocsRef = 'docs/runbooks/release-and-self-upgrade-debugging.md'
 
   if (!bunAvailable && !npmAvailable && !brewAvailable && !wingetAvailable) {
     issues.push({
+      blocking: true,
+      category: 'installers',
       code: 'NO_MANAGED_INSTALLER',
+      docsRef: troubleshootingDocsRef,
       message: 'No managed installer found. Install bun, npm, brew, or winget before relying on managed lifecycle operations.',
       severity: 'warning',
+      subject: { kind: 'system' },
+      suggestedAction: 'restore-managed-installer',
+      suggestedCommands: [],
     })
   }
 
   if ((selfInspection.installSource === 'bun' && !bunAvailable) || (selfInspection.installSource === 'npm' && !npmAvailable)) {
     issues.push({
+      blocking: true,
+      category: 'self',
       code: 'SELF_INSTALLER_MISSING',
+      docsRef: selfUpgradeDocsRef,
       message: `Quantex CLI is tracked as a ${selfInspection.installSource} install, but ${selfInspection.installSource} is not available in PATH. Reinstall that package manager or reinstall Quantex from a supported source.`,
       severity: 'warning',
+      subject: { kind: 'self', name: 'quantex' },
+      suggestedAction: 'restore-self-installer',
+      suggestedCommands: getSelfRecoveryCommands(selfInspection.installSource, selfInspection.updateChannel),
     })
   }
 
   if (!selfInspection.canAutoUpdate) {
     issues.push({
+      blocking: false,
+      category: 'self',
       code: 'SELF_AUTO_UPDATE_UNAVAILABLE',
+      docsRef: selfUpgradeDocsRef,
       message: `Quantex CLI cannot auto-update from install source "${selfInspection.installSource}". Reinstall via bun, npm, or the standalone binary if you want \`quantex upgrade\` support.`,
       severity: 'warning',
+      subject: { kind: 'self', name: 'quantex' },
+      suggestedAction: 'reinstall-self-with-auto-update-source',
+      suggestedCommands: [],
     })
   }
 
   if (selfOutdated && selfInspection.recommendedUpgradeCommand) {
     const recoveryHint = getSelfUpgradeRecoveryHintForInspection(selfInspection)
     issues.push({
+      blocking: false,
+      category: 'self',
       code: 'SELF_UPDATE_AVAILABLE',
+      docsRef: selfUpgradeDocsRef,
       message: recoveryHint
         ? `Quantex CLI ${selfInspection.currentVersion} is behind ${selfInspection.latestVersion}. Run ${selfInspection.recommendedUpgradeCommand} or follow: ${recoveryHint}`
         : `Quantex CLI ${selfInspection.currentVersion} is behind ${selfInspection.latestVersion}. Run ${selfInspection.recommendedUpgradeCommand}.`,
       severity: 'warning',
+      subject: { kind: 'self', name: 'quantex' },
+      suggestedAction: 'run-self-upgrade',
+      suggestedCommands: [selfInspection.recommendedUpgradeCommand],
     })
   }
 
   for (const inspection of inspections.filter(candidate => candidate.inPath)) {
     if (!inspection.installedState) {
       issues.push({
+        blocking: false,
+        category: 'agent',
         code: 'AGENT_UNTRACKED_IN_PATH',
+        docsRef: troubleshootingDocsRef,
         message: `${inspection.agent.displayName} is available in PATH but not tracked as a managed Quantex install. Use \`quantex inspect ${inspection.agent.name} --json\` to confirm the source, then reinstall through Quantex if you want managed lifecycle operations.`,
         severity: 'warning',
+        subject: { kind: 'agent', name: inspection.agent.name },
+        suggestedAction: 'inspect-agent-install-source',
+        suggestedCommands: [
+          `quantex inspect ${inspection.agent.name} --json`,
+          `quantex install ${inspection.agent.name}`,
+        ],
       })
     }
 
@@ -114,9 +170,15 @@ export async function doctorCommand(): Promise<CommandResult<DoctorData>> {
       ?? getManualAgentUpdateMessage(inspection.agent)
 
     issues.push({
+      blocking: false,
+      category: 'agent',
       code: 'AGENT_MANUAL_UPDATE_REQUIRED',
+      docsRef: troubleshootingDocsRef,
       message: `${inspection.agent.displayName} ${inspection.installedVersion} is behind ${inspection.latestVersion}, but the current source is ${inspection.sourceLabel}. ${recoveryHint}`,
       severity: 'warning',
+      subject: { kind: 'agent', name: inspection.agent.name },
+      suggestedAction: inspection.agent.selfUpdate ? 'run-agent-self-update' : 'follow-manual-agent-update',
+      suggestedCommands: inspection.agent.selfUpdate ? [inspection.agent.selfUpdate.command.join(' ')] : [],
     })
   }
 
@@ -184,9 +246,23 @@ function renderDoctorHuman(result: { data?: DoctorData }): void {
     console.log(pc.green('  No issues found.'))
   }
   else {
-    for (const issue of result.data.issues)
+    for (const issue of result.data.issues) {
       console.log(pc.yellow(`  - ${issue.message}`))
+      if (issue.suggestedCommands.length > 0)
+        console.log(pc.dim(`    Next: ${issue.suggestedCommands.join(' | ')}`))
+    }
   }
 
   console.log()
+}
+
+function getSelfRecoveryCommands(installSource: string, updateChannel: 'stable' | 'beta'): string[] {
+  const versionTag = updateChannel === 'beta' ? 'beta' : 'latest'
+
+  if (installSource === 'bun')
+    return [`bun add -g ${BUILD_PACKAGE_NAME}@${versionTag}`]
+  if (installSource === 'npm')
+    return [`npm install -g ${BUILD_PACKAGE_NAME}@${versionTag}`]
+
+  return []
 }

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -195,6 +195,89 @@ const schemaCatalog: SchemaDocument[] = [
     dataSchema: {
       additionalProperties: false,
       properties: {
+        agents: {
+          items: {
+            additionalProperties: false,
+            properties: {
+              displayName: { type: 'string' },
+              installedVersion: { type: 'string' },
+              latestVersion: { type: 'string' },
+              lifecycle: { type: 'string' },
+              outdated: { type: 'boolean' },
+              sourceLabel: { type: 'string' },
+            },
+            required: ['displayName', 'lifecycle', 'outdated', 'sourceLabel'],
+            type: 'object',
+          },
+          type: 'array',
+        },
+        installers: {
+          additionalProperties: false,
+          properties: {
+            brew: { type: 'boolean' },
+            bun: { type: 'boolean' },
+            npm: { type: 'boolean' },
+            winget: { type: 'boolean' },
+          },
+          required: ['brew', 'bun', 'npm', 'winget'],
+          type: 'object',
+        },
+        issues: {
+          items: {
+            additionalProperties: false,
+            properties: {
+              blocking: { type: 'boolean' },
+              category: { type: 'string' },
+              code: { type: 'string' },
+              docsRef: { type: 'string' },
+              message: { type: 'string' },
+              severity: { type: 'string' },
+              subject: {
+                additionalProperties: false,
+                properties: {
+                  kind: { type: 'string' },
+                  name: { type: 'string' },
+                },
+                required: ['kind'],
+                type: 'object',
+              },
+              suggestedAction: { type: 'string' },
+              suggestedCommands: {
+                items: { type: 'string' },
+                type: 'array',
+              },
+            },
+            required: ['blocking', 'category', 'code', 'message', 'severity', 'subject', 'suggestedAction', 'suggestedCommands'],
+            type: 'object',
+          },
+          type: 'array',
+        },
+        self: {
+          additionalProperties: false,
+          properties: {
+            canAutoUpdate: { type: 'boolean' },
+            currentVersion: { type: 'string' },
+            installSource: { type: 'string' },
+            latestVersion: { type: 'string' },
+            outdated: { type: 'boolean' },
+            recoveryHint: { type: 'string' },
+          },
+          required: ['canAutoUpdate', 'currentVersion', 'installSource', 'outdated'],
+          type: 'object',
+        },
+      },
+      required: ['agents', 'installers', 'issues', 'self'],
+      type: 'object',
+    },
+    description: 'Diagnostic state and remediation guidance for the current environment',
+    envelopeSchema: baseEnvelopeSchema,
+    name: 'doctor',
+    ndjsonEventSchema: baseNdjsonEventSchema,
+  },
+  {
+    dataSchema: {
+      additionalProperties: false,
+      properties: {
         agent: { type: 'object' },
         changed: { type: 'boolean' },
         installState: { type: 'object' },

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as agents from '../../src/agents'
+import { setCliContext } from '../../src/cli-context'
 import { doctorCommand } from '../../src/commands/doctor'
 import * as selfModule from '../../src/self'
 import * as state from '../../src/state'
@@ -42,6 +43,17 @@ const testAgent = {
     linux: [{ type: 'bun' as const }],
     macos: [{ type: 'bun' as const }],
     windows: [{ type: 'bun' as const }],
+  },
+}
+
+const selfUpdatingAgent = {
+  ...testAgent,
+  binaryName: 'self-updating-bin',
+  displayName: 'Self Updating Agent',
+  name: 'self-updating-agent',
+  selfUpdate: {
+    command: ['self-updating-bin', 'update'],
+    versionAfter: 'same-process' as const,
   },
 }
 
@@ -237,5 +249,78 @@ describe('doctorCommand', () => {
     const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
     expect(output).toContain('available in PATH but not tracked as a managed Quantex install')
     expect(output).toContain('quantex inspect test-agent --json')
+  })
+
+  it('returns machine-actionable self remediation in json mode', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'doctor-run-id',
+    })
+    isBunSpy.mockResolvedValue(false)
+    isNpmSpy.mockResolvedValue(true)
+    allAgentsSpy.mockReturnValue([])
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: '/Users/test/.bun/bin/qtx',
+      installSource: 'bun',
+      latestVersion: '1.1.0',
+      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    const result = await doctorCommand()
+    const payload = JSON.parse(logSpy.mock.calls[0][0])
+    const installerIssue = result.data?.issues.find(issue => issue.code === 'SELF_INSTALLER_MISSING')
+    const updateIssue = result.data?.issues.find(issue => issue.code === 'SELF_UPDATE_AVAILABLE')
+
+    expect(payload.meta.runId).toBe('doctor-run-id')
+    expect(installerIssue).toMatchObject({
+      blocking: true,
+      category: 'self',
+      docsRef: 'docs/runbooks/release-and-self-upgrade-debugging.md',
+      subject: { kind: 'self', name: 'quantex' },
+      suggestedAction: 'restore-self-installer',
+      suggestedCommands: ['bun add -g quantex-cli@latest'],
+    })
+    expect(updateIssue).toMatchObject({
+      category: 'self',
+      suggestedAction: 'run-self-upgrade',
+      suggestedCommands: ['quantex upgrade'],
+    })
+  })
+
+  it('returns machine-actionable agent remediation in json mode', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'doctor-agent-run-id',
+    })
+    isBunSpy.mockResolvedValue(true)
+    isNpmSpy.mockResolvedValue(true)
+    allAgentsSpy.mockReturnValue([selfUpdatingAgent])
+    binaryInPathSpy.mockResolvedValue(true)
+    installedStateSpy.mockResolvedValue(undefined)
+    installedVerSpy.mockResolvedValue('1.0.0')
+    latestVerSpy.mockResolvedValue('2.0.0')
+
+    const result = await doctorCommand()
+    const untrackedIssue = result.data?.issues.find(issue => issue.code === 'AGENT_UNTRACKED_IN_PATH')
+    const updateIssue = result.data?.issues.find(issue => issue.code === 'AGENT_MANUAL_UPDATE_REQUIRED')
+
+    expect(untrackedIssue).toMatchObject({
+      category: 'agent',
+      docsRef: 'docs/runbooks/quantex-troubleshooting.md',
+      subject: { kind: 'agent', name: 'self-updating-agent' },
+      suggestedAction: 'inspect-agent-install-source',
+      suggestedCommands: ['quantex inspect self-updating-agent --json', 'quantex install self-updating-agent'],
+    })
+    expect(updateIssue).toMatchObject({
+      category: 'agent',
+      suggestedAction: 'run-agent-self-update',
+      suggestedCommands: ['self-updating-bin update'],
+    })
   })
 })

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -20,6 +20,7 @@ describe('schemaCommand', () => {
     expect(output).toContain('Quantex Schemas')
     expect(output).toContain('capabilities')
     expect(output).toContain('commands')
+    expect(output).toContain('doctor')
     expect(output).toContain('inspect')
     expect(output).toContain('resolve')
   })
@@ -49,5 +50,21 @@ describe('schemaCommand', () => {
     await schemaCommand('missing-command')
 
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown schema target'))
+  })
+
+  it('returns the doctor schema in json mode', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'schema-doctor-run-id',
+    })
+
+    await schemaCommand('doctor')
+
+    const payload = JSON.parse(logSpy.mock.calls[0][0])
+    expect(payload.data.commands).toHaveLength(1)
+    expect(payload.data.commands[0].name).toBe('doctor')
+    expect(payload.data.commands[0].dataSchema.properties.issues.items.properties.suggestedAction).toBeDefined()
+    expect(payload.data.commands[0].dataSchema.properties.issues.items.properties.suggestedCommands).toBeDefined()
   })
 })

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -19,6 +19,7 @@ describe('surface contracts', () => {
       [
         "capabilities",
         "commands",
+        "doctor",
         "ensure",
         "inspect",
         "resolve",


### PR DESCRIPTION
## Summary

Strengthen `quantex doctor --json` so each diagnostic issue includes machine-actionable remediation metadata instead of only warning prose. This also adds an explicit `doctor` schema entry and updates the troubleshooting / automation guidance that agents should follow.

## Linked Artifacts

- Issue: N/A
- Task: `qtx-0023` (`autonomy/tasks/qtx-0023-make-doctor-output-machine-actionable-remediation.md`)
- ADR: N/A
- OpenSpec: `openspec/specs/self-upgrade/spec.md`, `openspec/specs/agent-update/spec.md`
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `autonomy/...`
- [x] `openspec/...`
- [ ] Follow-up task created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant task, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Notes

This is the first concrete task in the second autonomy-validation round. It keeps Quantex in lifecycle-CLI scope while making `doctor` easier for future agents to consume programmatically.