### PR TITLE
chore(release): enable prerelease beta versioning

### DIFF
--- a/autonomy/tasks/qtx-0032-verify-beta-release-channel.md
+++ b/autonomy/tasks/qtx-0032-verify-beta-release-channel.md
@@ -37,7 +37,7 @@ Stable release publication has been tested with release-please, npm trusted publ
 ## Implementation Notes
 
 - GitHub issue: https://github.com/Drswith/quantex-cli/issues/21
-- Add a beta release-please manifest config with `prerelease: true` and `prerelease-type: beta`.
+- Add a beta release-please manifest config with `versioning: prerelease`, `prerelease: true`, and `prerelease-type: beta`.
 - Route the Release workflow by branch so `main` uses stable config and `beta` uses beta config.
 - Ensure CI runs for `beta` pushes and PRs.
 - After merging the workflow support, create a real beta-targeted change and merge the resulting beta Release PR.

--- a/release-please-config.beta.json
+++ b/release-please-config.beta.json
@@ -7,6 +7,7 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "include-v-in-release-name": true,
+      "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "beta",
       "extra-files": [


### PR DESCRIPTION
## Summary
- configure the beta release-please file to use the prerelease versioning strategy
- document the required beta prerelease knobs in the task contract

## Linked Artifacts
- Issue: https://github.com/Drswith/quantex-cli/issues/21
- Task: autonomy/tasks/qtx-0032-verify-beta-release-channel.md

## Validation
- bun run memory:check
- bun run lint
- bun run typecheck

## Docs Updated
- autonomy/tasks/qtx-0032-verify-beta-release-channel.md

## Scope Check
- Beta release configuration only; no stable publishing or runtime behavior changes