### PR TITLE
docs(release): record release flow verification

### DIFF
--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -6,12 +6,13 @@ This queue is the prioritized entry point for future agent-driven work.
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
-| [qtx-0031](./tasks/qtx-0031-harden-release-artifact-matrix-validation.md) | `in_progress` | `high` | Harden release artifact matrix validation | qtx-0030 |
+| _None right now._ |
 
 ## Completed milestones
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
+| [qtx-0031](./tasks/qtx-0031-harden-release-artifact-matrix-validation.md) | `done` | `high` | Harden release artifact matrix validation | qtx-0030 |
 | [qtx-0030](./tasks/qtx-0030-adopt-release-please-release-pr-flow.md) | `done` | `high` | Adopt release-please Release PR flow | - |
 | [qtx-0029](./tasks/qtx-0029-fix-semantic-release-trusted-publishing-on-main.md) | `done` | `high` | Fix semantic-release trusted publishing on main | - |
 | [qtx-0028](./tasks/qtx-0028-replace-bumpp-with-merge-to-main-auto-release.md) | `done` | `high` | Replace bumpp with merge-to-main auto release | - |

--- a/autonomy/tasks/qtx-0031-harden-release-artifact-matrix-validation.md
+++ b/autonomy/tasks/qtx-0031-harden-release-artifact-matrix-validation.md
@@ -1,7 +1,7 @@
 ---
 id: qtx-0031
 title: Harden release artifact matrix validation
-status: in_progress
+status: done
 priority: high
 area: release
 depends_on:
@@ -50,6 +50,16 @@ The newly adopted release-please flow has verified the non-publishing path, but 
 - Merging the fix to `main` causes release-please to create or update a Release PR.
 - Merging the Release PR publishes the next patch version to npm and GitHub Releases.
 - The published GitHub Release includes npm package publication and all required binary assets.
+
+## Verification Notes
+
+- Fix PR: https://github.com/Drswith/quantex-cli/pull/18
+- Release PR: https://github.com/Drswith/quantex-cli/pull/19
+- Release workflow: https://github.com/Drswith/quantex-cli/actions/runs/24843043908
+- GitHub Release: https://github.com/Drswith/quantex-cli/releases/tag/v0.2.1
+- npm official registry latest: `0.2.1`
+- GitHub Release assets include `manifest.json`, `SHA256SUMS.txt`, and all five platform binaries.
+- npm mirror registries may lag the official npm registry; verify release publication against `https://registry.npmjs.org`.
 
 ## Non-Goals
 

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -89,6 +89,27 @@ GitHub's documented behavior is that events created by `GITHUB_TOKEN` do not sta
 
 That is why Quantex performs release-please tagging, npm publish, and artifact upload inside the same release workflow.
 
+## Repository settings
+
+The Release workflow depends on repository-level GitHub Actions settings, not only versioned YAML.
+
+Required Actions workflow permissions:
+
+- default workflow permissions: read and write
+- allow GitHub Actions to create and approve pull requests: enabled
+
+If this permission is disabled, release-please can calculate the next version and create its branch, but it fails when opening the Release PR with:
+
+```text
+GitHub Actions is not permitted to create or approve pull requests.
+```
+
+## Release PR checks
+
+Release PRs are created by `github-actions[bot]`. If GitHub marks the generated Release PR checks as `action_required` with no jobs, close and reopen the Release PR from a maintainer account to trigger the required `pull_request` checks.
+
+For a fully non-interactive future flow, prefer replacing `GITHUB_TOKEN` in the release-please step with a dedicated release bot token or GitHub App token that is allowed to create PRs and trigger checks.
+
 ## Validation
 
 The closest local verification path for release artifacts remains:


### PR DESCRIPTION
## Summary
- mark qtx-0031 complete after the real 0.2.1 release verification
- record the GitHub Actions permission requirement for release-please PR creation
- document the maintainer close/reopen recovery for bot-created Release PR checks

## Linked Artifacts
- Task: autonomy/tasks/qtx-0031-harden-release-artifact-matrix-validation.md
- Release: https://github.com/Drswith/quantex-cli/releases/tag/v0.2.1

## Validation
- bun run memory:check
- bun run lint

## Docs Updated
- docs/runbooks/releasing-quantex.md
- autonomy/tasks/qtx-0031-harden-release-artifact-matrix-validation.md
- autonomy/queue.md

## Scope Check
- Documentation and project memory only; no release workflow or runtime behavior changes.