### PR TITLE
feat(exec): add machine-actionable preflight guidance

### DIFF
--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -4,6 +4,8 @@ This queue is the prioritized entry point for future agent-driven work.
 
 ## Active queue
 
+No active tasks are currently queued. Add the next executable task contract in `autonomy/tasks/` before reopening this section.
+
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
 
@@ -11,6 +13,7 @@ This queue is the prioritized entry point for future agent-driven work.
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
+| [qtx-0026](./tasks/qtx-0026-make-exec-surface-machine-actionable-install-guidance.md) | `done` | `high` | Make exec surface machine-actionable install guidance | - |
 | [qtx-0024](./tasks/qtx-0024-fix-task-queue-insertion-when-active-queue-is-empty.md) | `done` | `medium` | Fix task queue insertion when active queue is empty | - |
 | [qtx-0025](./tasks/qtx-0025-make-resolve-surface-machine-actionable-install-guidance.md) | `done` | `high` | Make resolve surface machine-actionable install guidance | - |
 | [qtx-0001](./tasks/qtx-0001-migrate-troubleshooting-into-runbooks.md) | `done` | `high` | Migrate troubleshooting knowledge into canonical runbooks | - |

--- a/autonomy/tasks/qtx-0026-make-exec-surface-machine-actionable-install-guidance.md
+++ b/autonomy/tasks/qtx-0026-make-exec-surface-machine-actionable-install-guidance.md
@@ -1,0 +1,47 @@
+---
+id: qtx-0026
+title: Make exec surface machine-actionable install guidance
+status: done
+priority: high
+area: surface
+depends_on: []
+human_review: required
+checks:
+  - bun run lint
+  - bun run typecheck
+docs_to_update:
+  - openspec/specs/agent-update/spec.md
+  - skills/quantex-cli/references/command-recipes.md
+---
+
+# Task: Make exec surface machine-actionable install guidance
+
+## Goal
+
+Make `quantex exec` expose machine-actionable preflight guidance when launch cannot proceed because installation is missing or an install policy blocks the next step.
+
+## Context
+
+The second autonomy round has already upgraded `doctor` and `resolve` into more useful machine-readable contracts. `exec` is the next high-value runtime entry point: future agents need structured next steps when execution cannot even start.
+
+## Constraints
+
+- Keep successful `exec` launches as passthrough behavior.
+- Strengthen only the preflight and failure paths that Quantex itself owns.
+
+## Implementation Notes
+
+- Relevant files: `src/commands/run.ts`, `src/commands/schema.ts`, `test/commands/run.test.ts`, `test/commands/schema.test.ts`
+- Relevant commands: `quantex exec <agent> --install never -- ...`, `quantex exec <agent> --json`
+- Relevant specs or ADRs: `openspec/specs/agent-update/spec.md`
+
+## Done When
+
+- `exec` emits structured preflight guidance when launch is blocked by missing installation or policy.
+- The `schema` catalog explicitly documents the `exec` preflight contract.
+- Tests cover the new JSON guidance paths.
+
+## Non-Goals
+
+- Replacing passthrough child-process execution with a fully structured runtime protocol
+- Expanding Quantex into a workflow orchestrator

--- a/openspec/specs/agent-update/spec.md
+++ b/openspec/specs/agent-update/spec.md
@@ -90,3 +90,10 @@ Agent update behavior SHALL be inspectable through user-facing diagnostic comman
 - THEN it keeps the `AGENT_NOT_INSTALLED` error semantics
 - AND includes structured install guidance in the result data
 - AND that guidance includes a suggested ensure command plus install methods that Quantex can attempt
+
+#### Scenario: Exec exposes machine-actionable preflight guidance
+
+- GIVEN the user runs `quantex exec <agent>` with an agent that is not currently installed
+- WHEN the command cannot continue without installation or an explicit install policy
+- THEN Quantex keeps the existing error semantics
+- AND exposes structured guidance that points to `ensure` and a rerun command with `--install if-missing`

--- a/skills/quantex-cli/references/command-recipes.md
+++ b/skills/quantex-cli/references/command-recipes.md
@@ -76,6 +76,8 @@ Rules:
 - prefer `--install never` when mutation would be surprising
 - prefer `--install if-missing` when you want lifecycle management and execution in one step
 
