### PR TITLE
docs(workflow): standardize worktree-first task flow

### DIFF
--- a/autonomy/README.md
+++ b/autonomy/README.md
@@ -15,7 +15,8 @@ This directory defines how Quantex can evolve toward agent-driven iteration with
 1. Read `queue.md`.
 2. Pick the highest-priority task that is `ready` and not blocked by dependencies.
 3. Read the task file and any linked ADRs, specs, or runbooks.
-4. Implement the change, run the required checks, and update relevant docs.
-5. Update task status and record any new follow-up tasks.
+4. If the task will create commits or a PR, create a dedicated worktree-backed branch before editing.
+5. Implement the change, run the required checks, and update relevant docs.
+6. Update task status and record any new follow-up tasks.
 
 The goal is not blind automation. The goal is bounded, reviewable autonomy.

--- a/autonomy/policy.md
+++ b/autonomy/policy.md
@@ -16,6 +16,10 @@ Work should flow through task files with scope, risks, dependencies, and done cr
 
 The agent may make local implementation decisions inside an accepted task, but should not silently expand product scope.
 
+### Workspace isolation
+
+When accepted work is expected to produce commits or a PR, prefer a dedicated git worktree instead of switching the user's active workspace in place.
+
 ### Promotion over accumulation
 
 Discussion output should be promoted into specs, ADRs, runbooks, postmortems, and tasks instead of accumulating as loose notes.
@@ -26,6 +30,8 @@ Discussion output should be promoted into specs, ADRs, runbooks, postmortems, an
 - split a large task into smaller tasks when that reduces risk
 - update specs, ADR follow-up links, runbooks, and task status when the change requires it
 - add tests, checks, and migration notes that are directly implied by the accepted task
+- create dedicated task worktrees and branches for implementation work
+- remove a dedicated task worktree after its changes are merged or intentionally abandoned
 
 ## The agent must escalate before proceeding
 
@@ -35,6 +41,8 @@ Discussion output should be promoted into specs, ADRs, runbooks, postmortems, an
 - introducing new external services, paid dependencies, or credentials
 - deleting legacy documents before their canonical replacement exists
 - overriding an accepted ADR
+- implementing PR-bound changes directly in a user's active dirty workspace when a worktree-backed flow is feasible
+- removing a worktree whose unmerged commits or ownership are unclear
 
 ## Done criteria
 

--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -12,6 +12,7 @@ This queue is the prioritized entry point for future agent-driven work.
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
+| [qtx-0033](./tasks/qtx-0033-standardize-worktree-first-task-execution.md) | `done` | `high` | Standardize worktree-first task execution | - |
 | [qtx-0031](./tasks/qtx-0031-harden-release-artifact-matrix-validation.md) | `done` | `high` | Harden release artifact matrix validation | qtx-0030 |
 | [qtx-0030](./tasks/qtx-0030-adopt-release-please-release-pr-flow.md) | `done` | `high` | Adopt release-please Release PR flow | - |
 | [qtx-0029](./tasks/qtx-0029-fix-semantic-release-trusted-publishing-on-main.md) | `done` | `high` | Fix semantic-release trusted publishing on main | - |

--- a/autonomy/tasks/README.md
+++ b/autonomy/tasks/README.md
@@ -4,6 +4,8 @@ Each file in this directory is a task that an agent can execute with bounded aut
 
 Use `bun run task:new -- --title "Task title"` to scaffold a new task file without hand-editing frontmatter.
 
+If the task will produce commits or a PR, start execution from a dedicated worktree with `bun run worktree:new`.
+
 ## Requirements
 
 - every task has a stable ID

