### PR TITLE
feat(release): add beta prerelease channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+      - beta
 
   pull_request:
     branches:
       - main
+      - beta
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - beta
   workflow_dispatch:
 
 permissions:
@@ -13,19 +14,31 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: release-main
+  group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Select release channel
+        id: channel
+        run: |
+          if [ "${GITHUB_REF_NAME}" = "beta" ]; then
+            echo "config_file=release-please-config.beta.json" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=beta" >> "$GITHUB_OUTPUT"
+          else
+            echo "config_file=release-please-config.json" >> "$GITHUB_OUTPUT"
+            echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          config-file: release-please-config.json
+          target-branch: ${{ github.ref_name }}
+          config-file: ${{ steps.channel.outputs.config_file }}
           manifest-file: .release-please-manifest.json
 
       - name: Checkout released source
@@ -86,7 +99,7 @@ jobs:
 
       - name: Publish npm package
         if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --access public --ignore-scripts
+        run: npm publish --access public --ignore-scripts --tag ${{ steps.channel.outputs.npm_tag }}
 
       - name: Upload release artifacts
         if: ${{ steps.release.outputs.release_created }}

--- a/autonomy/tasks/qtx-0032-verify-beta-release-channel.md
+++ b/autonomy/tasks/qtx-0032-verify-beta-release-channel.md
@@ -1,0 +1,55 @@
+---
+id: qtx-0032
+title: Verify beta release channel
+status: planned
+priority: high
+area: release
+depends_on:
+  - qtx-0030
+  - qtx-0031
+human_review: required
+checks:
+  - bun run lint
+  - bun run typecheck
+  - bun run test
+docs_to_update:
+  - release-please-config.beta.json
+  - .github/workflows/release.yml
+---
+
+# Task: Verify beta release channel
+
+## Goal
+
+The release system should publish beta prereleases from a dedicated `beta` branch without changing the stable `main` release path.
+
+## Context
+
+Stable release publication has been tested with release-please, npm trusted publishing, GitHub Releases, binary artifacts, and smoke checks. The remaining gap is proving that prerelease versions such as `0.3.0-beta.1` can be prepared, published, and installed through the npm `beta` dist-tag.
+
+## Constraints
+
+- Keep `main` publishing stable releases with the npm `latest` dist-tag.
+- Publish beta versions only from the `beta` branch.
+- Use release-please Release PRs so `package.json`, `.release-please-manifest.json`, generated build metadata, and changelog entries stay source-controlled.
+- Treat the beta publish as a real prerelease, not a dry run.
+
+## Implementation Notes
+
+- GitHub issue: https://github.com/Drswith/quantex-cli/issues/21
+- Add a beta release-please manifest config with `prerelease: true` and `prerelease-type: beta`.
+- Route the Release workflow by branch so `main` uses stable config and `beta` uses beta config.
+- Ensure CI runs for `beta` pushes and PRs.
+- After merging the workflow support, create a real beta-targeted change and merge the resulting beta Release PR.
+
+## Done When
+
+- A PR lands the beta release-channel automation.
+- A `beta` branch exists with the release workflow support.
+- Merging a conventional commit into `beta` creates a beta Release PR.
+- Merging the beta Release PR publishes the beta package with npm dist-tag `beta` and GitHub prerelease metadata.
+
+## Non-Goals
+
+- Changing the stable release cadence.
+- Publishing alpha or release-candidate channels.

--- a/release-please-config.beta.json
+++ b/release-please-config.beta.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "package-name": "quantex-cli",
+      "include-component-in-tag": false,
+      "include-v-in-tag": true,
+      "include-v-in-release-name": true,
+      "prerelease": true,
+      "prerelease-type": "beta",
+      "extra-files": [
+        "src/generated/build-meta.ts"
+      ],
+      "pull-request-title-pattern": "chore: release ${version}",
+      "pull-request-header": "## Summary\n- materialize the next Quantex beta release version in source-controlled files\n- update the repository changelog for the pending beta release\n\n## Linked Artifacts\n- Release automation: release-please beta channel\n\n## Validation\n- CI must pass before merging this beta Release PR\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Beta Release PR only; merge this PR to publish the prepared beta version\n"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated release-please beta prerelease config
- route Release workflow behavior by branch so main publishes latest and beta publishes beta
- run CI for beta branch pushes and PRs

## Linked Artifacts
- Issue: https://github.com/Drswith/quantex-cli/issues/21
- Task: autonomy/tasks/qtx-0032-verify-beta-release-channel.md

## Validation
- bun run memory:check
- bun run lint
- bun run typecheck
- bun run test

## Docs Updated
- autonomy/tasks/qtx-0032-verify-beta-release-channel.md

## Scope Check
- Release automation only; no product runtime behavior changes