### PR TITLE
fix(release): harden artifact matrix validation

### DIFF
--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -6,7 +6,7 @@ This queue is the prioritized entry point for future agent-driven work.
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
-| _None right now._ |
+| [qtx-0031](./tasks/qtx-0031-harden-release-artifact-matrix-validation.md) | `in_progress` | `high` | Harden release artifact matrix validation | qtx-0030 |
 
 ## Completed milestones
 

--- a/autonomy/tasks/qtx-0031-harden-release-artifact-matrix-validation.md
+++ b/autonomy/tasks/qtx-0031-harden-release-artifact-matrix-validation.md
@@ -1,0 +1,57 @@
+---
+id: qtx-0031
+title: Harden release artifact matrix validation
+status: in_progress
+priority: high
+area: release
+depends_on:
+  - qtx-0030
+human_review: required
+checks:
+  - bun run lint
+  - bun run typecheck
+  - bun run test
+  - bun run build
+  - bun run build:bin
+  - bun run release:artifacts
+  - bun run release:smoke
+docs_to_update:
+  - docs/runbooks/releasing-quantex.md
+  - docs/runbooks/release-and-self-upgrade-debugging.md
+---
+
+# Task: Harden release artifact matrix validation
+
+## Goal
+
+Release validation should fail before publication if any required platform binary is missing, and the resulting patch should exercise the release-please publication path end to end.
+
+## Context
+
+The newly adopted release-please flow has verified the non-publishing path, but not a full patch release. A small release hardening fix provides a legitimate `fix:` change that can trigger a Release PR and publish `0.2.1` without manufacturing an empty version bump.
+
+## Constraints
+
+- Keep the product behavior unchanged except for stricter release artifact validation.
+- Do not bypass protected `main`; use PR checks and release-please Release PRs.
+- Treat the final publish as a real release, not a dry run.
+
+## Implementation Notes
+
+- GitHub issue: https://github.com/Drswith/quantex-cli/issues/17
+- Harden `scripts/build-bin.ts` so a failed target build exits nonzero.
+- Harden `src/release-artifacts/index.ts` so manifest validation requires all platform assets.
+- Cover the stricter validation in `test/release-artifacts.test.ts`.
+- Update release runbooks with the required asset matrix.
+
+## Done When
+
+- PR checks pass for the release hardening change.
+- Merging the fix to `main` causes release-please to create or update a Release PR.
+- Merging the Release PR publishes the next patch version to npm and GitHub Releases.
+- The published GitHub Release includes npm package publication and all required binary assets.
+
+## Non-Goals
+
+- Changing release versioning rules.
+- Adding prerelease branch support.

--- a/docs/runbooks/release-and-self-upgrade-debugging.md
+++ b/docs/runbooks/release-and-self-upgrade-debugging.md
@@ -99,11 +99,14 @@ What this should guarantee:
 - every release binary listed in `manifest.json` exists in `SHA256SUMS.txt`
 - every checksum in the manifest matches the checksum file
 - asset filenames still match Quantex release naming rules
+- the stable release matrix contains all required platform binaries
 
 Common symptoms and likely causes:
 
 - missing checksum entry:
   the build produced a binary that checksum generation or manifest generation did not include
