### PR TITLE
feat(resolve): add install guidance for missing agents

### DIFF
--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -12,6 +12,7 @@ This queue is the prioritized entry point for future agent-driven work.
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
 | [qtx-0024](./tasks/qtx-0024-fix-task-queue-insertion-when-active-queue-is-empty.md) | `done` | `medium` | Fix task queue insertion when active queue is empty | - |
+| [qtx-0025](./tasks/qtx-0025-make-resolve-surface-machine-actionable-install-guidance.md) | `done` | `high` | Make resolve surface machine-actionable install guidance | - |
 | [qtx-0001](./tasks/qtx-0001-migrate-troubleshooting-into-runbooks.md) | `done` | `high` | Migrate troubleshooting knowledge into canonical runbooks | - |
 | [qtx-0002](./tasks/qtx-0002-consolidate-auto-upgrade-docs-into-openspec-and-adr.md) | `done` | `high` | Consolidate auto-upgrade design into OpenSpec specs and ADRs | - |
 | [qtx-0003](./tasks/qtx-0003-convert-root-backlogs-into-task-contracts.md) | `done` | `medium` | Convert legacy root backlogs into autonomy task contracts | - |

--- a/autonomy/tasks/qtx-0025-make-resolve-surface-machine-actionable-install-guidance.md
+++ b/autonomy/tasks/qtx-0025-make-resolve-surface-machine-actionable-install-guidance.md
@@ -1,0 +1,48 @@
+---
+id: qtx-0025
+title: Make resolve surface machine-actionable install guidance
+status: done
+priority: high
+area: surface
+depends_on: []
+human_review: required
+checks:
+  - bun run lint
+  - bun run typecheck
+  - bun run test
+docs_to_update:
+  - openspec/specs/agent-update/spec.md
+  - skills/quantex-cli/references/command-recipes.md
+---
+
+# Task: Make resolve surface machine-actionable install guidance
+
+## Goal
+
+Make `quantex resolve` expose structured install guidance when an agent is not installed, so another agent can decide the next lifecycle action without falling back to prose-only errors.
+
+## Context
+
+The second autonomy round already strengthened `doctor --json`, but another common decision point is `resolve`: when an agent is missing, the caller still only gets a human-oriented error. Tightening this surface makes Quantex more useful as a runtime contract for future autonomous agent flows.
+
+## Constraints
+
+- Keep Quantex in lifecycle CLI scope.
+- Preserve existing successful `resolve` behavior while enriching the missing-agent path.
+
+## Implementation Notes
+
+- Relevant files: `src/commands/resolve.ts`, `src/commands/schema.ts`, `test/commands/resolve.test.ts`
+- Relevant commands: `quantex resolve <agent> --json`, `quantex schema resolve --json`
+- Relevant specs or ADRs: `openspec/specs/agent-update/spec.md`
+
+## Done When
+
+- `resolve --json` exposes machine-actionable install guidance for missing agents.
+- The `schema` command documents the enriched resolve contract.
+- Tests cover the not-installed guidance path.
+
+## Non-Goals
+
+- Auto-installing from `resolve`
+- Expanding Quantex into a workflow orchestrator

--- a/openspec/specs/agent-update/spec.md
+++ b/openspec/specs/agent-update/spec.md
@@ -81,3 +81,12 @@ Agent update behavior SHALL be inspectable through user-facing diagnostic comman
 - THEN each agent-related issue includes a stable issue code
 - AND includes `subject`, `suggestedAction`, and `suggestedCommands`
 - AND allows an automation layer to distinguish between inspection, self-update, and manual-follow-up paths
+
+#### Scenario: Resolve exposes machine-actionable install guidance
+
+- GIVEN the user runs `quantex resolve <agent> --json`
+- AND the target agent is not installed
+- WHEN Quantex returns the structured result
+- THEN it keeps the `AGENT_NOT_INSTALLED` error semantics
+- AND includes structured install guidance in the result data
+- AND that guidance includes a suggested ensure command plus install methods that Quantex can attempt

--- a/skills/quantex-cli/references/command-recipes.md
+++ b/skills/quantex-cli/references/command-recipes.md
@@ -44,6 +44,8 @@ Use:
 - `resolve` for executable path and launch resolution
 - `capabilities`, `commands`, `schema` for self-description
 
