### PR TITLE
fix(autonomy): place queued tasks in the right section

### DIFF
--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -4,8 +4,6 @@ This queue is the prioritized entry point for future agent-driven work.
 
 ## Active queue
 
-No active tasks are currently queued. Add the next executable task contract in `autonomy/tasks/` before reopening this section.
-
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
 
@@ -13,6 +11,7 @@ No active tasks are currently queued. Add the next executable task contract in `
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
+| [qtx-0024](./tasks/qtx-0024-fix-task-queue-insertion-when-active-queue-is-empty.md) | `done` | `medium` | Fix task queue insertion when active queue is empty | - |
 | [qtx-0001](./tasks/qtx-0001-migrate-troubleshooting-into-runbooks.md) | `done` | `high` | Migrate troubleshooting knowledge into canonical runbooks | - |
 | [qtx-0002](./tasks/qtx-0002-consolidate-auto-upgrade-docs-into-openspec-and-adr.md) | `done` | `high` | Consolidate auto-upgrade design into OpenSpec specs and ADRs | - |
 | [qtx-0003](./tasks/qtx-0003-convert-root-backlogs-into-task-contracts.md) | `done` | `medium` | Convert legacy root backlogs into autonomy task contracts | - |

--- a/autonomy/tasks/qtx-0024-fix-task-queue-insertion-when-active-queue-is-empty.md
+++ b/autonomy/tasks/qtx-0024-fix-task-queue-insertion-when-active-queue-is-empty.md
@@ -1,0 +1,46 @@
+---
+id: qtx-0024
+title: Fix task queue insertion when active queue is empty
+status: done
+priority: medium
+area: autonomy
+depends_on: []
+human_review: required
+checks:
+  - bun run lint
+  - bun run typecheck
+docs_to_update:
+  - autonomy/queue.md
+---
+
+# Task: Fix task queue insertion when active queue is empty
+
+## Goal
+
+Make `bun run task:new -- --queue` place new rows into the correct queue section even when the active queue is currently empty.
+
+## Context
+
+The second-round workflow exposed a real autonomy gap: scaffolding a new queued task while `autonomy/queue.md` had no active items inserted the row into the wrong section. That makes the queue a less reliable entry point for future agents.
+
+## Constraints
+
+- Keep the fix scoped to queue insertion behavior.
+- Preserve the current queue layout and intake rules instead of redesigning the file format.
+
+## Implementation Notes
+
+- Relevant files: `scripts/new-task.ts`, `scripts/project-memory-utils.ts`, `test/project-memory-utils.test.ts`
+- Relevant commands: `bun run task:new -- --queue`
+- Relevant specs or ADRs: none; this is a project-memory workflow fix
+
+## Done When
+
+- Non-`done` tasks created with `--queue` appear in the active queue section.
+- `done` tasks created with `--queue` appear in completed milestones.
+- A regression test covers the empty-active-queue case.
+
+## Non-Goals
+
+- Redesigning the autonomy queue format
+- Introducing a separate task database or planner service

--- a/scripts/new-task.ts
+++ b/scripts/new-task.ts
@@ -4,7 +4,7 @@ import process from 'node:process'
 import { parseArgs } from 'node:util'
 import prompts from 'prompts'
 import { defaultTaskChecks, taskHumanReviewValues, taskPriorityValues, taskStatusValues } from './project-memory-schema'
-import { getNextSequenceNumber, isInteractiveSession, normalizeListValues, renderFrontmatterList, rootDir, slugify, writeNewFile } from './project-memory-utils'
+import { getNextSequenceNumber, insertQueueRow, isInteractiveSession, normalizeListValues, renderFrontmatterList, rootDir, slugify, writeNewFile } from './project-memory-utils'
 
 const { values } = parseArgs({
   args: process.argv.slice(2),
@@ -223,9 +223,7 @@ async function appendTaskToQueue(input: {
 
   const dependsOnCell = input.dependsOn.length > 0 ? input.dependsOn.join(', ') : '-'
   const row = `| [${input.id}](${input.relativePath}) | \`${input.status}\` | \`${input.priority}\` | ${input.title} | ${dependsOnCell} |`
-  const updatedQueue = queueContent.includes('\n\n## Intake rules')
-    ? queueContent.replace('\n\n## Intake rules', `\n${row}\n\n## Intake rules`)
-    : `${queueContent.trimEnd()}\n${row}\n`
+  const updatedQueue = insertQueueRow(queueContent, row, input.status)
 
   await writeFile(queuePath, updatedQueue, 'utf8')
 }