--- a/autonomy/tasks/qtx-0033-standardize-worktree-first-task-execution.md
+++ b/autonomy/tasks/qtx-0033-standardize-worktree-first-task-execution.md
@@ -1,0 +1,68 @@
+---
+id: qtx-0033
+title: Standardize worktree-first task execution
+status: done
+priority: high
+area: workflow
+depends_on: []
+human_review: required
+checks:
+  - bun run lint
+  - bun run typecheck
+docs_to_update:
+  - autonomy/README.md
+  - autonomy/policy.md
+  - docs/README.md
+  - autonomy/tasks/README.md
+  - docs/github-collaboration.md
+  - docs/runbooks/README.md
+  - docs/runbooks/worktree-task-execution.md
+  - docs/adr/0004-standardize-worktree-first-task-execution.md
+---
+
+# Task: Standardize worktree-first task execution
+
+## Goal
+
+Task implementation that is expected to produce commits or a PR should default to a dedicated git worktree, with one canonical helper command and one canonical runbook that future agents can follow.
+
+## Context
+
+Quantex has already adopted task contracts, protected branches, release PRs, and agent-driven execution. Continuing to implement those tasks by repeatedly switching the user's active workspace adds avoidable friction and risk.
+
+If worktree-backed execution remains only a conversational preference, future agents may fall back to branch switching in place. The rule needs to become durable project memory and low-friction tooling.
+
+## Constraints
+
+- Keep the existing branch-and-PR governance model; worktrees should host branches rather than replace them.
+- Do not add destructive cleanup automation that could remove a worktree with unmerged commits.
+- Keep the helper command lightweight and dependency-free beyond the existing Bun script environment.
+
+## Implementation Notes
+
+- GitHub issue: https://github.com/Drswith/quantex-cli/issues/28
+- Relevant files: `scripts/new-worktree.ts`, `package.json`, `docs/github-collaboration.md`, `autonomy/README.md`, `autonomy/policy.md`, `docs/runbooks/worktree-task-execution.md`, `docs/adr/0004-standardize-worktree-first-task-execution.md`
+- Relevant commands: `bun run worktree:new`, `git worktree list`, `git worktree remove`, `git worktree prune`
+- Relevant specs or ADRs: `docs/adr/0004-standardize-worktree-first-task-execution.md`
+
+## Done When
+
+- `bun run worktree:new` can scaffold a dedicated task worktree with sensible default branch and path names.
+- The collaboration, autonomy, and runbook entry points all describe worktree-first implementation consistently.
+- A durable ADR records when worktrees are required versus optional.
+
+## Verification Notes
+
+- GitHub issue: https://github.com/Drswith/quantex-cli/issues/28
+- Local checks passed: `bun run memory:check`, `bun run lint`, `bun run typecheck`
+- Smoke test created and removed a disposable worktree successfully:
+  - `bun run worktree:new -- --task qtx-0999 --title "Worktree smoke" --branch codex/qtx-0999-worktree-smoke --path ../quantex-cli-qtx-0999-worktree-smoke --base main`
+  - `git -C ../quantex-cli-qtx-0999-worktree-smoke status --short --branch`
+  - `git worktree remove ../quantex-cli-qtx-0999-worktree-smoke`
+  - `git branch -D codex/qtx-0999-worktree-smoke`
+  - `git worktree prune`
+
+## Non-Goals
+
+- Replacing branches with a new workflow model.
+- Automatically deleting arbitrary worktrees or branches.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Discussion transcripts are not the long-term artifact. Use this funnel instead:
 3. Promote durable design choices into `docs/adr/`.
 4. Promote recurring troubleshooting knowledge into `docs/runbooks/`.
 5. Promote actionable follow-up work into `autonomy/tasks/` and `autonomy/queue.md`.
+6. When the follow-up will create commits or a PR, implement it from a dedicated git worktree.
 
 This keeps the project memory compact, searchable, and safe for future agent iteration.
 
@@ -45,6 +46,7 @@ Useful scaffolds:
 
 - `bun run task:new -- --title "Task title"`
 - `bun run adr:new -- --title "Decision title"`
+- `bun run worktree:new -- --task qtx-0000 --title "Task title"`
 
 GitHub workflow guidance:
 