+If `exec` fails before launch because the agent is missing, prefer the structured preflight guidance in the JSON result. It now includes both `suggestedEnsureCommand` and a rerun command with `--install if-missing`.
+
 ### Configuration and diagnosis
 
 ```bash

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,15 +1,44 @@
+import type { InstallMethod } from '../agents/types'
 import type { SpawnHandle } from '../utils/child-process'
 import type { ExecInstallPolicy } from './exec'
 import process from 'node:process'
 import prompts from 'prompts'
 import { cancelCliContextOperations, getCliContext } from '../cli-context'
 import { getExitCodeForError } from '../errors'
+import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
 import { installAgent } from '../package-manager'
 import { resolveAgentInspection } from '../services/agents'
 import { spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
 import { pc } from '../utils/color'
+import { formatInstallMethodCommand, formatInstallMethodLabel } from '../utils/install'
 import { isResourceLockError } from '../utils/lock'
 import { isAssumeYesEnabled, isDryRunEnabled, printError, printInfo, printWarn, writeDirectOutput } from '../utils/user-output'
+
+interface ExecPreflightData {
+  agent: {
+    binaryName?: string
+    displayName?: string
+    name: string
+  }
+  execution: {
+    args: string[]
+    installGuidance?: {
+      docsRef: string
+      installMethods: Array<{
+        command: string
+        label: string
+        type: string
+      }>
+      suggestedAction: 'ensure-agent-installed' | 'rerun-with-install-policy'
+      suggestedEnsureCommand: string
+      suggestedExecCommand: string
+    }
+    installPolicy: ExecInstallPolicy | 'prompt'
+    installed: boolean
+    interactive: boolean
+    launched: boolean
+  }
+}
 
 export async function runCommand(
   agentName: string,
@@ -23,7 +52,20 @@ export async function runCommand(
 ): Promise<number> {
   const resolved = await resolveAgentInspection(agentName)
   if (!resolved) {
-    printError(pc.red(`Unknown agent: ${agentName}`))
+    emitExecPreflightError({
+      agent: {
+        name: agentName,
+      },
+      errorCode: 'AGENT_NOT_FOUND',
+      errorMessage: `Unknown agent: ${agentName}`,
+      execution: {
+        args,
+        installPolicy: options.install ?? 'prompt',
+        installed: false,
+        interactive: false,
+        launched: false,
+      },
+    })
     return getExitCodeForError('AGENT_NOT_FOUND')
   }
 
@@ -35,7 +77,23 @@ export async function runCommand(
 
   if (!inspection.inPath) {
     if (installPolicy === 'never') {
-      printError(pc.red(`${agent.displayName} is not installed.`))
+      emitExecPreflightError({
+        agent: {
+          binaryName: agent.binaryName,
+          displayName: agent.displayName,
+          name: agent.name,
+        },
+        errorCode: 'AGENT_NOT_INSTALLED',
+        errorMessage: `${agent.displayName} is not installed.`,
+        execution: {
+          args,
+          installGuidance: createExecInstallGuidance(agent, inspection.methods, args),
+          installPolicy,
+          installed: false,
+          interactive,
+          launched: false,
+        },
+      })
       return getExitCodeForError('AGENT_NOT_INSTALLED')
     }
 
@@ -53,7 +111,23 @@ export async function runCommand(
       }
     }
     else if (!interactive) {
-      printError(pc.red(`${agent.displayName} is not installed and interactive installation is disabled.`))
+      emitExecPreflightError({
+        agent: {
+          binaryName: agent.binaryName,
+          displayName: agent.displayName,
+          name: agent.name,
+        },
+        errorCode: 'INTERACTION_REQUIRED',
+        errorMessage: `${agent.displayName} is not installed and interactive installation is disabled.`,
+        execution: {
+          args,
+          installGuidance: createExecInstallGuidance(agent, inspection.methods, args),
+          installPolicy,
+          installed: false,
+          interactive,
+          launched: false,
+        },
+      })
       return getExitCodeForError('INTERACTION_REQUIRED')
     }
     else {
@@ -86,7 +160,21 @@ export async function runCommand(
   }
 
   if (dryRun) {
-    writeDirectOutput(pc.cyan(`Dry run: would run ${[agent.binaryName, ...args].join(' ')}`))
+    emitExecDryRun({
+      agent: {
+        binaryName: agent.binaryName,
+        displayName: agent.displayName,
+        name: agent.name,
+      },
+      execution: {
+        args,
+        installPolicy,
+        installed: true,
+        interactive,
+        launched: false,
+      },
+      message: `Dry run: would run ${[agent.binaryName, ...args].join(' ')}`,
+    })
     return 0
   }
 
@@ -97,6 +185,90 @@ export async function runCommand(
     printError(pc.red(`Failed to launch ${agent.displayName}: ${e instanceof Error ? e.message : String(e)}`))
     return 1
   }
+}
+
+function createExecInstallGuidance(
+  agent: {
+    binaryName: string
+    displayName: string
+    name: string
+    packages?: { npm?: string }
+  },
+  methods: InstallMethod[],
+  args: string[],
+): ExecPreflightData['execution']['installGuidance'] {
+  const installMethods = methods.map(method => ({
+    command: formatInstallMethodCommand(agent, method),
+    label: formatInstallMethodLabel(method),
+    type: method.type,
+  })).filter(method => method.command)
+
+  return {
+    docsRef: 'skills/quantex-cli/references/command-recipes.md',
+    installMethods,
+    suggestedAction: 'rerun-with-install-policy',
+    suggestedEnsureCommand: `quantex ensure ${agent.name}`,
+    suggestedExecCommand: ['quantex', 'exec', agent.name, '--install', 'if-missing', '--', ...args].join(' '),
+  }
+}
+
+function emitExecPreflightError(input: {
+  agent: ExecPreflightData['agent']
+  errorCode: 'AGENT_NOT_FOUND' | 'AGENT_NOT_INSTALLED' | 'INTERACTION_REQUIRED'
+  errorMessage: string
+  execution: ExecPreflightData['execution']
+}): void {
+  const context = getCliContext()
+  if (context.outputMode === 'human') {
+    printError(pc.red(input.errorMessage))
+    const guidance = input.execution.installGuidance
+    if (guidance) {
+      writeDirectOutput(pc.dim(`Try: ${guidance.suggestedEnsureCommand}`))
+      writeDirectOutput(pc.dim(`Or:  ${guidance.suggestedExecCommand}`))
+    }
+    return
+  }
+
+  emitCommandResult(createErrorResult<ExecPreflightData>({
+    action: 'exec',
+    data: {
+      agent: input.agent,
+      execution: input.execution,
+    },
+    error: {
+      code: input.errorCode,
+      details: input.execution.installGuidance,
+      message: input.errorMessage,
+    },
+    target: {
+      kind: 'agent',
+      name: input.agent.name,
+    },
+  }), () => {})
+}
+
+function emitExecDryRun(input: {
+  agent: ExecPreflightData['agent']
+  execution: ExecPreflightData['execution']
+  message: string
+}): void {
+  const context = getCliContext()
+  if (context.outputMode === 'human') {
+    writeDirectOutput(pc.cyan(input.message))
+    return
+  }
+
+  emitCommandResult(createSuccessResult<ExecPreflightData>({
+    action: 'exec',
+    data: {
+      agent: input.agent,
+      execution: input.execution,
+    },
+    target: {
+      kind: 'agent',
+      name: input.agent.name,
+    },
+  }), () => {})
 }
 
 async function tryInstallForRun(

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -278,6 +278,68 @@ const schemaCatalog: SchemaDocument[] = [
     dataSchema: {
       additionalProperties: false,
       properties: {
+        agent: {
+          additionalProperties: false,
+          properties: {
+            binaryName: { type: 'string' },
+            displayName: { type: 'string' },
+            name: { type: 'string' },
+          },
+          required: ['name'],
+          type: 'object',
+        },
+        execution: {
+          additionalProperties: false,
+          properties: {
+            args: {
+              items: { type: 'string' },
+              type: 'array',
+            },
+            installGuidance: {
+              additionalProperties: false,
+              properties: {
+                docsRef: { type: 'string' },
+                installMethods: {
+                  items: {
+                    additionalProperties: false,
+                    properties: {
+                      command: { type: 'string' },
+                      label: { type: 'string' },
+                      type: { type: 'string' },
+                    },
+                    required: ['command', 'label', 'type'],
+                    type: 'object',
+                  },
+                  type: 'array',
+                },
+                suggestedAction: { type: 'string' },
+                suggestedEnsureCommand: { type: 'string' },
+                suggestedExecCommand: { type: 'string' },
+              },
+              required: ['docsRef', 'installMethods', 'suggestedAction', 'suggestedEnsureCommand', 'suggestedExecCommand'],
+              type: 'object',
+            },
+            installPolicy: { type: 'string' },
+            installed: { type: 'boolean' },
+            interactive: { type: 'boolean' },
+            launched: { type: 'boolean' },
+          },
+          required: ['args', 'installPolicy', 'installed', 'interactive', 'launched'],
+          type: 'object',
+        },
+      },
+      required: ['agent', 'execution'],
+      type: 'object',
+    },
+    description: 'Preflight contract for managed agent execution',
+    envelopeSchema: baseEnvelopeSchema,
+    name: 'exec',
+    ndjsonEventSchema: baseNdjsonEventSchema,
+  },
+  {
+    dataSchema: {
+      additionalProperties: false,
+      properties: {
         agent: { type: 'object' },
         changed: { type: 'boolean' },
         installState: { type: 'object' },

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -135,6 +135,25 @@ describe('runCommand', () => {
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('interactive installation is disabled'))
   })
 
+  it('emits structured rerun guidance when non-interactive mode blocks install prompting', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'exec-interaction-run-id',
+    })
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+
+    const code = await runCommand('test-agent', ['--help'], { nonInteractive: true })
+
+    expect(code).toBe(7)
+    const payload = JSON.parse(logSpy.mock.calls[0][0])
+    expect(payload.action).toBe('exec')
+    expect(payload.error.code).toBe('INTERACTION_REQUIRED')
+    expect(payload.data.execution.installGuidance.suggestedAction).toBe('rerun-with-install-policy')
+    expect(payload.data.execution.installGuidance.suggestedExecCommand).toBe('quantex exec test-agent --install if-missing -- --help')
+  })
+
   it('returns agent-not-installed when install policy is never', async () => {
     agentSpy.mockReturnValue(testAgent)
     binaryInPathSpy.mockResolvedValue(false)
@@ -145,6 +164,26 @@ describe('runCommand', () => {
     expect(mockPrompts).not.toHaveBeenCalled()
     expect(installSpy).not.toHaveBeenCalled()
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('is not installed'))
+  })
+
+  it('emits structured install guidance when install policy is never in json mode', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'exec-missing-run-id',
+    })
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+
+    const code = await runCommand('test-agent', ['--help'], { install: 'never' })
+
+    expect(code).toBe(4)
+    const payload = JSON.parse(logSpy.mock.calls[0][0])
+    expect(payload.ok).toBe(false)
+    expect(payload.action).toBe('exec')
+    expect(payload.error.code).toBe('AGENT_NOT_INSTALLED')
+    expect(payload.data.execution.installGuidance.suggestedEnsureCommand).toBe('quantex ensure test-agent')
+    expect(payload.data.execution.installGuidance.suggestedExecCommand).toBe('quantex exec test-agent --install if-missing -- --help')
   })
 
   it('installs automatically when install policy is if-missing', async () => {

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -68,6 +68,22 @@ describe('schemaCommand', () => {
     expect(payload.data.commands[0].dataSchema.properties.issues.items.properties.suggestedCommands).toBeDefined()
   })
 
+  it('returns the exec schema in json mode', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'schema-exec-run-id',
+    })
+
+    await schemaCommand('exec')
+
+    const payload = JSON.parse(logSpy.mock.calls[0][0])
+    expect(payload.data.commands).toHaveLength(1)
+    expect(payload.data.commands[0].name).toBe('exec')
+    expect(payload.data.commands[0].dataSchema.properties.execution.properties.installGuidance).toBeDefined()
+    expect(payload.data.commands[0].dataSchema.properties.execution.properties.installPolicy).toBeDefined()
+  })
+
   it('returns the resolve schema with install guidance in json mode', async () => {
     setCliContext({
       interactive: false,

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -20,6 +20,7 @@ describe('surface contracts', () => {
         "capabilities",
         "commands",
         "doctor",
+        "exec",
         "ensure",
         "inspect",
         "resolve",


### PR DESCRIPTION
## Summary

Strengthen `quantex exec` preflight failures so missing-install and policy-blocked paths return machine-actionable structured guidance. This also fills the missing `exec` schema entry so the command catalog and schema catalog are aligned.

## Linked Artifacts

- Issue: N/A
- Task: `qtx-0026` (`autonomy/tasks/qtx-0026-make-exec-surface-machine-actionable-install-guidance.md`)
- ADR: N/A
- OpenSpec: `openspec/specs/agent-update/spec.md`
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `autonomy/...`
- [x] `openspec/...`
- [ ] Follow-up task created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant task, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Notes

This continues the second autonomy-validation round by making the managed execution entrypoint more usable for future agent-driven flows.