### PR TITLE
docs(memory): close qtx-0029 after successful release

### DIFF
--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -6,12 +6,13 @@ This queue is the prioritized entry point for future agent-driven work.
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
-| [qtx-0029](./tasks/qtx-0029-fix-semantic-release-trusted-publishing-on-main.md) | `in_progress` | `high` | Fix semantic-release trusted publishing on main | - |
+| _None right now._ |
 
 ## Completed milestones
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
+| [qtx-0029](./tasks/qtx-0029-fix-semantic-release-trusted-publishing-on-main.md) | `done` | `high` | Fix semantic-release trusted publishing on main | - |
 | [qtx-0028](./tasks/qtx-0028-replace-bumpp-with-merge-to-main-auto-release.md) | `done` | `high` | Replace bumpp with merge-to-main auto release | - |
 | [qtx-0027](./tasks/qtx-0027-make-release-flow-compatible-with-pr-only-main.md) | `done` | `high` | Make release flow compatible with PR-only main | - |
 | [qtx-0026](./tasks/qtx-0026-make-exec-surface-machine-actionable-install-guidance.md) | `done` | `high` | Make exec surface machine-actionable install guidance | - |

--- a/autonomy/tasks/qtx-0029-fix-semantic-release-trusted-publishing-on-main.md
+++ b/autonomy/tasks/qtx-0029-fix-semantic-release-trusted-publishing-on-main.md
@@ -1,7 +1,7 @@
 ---
 id: qtx-0029
 title: Fix semantic-release trusted publishing on main
-status: in_progress
+status: done
 priority: high
 area: release
 depends_on: []
@@ -55,6 +55,12 @@ docs_to_update:
 - `semantic-release` resolves an npm plugin version that supports npm trusted publishing on GitHub Actions
 - release automation is triggered from `.github/workflows/release.yml` on merged `main` pushes
 - docs explain the trusted publishing contract and no longer describe the old `workflow_run` dependency
+
+## Validation Outcome
+
+- `semantic-release` now runs on merged `main` pushes through `.github/workflows/release.yml`
+- merge commit `a33695dbcfbace7d018d4e6ba4bc01eca29ce06e` triggered successful `Release` run `24838880060`
+- GitHub Release `v0.2.0` was created and npm registry now reports `quantex-cli@0.2.0`
 
 ## Non-Goals
 


### PR DESCRIPTION
## Summary
- mark `qtx-0029` as done now that merge-to-main release automation succeeded
- move `qtx-0029` from the active queue into completed milestones
- capture the concrete validation outcome for the successful `v0.2.0` release

## Linked Artifacts
- Task: [qtx-0029](https://github.com/Drswith/quantex-cli/blob/main/autonomy/tasks/qtx-0029-fix-semantic-release-trusted-publishing-on-main.md)
- Release run: [24838880060](https://github.com/Drswith/quantex-cli/actions/runs/24838880060)
- Release: [v0.2.0](https://github.com/Drswith/quantex-cli/releases/tag/v0.2.0)

## Validation
- `bun run memory:check`
- `bun run lint`
- `bun run typecheck`

## Docs Updated
- `autonomy/tasks/qtx-0029-fix-semantic-release-trusted-publishing-on-main.md`
- `autonomy/queue.md`

## Scope Check
- no runtime or release workflow behavior changed in this follow-up
- this PR only reconciles project memory with the already-successful release result