--- a/docs/adr/0004-standardize-worktree-first-task-execution.md
+++ b/docs/adr/0004-standardize-worktree-first-task-execution.md
@@ -1,0 +1,45 @@
+# ADR 0004: Standardize Worktree-First Task Execution
+
+- Status: Accepted
+- Date: 2026-04-24
+
+## Context
+
+Quantex is being developed through human plus agent collaboration, and the implementation loop now relies on explicit task contracts, protected branches, release PRs, and increasingly autonomous execution.
+
+Switching branches inside a single shared working directory has three recurring costs:
+
+- it disrupts the user's current IDE context and branch position
+- it makes parallel task execution harder and riskier
+- it increases the chance of mixing task work with `main`, `beta`, or automation-managed release branches
+
+As the project moves toward more agent-led iteration, workspace isolation needs to become a durable process rule rather than an informal preference.
+
+## Decision
+
+Quantex standardizes on worktree-first task execution for implementation work that is expected to create commits or a PR.
+
+- Read-only inspection may still happen in the current workspace.
+- PR-bound implementation should use a dedicated git worktree by default.
+- Worktrees are required when the current workspace is dirty, when multiple tasks may proceed in parallel, or when the user's primary workspace should remain on another branch.
+- Quantex provides a helper command, `bun run worktree:new`, to scaffold a task worktree using the preferred naming convention.
+
+## Consequences
+
+- The user's main workspace can stay stable while task branches evolve elsewhere.
+- Parallel agent work becomes safer and easier to reason about.
+- Task execution now has an explicit isolation boundary that future agents can follow.
+- Contributors need to manage extra filesystem directories and clean up merged worktrees.
+- Worktrees do not replace branches; they are the standard way to host task branches.
+
+## Alternatives Considered
+
+- Keep using a single workspace and switch branches in place.
+- Use multiple full clones instead of git worktrees.
+- Leave worktree usage as an informal recommendation instead of a project rule.
+
+## Follow-up
+
+- Update the GitHub collaboration flow and autonomy guidance to point implementation work at dedicated worktrees.
+- Publish a runbook that explains setup, verification, cleanup, and escalation for worktree-backed task execution.
+- Keep task scaffolding and helper commands low-friction so the standard flow is easier to follow than ad hoc branch switching.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -30,9 +30,35 @@ Use the repository for:
    - `autonomy/tasks/` for executable work
    - `docs/adr/` for durable decisions
    - `openspec/` for non-trivial behavior changes
-5. Implement in a branch and open a PR.
+5. Create a dedicated worktree-backed branch and open a PR.
 6. Merge only after CI, PR governance, and documentation updates are in place.
 7. Mark the task done and update any affected runbooks, specs, or ADRs.
+
+## Worktree-backed task execution
+
+For implementation that is expected to create commits or a PR, Quantex defaults to a dedicated git worktree rather than switching the user's active workspace in place.
+
+Use `bun run worktree:new -- --task qtx-0000 --title "Task title"` to scaffold a new task worktree.
+
+Worktrees are required when:
+
+- the current workspace already has local changes
+- more than one task may be active in parallel
+- the user wants their IDE to stay on its current branch or context
+- the task may touch `main`, `beta`, or automation-managed release branches during verification
+
+Working directly in the current workspace is reserved for:
+
+- read-only inspection
+- short-lived commands that do not create commits
+- explicit in-place edits requested by the user
+
+Preferred naming:
+
+- branch: `codex/<task-or-title-slug>`
+- worktree path: `../<repo-name>-<task-or-title-slug>`
+
+Clean up merged or abandoned worktrees with `git worktree remove <path>` and `git worktree prune` after confirming no unmerged commits remain.
 
 ## Release under protected `main`
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -19,3 +19,4 @@ Current canonical runbooks:
 - [quantex-troubleshooting.md](./quantex-troubleshooting.md)
 - [releasing-quantex.md](./releasing-quantex.md)
 - [release-and-self-upgrade-debugging.md](./release-and-self-upgrade-debugging.md)
+- [worktree-task-execution.md](./worktree-task-execution.md)