--- a/scripts/project-memory-utils.ts
+++ b/scripts/project-memory-utils.ts
@@ -1,8 +1,11 @@
 import { access, mkdir, readdir, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
+import { fileURLToPath } from 'node:url'
 
-export const rootDir = resolve(import.meta.dir, '..')
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+
+export const rootDir = resolve(scriptDir, '..')
 
 export function formatCurrentDate() {
   return new Intl.DateTimeFormat('en-CA', {
@@ -69,6 +72,35 @@ export function slugify(value: string, fallback = 'item') {
     .replace(/-+$/, '')
 
   return normalized || fallback
+}
+
+export function insertQueueRow(queueContent: string, row: string, status: string) {
+  const activeHeader = '## Active queue'
+  const completedHeader = '## Completed milestones'
+  const intakeHeader = '## Intake rules'
+  const tableDivider = '|---|---|---|---|---|'
+  const emptyActiveNotice = 'No active tasks are currently queued. Add the next executable task contract in `autonomy/tasks/` before reopening this section.'
+
+  const normalizedQueue = queueContent.replace(`${emptyActiveNotice}\n\n`, '')
+  const targetHeader = status === 'done' ? completedHeader : activeHeader
+  const fallbackHeader = status === 'done' ? intakeHeader : completedHeader
+  const sectionStart = normalizedQueue.indexOf(targetHeader)
+  const sectionEnd = normalizedQueue.indexOf(fallbackHeader)
+
+  if (sectionStart === -1 || sectionEnd === -1 || sectionEnd <= sectionStart)
+    return `${normalizedQueue.trimEnd()}\n${row}\n`
+
+  const beforeSection = normalizedQueue.slice(0, sectionStart)
+  const section = normalizedQueue.slice(sectionStart, sectionEnd)
+  const afterSection = normalizedQueue.slice(sectionEnd)
+  const dividerIndex = section.indexOf(tableDivider)
+
+  if (dividerIndex === -1)
+    return `${normalizedQueue.trimEnd()}\n${row}\n`
+
+  const dividerEnd = dividerIndex + tableDivider.length
+  const sectionWithRow = `${section.slice(0, dividerEnd)}\n${row}${section.slice(dividerEnd)}`
+  return `${beforeSection}${sectionWithRow}${afterSection}`
 }
 
 export async function writeNewFile(filePath: string, content: string) {

--- a/test/project-memory-utils.test.ts
+++ b/test/project-memory-utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { insertQueueRow } from '../scripts/project-memory-utils'
+
+const queueFixture = `# Autonomy Queue
+
+This queue is the prioritized entry point for future agent-driven work.
+
+## Active queue
+
+No active tasks are currently queued. Add the next executable task contract in \`autonomy/tasks/\` before reopening this section.
+
+| ID | Status | Priority | Title | Depends on |
+|---|---|---|---|---|
+
+## Completed milestones
+
+| ID | Status | Priority | Title | Depends on |
+|---|---|---|---|---|
+| [qtx-0001](./tasks/qtx-0001-example.md) | \`done\` | \`high\` | Example | - |
+
+## Intake rules
+`
+
+describe('insertQueueRow', () => {
+  it('inserts non-done tasks into the active queue when it is empty', () => {
+    const row = '| [qtx-0024](./tasks/qtx-0024-example.md) | `ready` | `high` | Example task | - |'
+    const updated = insertQueueRow(queueFixture, row, 'ready')
+
+    expect(updated).toContain('## Active queue')
+    expect(updated).not.toContain('No active tasks are currently queued')
+    expect(updated).toContain(`${'|---|---|---|---|---|'}\n${row}`)
+    expect(updated.indexOf(row)).toBeLessThan(updated.indexOf('## Completed milestones'))
+  })
+
+  it('inserts done tasks into completed milestones', () => {
+    const row = '| [qtx-0024](./tasks/qtx-0024-example.md) | `done` | `high` | Example task | - |'
+    const updated = insertQueueRow(queueFixture, row, 'done')
+
+    const completedIndex = updated.indexOf('## Completed milestones')
+    const rowIndex = updated.indexOf(row)
+
+    expect(rowIndex).toBeGreaterThan(completedIndex)
+    expect(updated).toContain(`${'|---|---|---|---|---|'}\n${row}\n| [qtx-0001](./tasks/qtx-0001-example.md) | \`done\` | \`high\` | Example | - |`)
+  })
+})


### PR DESCRIPTION
## Summary

Fix `bun run task:new -- --queue` so it inserts new rows into the correct section of `autonomy/queue.md`. Non-`done` tasks now go to the active queue, `done` tasks go to completed milestones, and the empty-active-queue placeholder is removed when a new active task is added.

## Linked Artifacts

- Issue: N/A
- Task: `qtx-0024` (`autonomy/tasks/qtx-0024-fix-task-queue-insertion-when-active-queue-is-empty.md`)
- ADR: N/A
- OpenSpec: N/A
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `autonomy/...`
- [ ] `openspec/...`
- [ ] Follow-up task created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant task, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Notes

This was discovered during the second autonomy-validation round while creating `qtx-0023`, so the fix also improves the project-memory workflow itself.