### PR TITLE
fix(release): restore npm trusted publishing flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
-          registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -45,6 +45,8 @@ Quantex no longer uses a separate release-preparation command or release PR. Rel
 
 Release notes are canonical in [docs/releases.md](./releases.md) and on GitHub Releases.
 
+The npm publish step uses GitHub Actions trusted publishing with OIDC rather than a long-lived `NPM_TOKEN`, so the `Release` workflow file itself must match the trusted publisher configuration on npm.
+
 The current release workflow relies on merged commit metadata. In practice that means:
 
 - `feat:` commits produce a minor release

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -42,7 +42,6 @@ Current release rules:
 
 When a release is warranted, `.github/workflows/release.yml` now:
 
-- detects that `package.json` version changed on `main`
 - computes the next version
 - creates the git tag
 - builds binaries
@@ -52,6 +51,16 @@ When a release is warranted, `.github/workflows/release.yml` now:
 - creates or updates the GitHub release
 
 For regular non-release merges to `main`, the workflow exits cleanly without publishing anything.
+
+## npm trusted publishing
+
+Quantex publishes to npm through GitHub Actions trusted publishing with OIDC. The release workflow must keep `id-token: write` enabled and must not inject npm registry auth through `actions/setup-node` when `semantic-release` performs the publish step.
+
+That means:
+
+- do not configure `registry-url` in the release workflow's `setup-node` step
+- do not depend on `NPM_TOKEN` for the normal publish path
+- make sure npm package settings point the trusted publisher at the exact workflow filename `release.yml`
 
 ## Important automation note
 


### PR DESCRIPTION
## Summary
- remove the `registry-url` setup from the release workflow so `semantic-release` can use GitHub Actions OIDC trusted publishing
- document that Quantex release publishing relies on npm trusted publishing instead of `NPM_TOKEN`
- clarify the release runbook so future failures are easier to diagnose

## Linked Artifacts
- Issue: none
- Task: [qtx-0028](/Users/drs/workspaces/personal/quantex-cli/autonomy/tasks/qtx-0028-replace-bumpp-with-merge-to-main-auto-release.md)
- ADR: none
- OpenSpec: none
- Discussion: none

## Validation
- `bun run memory:check`
- `bun run lint`
- `bun run typecheck`

## Docs Updated
- [docs/runbooks/releasing-quantex.md](/Users/drs/workspaces/personal/quantex-cli/docs/runbooks/releasing-quantex.md)
- [docs/github-collaboration.md](/Users/drs/workspaces/personal/quantex-cli/docs/github-collaboration.md)

## Scope Check
- limited to the release workflow and its supporting documentation
- no runtime CLI behavior changes

## Impact
This fixes the current release failure mode where `semantic-release` falls back into token validation and errors with `EINVALIDNPMTOKEN` despite npm trusted publishing being configured.