--- a/docs/runbooks/worktree-task-execution.md
+++ b/docs/runbooks/worktree-task-execution.md
@@ -1,0 +1,68 @@
+# Runbook: Worktree-Backed Task Execution
+
+## Purpose
+
+Provide the canonical setup and cleanup flow for implementing Quantex tasks from dedicated git worktrees.
+
+## When to use
+
+- you are starting a task that will create commits or a PR
+- the current workspace already has local changes
+- multiple tasks or release-related branches may be active in parallel
+- you want the user's main IDE workspace to stay on its current branch
+
+## Inputs
+
+- task id or short task title
+- base branch or ref, usually `main`
+- `bun run worktree:new`
+- `git worktree list`
+
+## Triage order
+
+1. Decide whether the work is read-only. If it will produce commits or a PR, use a dedicated worktree by default.
+2. Create the worktree:
+
+   ```bash
+   bun run worktree:new -- --task qtx-0000 --title "Task title"
+   ```
+
+3. Verify the new workspace:
+
+   ```bash
+   git -C ../quantex-cli-qtx-0000-task-title status --short --branch
+   ```
+
+4. Implement, commit, push, and open the PR from the worktree path rather than switching the user's primary workspace.
+5. After the branch is merged or intentionally abandoned, remove the worktree and prune stale metadata:
+
+   ```bash
+   git worktree remove ../quantex-cli-qtx-0000-task-title
+   git worktree prune
+   ```
+
+## Recovery
+
+If the target path already exists, inspect `git worktree list` before deleting or reusing it.
+
+If the branch name is wrong, remove the unused worktree and rerun `bun run worktree:new` with `--branch`, `--task`, or `--title`.
+
+If cleanup fails because the branch still has unique commits, compare it against the intended base first:
+
+```bash
+git log --oneline main..codex/qtx-0000-task-title
+```
+
+## Escalation
+
+Stop and ask for human input when:
+
+- the worktree contains unmerged or unpushed commits you did not create
+- the task appears to require in-place edits inside the user's active workspace
+- you need to reuse protected or automation-managed branches such as `main`, `beta`, or `release-please...`
+
+## Related artifacts
+
+- [ADR 0004](../adr/0004-standardize-worktree-first-task-execution.md)
+- [qtx-0033](../../autonomy/tasks/qtx-0033-standardize-worktree-first-task-execution.md)
+- [GitHub Collaboration Flow](../github-collaboration.md)

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "release:artifacts": "bun run scripts/write-release-checksums.ts && bun run scripts/generate-release-manifest.ts && bun run scripts/verify-release-artifacts.ts",
     "release:smoke": "bun run scripts/verify-release-smoke.ts",
     "task:new": "bun run scripts/new-task.ts",
+    "worktree:new": "bun run scripts/new-worktree.ts",
     "dev": "bun run src/cli.ts",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/new-worktree.ts