+When `resolve --json` reports `AGENT_NOT_INSTALLED`, prefer `data.resolution.installGuidance` instead of scraping the error text. It now includes a suggested `quantex ensure <agent>` command plus install methods Quantex can attempt.
+
 ### Installation and updates
 
 ```bash

--- a/src/commands/resolve.ts
+++ b/src/commands/resolve.ts
@@ -2,6 +2,7 @@ import type { CommandResult } from '../output/types'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
 import { resolveAgentInspection } from '../services/agents'
 import { pc } from '../utils/color'
+import { formatInstallMethodCommand, formatInstallMethodLabel } from '../utils/install'
 
 interface ResolveCommandData {
   agent: {
@@ -11,6 +12,17 @@ interface ResolveCommandData {
   }
   resolution: {
     binaryPath: string
+    installGuidance?: {
+      docsRef: string
+      installMethods: Array<{
+        command: string
+        label: string
+        type: string
+      }>
+      suggestedAction: 'ensure-agent-installed'
+      suggestedEnsureCommand: string
+    }
+    installed: boolean
     installSource: string
     installedVersion?: string
     lifecycle: 'managed' | 'unmanaged'
@@ -40,10 +52,43 @@ export async function resolveCommand(agentName: string): Promise<CommandResult<R
 
   const { agent, inspection } = resolved
   if (!inspection.inPath || !inspection.binaryPath) {
+    const installMethods = inspection.methods.map(method => ({
+      command: formatInstallMethodCommand(agent, method),
+      label: formatInstallMethodLabel(method),
+      type: method.type,
+    })).filter(method => method.command)
+
     return emitCommandResult(createErrorResult<ResolveCommandData>({
       action: 'resolve',
+      data: {
+        agent: {
+          binaryName: agent.binaryName,
+          displayName: agent.displayName,
+          name: agent.name,
+        },
+        resolution: {
+          binaryPath: '',
+          installGuidance: {
+            docsRef: 'skills/quantex-cli/references/command-recipes.md',
+            installMethods,
+            suggestedAction: 'ensure-agent-installed',
+            suggestedEnsureCommand: `quantex ensure ${agent.name}`,
+          },
+          installed: false,
+          installSource: 'not-installed',
+          lifecycle: 'unmanaged',
+          sourceLabel: 'not installed',
+          suggestedLaunchCommand: [],
+        },
+      },
       error: {
         code: 'AGENT_NOT_INSTALLED',
+        details: {
+          docsRef: 'skills/quantex-cli/references/command-recipes.md',
+          installMethods,
+          suggestedAction: 'ensure-agent-installed',
+          suggestedEnsureCommand: `quantex ensure ${agent.name}`,
+        },
         message: `${agent.displayName} is not installed.`,
       },
       target: {
@@ -63,6 +108,7 @@ export async function resolveCommand(agentName: string): Promise<CommandResult<R
       },
       resolution: {
         binaryPath: inspection.binaryPath,
+        installed: true,
         installSource: inspection.installedState?.installType ?? 'detected-in-path',
         installedVersion: inspection.installedVersion,
         lifecycle: inspection.lifecycle,
@@ -80,6 +126,12 @@ export async function resolveCommand(agentName: string): Promise<CommandResult<R
 function renderResolveHuman(result: { data?: ResolveCommandData, error: { message: string } | null }): void {
   if (result.error) {
     console.log(pc.red(result.error.message))
+    const guidance = result.data?.resolution.installGuidance
+    if (guidance) {
+      console.log(pc.dim(`Try: ${guidance.suggestedEnsureCommand}`))
+      for (const method of guidance.installMethods)
+        console.log(pc.dim(`Install: [${method.label}] ${method.command}`))
+    }
     return
   }
 

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -312,7 +312,46 @@ const schemaCatalog: SchemaDocument[] = [
       additionalProperties: false,
       properties: {
         agent: { type: 'object' },
-        resolution: { type: 'object' },
+        resolution: {
+          additionalProperties: false,
+          properties: {
+            binaryPath: { type: 'string' },
+            installGuidance: {
+              additionalProperties: false,
+              properties: {
+                docsRef: { type: 'string' },
+                installMethods: {
+                  items: {
+                    additionalProperties: false,
+                    properties: {
+                      command: { type: 'string' },
+                      label: { type: 'string' },
+                      type: { type: 'string' },
+                    },
+                    required: ['command', 'label', 'type'],
+                    type: 'object',
+                  },
+                  type: 'array',
+                },
+                suggestedAction: { type: 'string' },
+                suggestedEnsureCommand: { type: 'string' },
+              },
+              required: ['docsRef', 'installMethods', 'suggestedAction', 'suggestedEnsureCommand'],
+              type: 'object',
+            },
+            installed: { type: 'boolean' },
+            installSource: { type: 'string' },
+            installedVersion: { type: 'string' },
+            lifecycle: { type: 'string' },
+            sourceLabel: { type: 'string' },
+            suggestedLaunchCommand: {
+              items: { type: 'string' },
+              type: 'array',
+            },
+          },
+          required: ['binaryPath', 'installed', 'installSource', 'lifecycle', 'sourceLabel', 'suggestedLaunchCommand'],
+          type: 'object',
+        },
       },
       required: ['agent', 'resolution'],
       type: 'object',

--- a/test/commands/resolve.test.ts
+++ b/test/commands/resolve.test.ts
@@ -67,6 +67,7 @@ describe('resolveCommand', () => {
     await resolveCommand('test-agent')
 
     expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('is not installed'))
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('quantex ensure test-agent'))
   })
 
   it('shows resolved executable information for an installed agent', async () => {
@@ -117,5 +118,29 @@ describe('resolveCommand', () => {
     expect(payload.data.resolution.binaryPath).toBe('/usr/bin/test-bin')
     expect(payload.data.resolution.suggestedLaunchCommand).toEqual(['/usr/bin/test-bin'])
     expect(payload.meta.runId).toBe('resolve-run-id')
+  })
+
+  it('emits machine-actionable install guidance when the agent is not installed', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'resolve-missing-run-id',
+    })
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+
+    await resolveCommand('test-agent')
+
+    const payload = JSON.parse(logSpy.mock.calls[0][0])
+    expect(payload.ok).toBe(false)
+    expect(payload.error.code).toBe('AGENT_NOT_INSTALLED')
+    expect(payload.data.agent.name).toBe('test-agent')
+    expect(payload.data.resolution.installed).toBe(false)
+    expect(payload.data.resolution.installGuidance.suggestedAction).toBe('ensure-agent-installed')
+    expect(payload.data.resolution.installGuidance.suggestedEnsureCommand).toBe('quantex ensure test-agent')
+    expect(payload.data.resolution.installGuidance.installMethods[0]).toMatchObject({
+      command: 'bun add -g test-pkg',
+      type: 'bun',
+    })
   })
 })

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -67,4 +67,20 @@ describe('schemaCommand', () => {
     expect(payload.data.commands[0].dataSchema.properties.issues.items.properties.suggestedAction).toBeDefined()
     expect(payload.data.commands[0].dataSchema.properties.issues.items.properties.suggestedCommands).toBeDefined()
   })
+
+  it('returns the resolve schema with install guidance in json mode', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'schema-resolve-run-id',
+    })
+
+    await schemaCommand('resolve')
+
+    const payload = JSON.parse(logSpy.mock.calls[0][0])
+    expect(payload.data.commands).toHaveLength(1)
+    expect(payload.data.commands[0].name).toBe('resolve')
+    expect(payload.data.commands[0].dataSchema.properties.resolution.properties.installGuidance).toBeDefined()
+    expect(payload.data.commands[0].dataSchema.properties.resolution.properties.installed).toBeDefined()
+  })
 })


### PR DESCRIPTION
## Summary

Strengthen `quantex resolve` so the missing-agent path stays machine-readable. The command now keeps `AGENT_NOT_INSTALLED` semantics while returning structured install guidance in `data.resolution.installGuidance`, and the resolve schema documents that contract.

## Linked Artifacts

- Issue: N/A
- Task: `qtx-0025` (`autonomy/tasks/qtx-0025-make-resolve-surface-machine-actionable-install-guidance.md`)
- ADR: N/A
- OpenSpec: `openspec/specs/agent-update/spec.md`
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `autonomy/...`
- [x] `openspec/...`
- [ ] Follow-up task created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant task, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Notes

This continues the second autonomy-validation round by making another runtime decision point directly usable by future agents.