+- missing required release asset:
+  a target build failed, the filename changed, or stale local outputs hid an incomplete binary matrix
 - manifest checksum mismatch:
   artifact contents changed after checksum generation, or the manifest was generated from stale data
 - invalid asset name:

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -103,6 +103,14 @@ bun run release:artifacts
 bun run release:smoke
 ```
 
+`release:artifacts` must fail if the release manifest is missing any required platform binary:
+
+- `quantex-darwin-arm64`
+- `quantex-darwin-x64`
+- `quantex-linux-arm64`
+- `quantex-linux-x64`
+- `quantex-windows-x64.exe`
+
 ## Related artifacts
 
 - `.github/workflows/release.yml`

--- a/scripts/build-bin.ts
+++ b/scripts/build-bin.ts
@@ -1,3 +1,4 @@
+import { rm } from 'node:fs/promises'
 import process from 'node:process'
 
 const targets = [
@@ -21,8 +22,15 @@ async function buildBin(): Promise<void> {
 
   console.log(`Building ${filtered.length} targets...\n`)
 
+  let hasFailure = false
+
   for (const { target, outfile } of filtered) {
     console.log(`Building ${target}...`)
+    await Promise.all([
+      rm(outfile, { force: true }),
+      rm(`${outfile}.exe`, { force: true }),
+    ])
+
     const result = await Bun.build({
       entrypoints: ['./src/cli.ts'],
       compile: { target, outfile },
@@ -30,6 +38,7 @@ async function buildBin(): Promise<void> {
     })
 
     if (!result.success) {
+      hasFailure = true
       console.error(`  ❌ ${target} failed:`)
       for (const log of result.logs)
         console.error(`    ${log}`)
@@ -37,6 +46,11 @@ async function buildBin(): Promise<void> {
     else {
       console.log(`  ✅ ${outfile}`)
     }
+  }
+
+  if (hasFailure) {
+    console.error('\nOne or more release targets failed to build.')
+    process.exit(1)
   }
 }
 

--- a/src/release-artifacts/index.ts
+++ b/src/release-artifacts/index.ts
@@ -18,6 +18,14 @@ export interface ReleaseManifest {
   version: string
 }
 
+export const REQUIRED_RELEASE_ASSET_NAMES = [
+  'quantex-darwin-arm64',
+  'quantex-darwin-x64',
+  'quantex-linux-arm64',
+  'quantex-linux-x64',
+  'quantex-windows-x64.exe',
+] as const
+
 export function formatChecksums(entries: Array<{ checksum: string, name: string }>): string {
   return `${entries
     .sort((left, right) => left.name.localeCompare(right.name))
@@ -118,6 +126,13 @@ export function createReleaseManifest(input: {
 export function validateReleaseManifest(manifest: ReleaseManifest, checksums: Map<string, string>): void {
   if (manifest.assets.length === 0)
     throw new Error('manifest.json must contain at least one binary asset.')
+
+  const assetNames = new Set(manifest.assets.map(asset => asset.name))
+
+  for (const requiredName of REQUIRED_RELEASE_ASSET_NAMES) {
+    if (!assetNames.has(requiredName))
+      throw new Error(`manifest.json is missing required release asset: ${requiredName}.`)
+  }
 
   for (const asset of manifest.assets) {
     const expectedChecksum = checksums.get(asset.name)

--- a/test/release-artifacts.test.ts
+++ b/test/release-artifacts.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeRepositoryUrl,
   parseBinaryTarget,
   parseChecksums,
+  REQUIRED_RELEASE_ASSET_NAMES,
   resolveReleaseChannel,
   validateReleaseManifest,
 } from '../src/release-artifacts'
@@ -90,6 +91,22 @@ describe('release artifacts helpers', () => {
   })
 
   it('validates manifest/checksum consistency', () => {
+    const checksums = createRequiredChecksums()
+    const manifest = createReleaseManifest({
+      checksums,
+      files: createRequiredFiles(),
+      version: '1.2.3',
+    })
+
+    expect(() => validateReleaseManifest(manifest, checksums)).not.toThrow()
+
+    const mismatchedChecksums = new Map(checksums)
+    mismatchedChecksums.set('quantex-darwin-arm64', 'z'.repeat(64))
+
+    expect(() => validateReleaseManifest(manifest, mismatchedChecksums)).toThrow('manifest.json checksum mismatch for quantex-darwin-arm64.')
+  })
+
+  it('requires the complete release asset matrix', () => {
     const manifest = createReleaseManifest({
       checksums: new Map([
         ['quantex-darwin-arm64', 'a'.repeat(64)],
@@ -100,10 +117,20 @@ describe('release artifacts helpers', () => {
 
     expect(() => validateReleaseManifest(manifest, new Map([
       ['quantex-darwin-arm64', 'a'.repeat(64)],
-    ]))).not.toThrow()
-
-    expect(() => validateReleaseManifest(manifest, new Map([
-      ['quantex-darwin-arm64', 'b'.repeat(64)],
-    ]))).toThrow('manifest.json checksum mismatch for quantex-darwin-arm64.')
+    ]))).toThrow('manifest.json is missing required release asset: quantex-darwin-x64.')
   })
 })
+
+function createRequiredChecksums(): Map<string, string> {
+  return new Map(REQUIRED_RELEASE_ASSET_NAMES.map((name, index) => [
+    name,
+    String(index + 1).repeat(64),
+  ]))
+}
+
+function createRequiredFiles(): Array<{ name: string, size: number }> {
+  return REQUIRED_RELEASE_ASSET_NAMES.map((name, index) => ({
+    name,
+    size: index + 1,
+  }))
+}


### PR DESCRIPTION
## Summary
- make release binary builds fail the script when any target fails
- require the release manifest to contain the complete platform binary matrix
- use this real patch fix to exercise the release-please Release PR and publish path

## Linked Artifacts
- Closes #17
- Task: autonomy/tasks/qtx-0031-harden-release-artifact-matrix-validation.md

## Validation
- bun run memory:check
- bun run lint
- bun run typecheck
- bun run test
- bun run build && bun run build:bin && bun run release:artifacts && bun run release:smoke

## Docs Updated
- docs/runbooks/releasing-quantex.md
- docs/runbooks/release-and-self-upgrade-debugging.md
- autonomy/tasks/qtx-0031-harden-release-artifact-matrix-validation.md

## Scope Check
- Release hardening only; no versioning rule changes or prerelease branch support.
- This PR intentionally uses a fix commit so release-please should prepare the next patch Release PR after merge.