+++ b/scripts/new-worktree.ts
@@ -1,0 +1,140 @@
+import { spawnSync } from 'node:child_process'
+import { basename, relative, resolve } from 'node:path'
+import process from 'node:process'
+import { parseArgs } from 'node:util'
+import prompts from 'prompts'
+import { isInteractiveSession, rootDir, slugify } from './project-memory-utils'
+
+const { values } = parseArgs({
+  args: process.argv.slice(2),
+  options: {
+    base: { type: 'string' },
+    branch: { type: 'string' },
+    help: { type: 'boolean' },
+    path: { type: 'string' },
+    task: { type: 'string' },
+    title: { type: 'string' },
+  },
+  allowPositionals: false,
+})
+
+if (values.help) {
+  printHelp()
+  process.exit(0)
+}
+
+const interactive = isInteractiveSession()
+const promptResults = await collectPromptResults(interactive)
+
+const task = values.task ?? promptResults.task ?? ''
+const title = values.title ?? promptResults.title ?? ''
+const base = values.base ?? promptResults.base ?? 'main'
+const slug = slugify([task, title].filter(Boolean).join(' '), 'task')
+const branch = values.branch ?? `codex/${slug}`
+const worktreePath = resolve(values.path ?? resolve(rootDir, '..', `${basename(rootDir)}-${slug}`))
+
+assertGitRefExists(base)
+assertBranchDoesNotExist(branch)
+
+const addResult = spawnSync('git', ['worktree', 'add', worktreePath, '-b', branch, base], {
+  cwd: rootDir,
+  stdio: 'inherit',
+})
+
+if (addResult.status !== 0)
+  process.exit(addResult.status ?? 1)
+
+const relativeWorktreePath = relative(rootDir, worktreePath) || '.'
+
+console.log(`Created worktree: ${relativeWorktreePath}`)
+console.log(`Branch: ${branch}`)
+console.log(`Base: ${base}`)
+console.log('Next steps:')
+console.log(`  cd ${worktreePath}`)
+console.log('  git status --short --branch')
+
+async function collectPromptResults(enabled: boolean) {
+  if (!enabled)
+    return {}
+
+  const response = await prompts([
+    {
+      type: values.task ? null : 'text',
+      name: 'task',
+      message: 'Task id (optional)',
+      initial: '',
+    },
+    {
+      type: values.title || values.branch ? null : 'text',
+      name: 'title',
+      message: 'Short worktree title',
+      validate: input => input.trim().length > 0 ? true : 'Title is required unless --branch is provided',
+    },
+    {
+      type: values.base ? null : 'text',
+      name: 'base',
+      message: 'Base branch or ref',
+      initial: 'main',
+      validate: input => input.trim().length > 0 ? true : 'Base ref is required',
+    },
+  ], {
+    onCancel: () => {
+      console.error('Cancelled.')
+      process.exit(1)
+    },
+  })
+
+  return response as {
+    base?: string
+    task?: string
+    title?: string
+  }
+}
+
+function assertGitRefExists(ref: string) {
+  const result = spawnSync('git', ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`], {
+    cwd: rootDir,
+    stdio: 'ignore',
+  })
+
+  if (result.status === 0)
+    return
+
+  console.error(`Unknown base ref: "${ref}".`)
+  process.exit(1)
+}
+
+function assertBranchDoesNotExist(branch: string) {
+  const result = spawnSync('git', ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`], {
+    cwd: rootDir,
+    stdio: 'ignore',
+  })
+
+  if (result.status !== 0)
+    return
+
+  console.error(`Branch already exists locally: "${branch}". Choose another branch or attach a worktree manually.`)
+  process.exit(1)
+}
+
+function printHelp() {
+  console.log(`
+Create a dedicated git worktree for a task branch.
+
+Usage:
+  bun run worktree:new -- --task qtx-0000 --title "Task title"
+
+Options:
+  --task <qtx-0000>
+  --title <title>
+  --branch <branch-name>
+  --base <ref>
+  --path <worktree-path>
+  --help
+
+Defaults:
+  branch: codex/<task-and-title-slug>
+  base: main
+  path: ../<repo-name>-<task-and-title-slug>
+`.trim())
+}


### PR DESCRIPTION
## Summary
- standardize worktree-backed task execution across the collaboration and autonomy docs
- add a bun run worktree:new helper to scaffold dedicated task worktrees
- capture the durable rule in an ADR and a canonical worktree runbook

## Linked Artifacts
- Issue: https://github.com/Drswith/quantex-cli/issues/28
- Task: autonomy/tasks/qtx-0033-standardize-worktree-first-task-execution.md
- ADR: docs/adr/0004-standardize-worktree-first-task-execution.md

## Validation
- bun run memory:check
- bun run lint
- bun run typecheck
- bun run worktree:new -- --task qtx-0999 --title "Worktree smoke" --branch codex/qtx-0999-worktree-smoke --path ../quantex-cli-qtx-0999-worktree-smoke --base main
- git -C ../quantex-cli-qtx-0999-worktree-smoke status --short --branch
- git worktree remove ../quantex-cli-qtx-0999-worktree-smoke
- git branch -D codex/qtx-0999-worktree-smoke
- git worktree prune

## Docs Updated
- autonomy/README.md
- autonomy/policy.md
- autonomy/tasks/README.md
- docs/README.md
- docs/github-collaboration.md
- docs/runbooks/README.md
- docs/runbooks/worktree-task-execution.md
- autonomy/tasks/qtx-0033-standardize-worktree-first-task-execution.md
- docs/adr/0004-standardize-worktree-first-task-execution.md

## Scope Check
- Collaboration workflow and helper tooling only; no product runtime behavior changes