### PR TITLE
chore(release): harden release trigger governance

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -69,3 +69,44 @@ jobs:
             if (meaningfulArtifacts.length === 0) {
               core.setFailed('PR body must link at least one issue, task, ADR, OpenSpec artifact, or discussion in the "Linked Artifacts" section.')
             }
+
+      - name: Validate release trigger scope
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request
+            const title = pullRequest.title || ''
+            const body = pullRequest.body || ''
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            })
+
+            const changedFiles = files.map(file => file.filename)
+            const releaseProcessOnly = changedFiles.length > 0
+              && changedFiles.every(fileName => {
+                return fileName.startsWith('.github/')
+                  || fileName.startsWith('autonomy/')
+                  || fileName.startsWith('docs/')
+                  || fileName === 'release-please-config.json'
+                  || fileName === 'release-please-config.beta.json'
+                  || fileName === '.release-please-manifest.json'
+              })
+
+            if (!releaseProcessOnly)
+              return
+
+            const releaseWorthyTitle = /^(feat|fix|perf)(\(.+\))?!?:/.test(title)
+              || /^[a-z]+(\(.+\))?!:/.test(title)
+            const releaseWorthyBody = /\nBREAKING CHANGE:/.test(`\n${body}`)
+
+            if (releaseWorthyTitle || releaseWorthyBody) {
+              core.setFailed([
+                'Release/process/docs/memory-only PRs must not use release-worthy conventional commit metadata.',
+                'Use ci:, chore:, or docs: unless the PR changes user-facing product behavior.',
+                `Changed files: ${changedFiles.join(', ')}`,
+              ].join('\n'))
+            }

--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -12,6 +12,7 @@ This queue is the prioritized entry point for future agent-driven work.
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
+| [qtx-0034](./tasks/qtx-0034-harden-release-trigger-governance.md) | `done` | `high` | Harden release trigger governance | qtx-0030, qtx-0032 |
 | [qtx-0033](./tasks/qtx-0033-standardize-worktree-first-task-execution.md) | `done` | `high` | Standardize worktree-first task execution | - |
 | [qtx-0031](./tasks/qtx-0031-harden-release-artifact-matrix-validation.md) | `done` | `high` | Harden release artifact matrix validation | qtx-0030 |
 | [qtx-0030](./tasks/qtx-0030-adopt-release-please-release-pr-flow.md) | `done` | `high` | Adopt release-please Release PR flow | - |

--- a/autonomy/tasks/qtx-0034-harden-release-trigger-governance.md
+++ b/autonomy/tasks/qtx-0034-harden-release-trigger-governance.md
@@ -1,0 +1,61 @@
+---
+id: qtx-0034
+title: Harden release trigger governance
+status: done
+priority: high
+area: release
+depends_on:
+  - qtx-0030
+  - qtx-0032
+human_review: required
+checks:
+  - bun run memory:check
+  - bun run lint
+  - bun run typecheck
+docs_to_update:
+  - docs/runbooks/releasing-quantex.md
+  - docs/github-collaboration.md
+---
+
+# Task: Harden release trigger governance
+
+## Goal
+
+Release-process, documentation, and project-memory-only PRs should not accidentally create stable Release PRs through release-worthy conventional commit metadata.
+
+## Context
+
+PR #23 was created because release automation support landed with a `feat(release): ...` squash title. The resulting Release PR was technically correct under release-please rules, but semantically wrong for the project because the change was process infrastructure rather than user-facing product behavior.
+
+## Constraints
+
+- Keep release-please as the source-visible versioning path.
+- Do not publish the accidental stable `0.3.0` Release PR.
+- Prefer an automated PR governance check over relying on reviewer memory.
+- Keep real product `feat:`, `fix:`, and `perf:` PRs release-worthy.
+
+## Implementation Notes
+
+- GitHub issue: https://github.com/Drswith/quantex-cli/issues/30
+- Close accidental stable Release PR #23.
+- Extend PR Governance to inspect changed files and PR release metadata.
+- Reject release-worthy PR titles or breaking metadata when all changed files are limited to workflow, documentation, project-memory, or release configuration files.
+- Document the commit-title rule in release and collaboration guidance.
+
+## Done When
+
+- Accidental Release PR #23 is closed.
+- A PR that only changes release/process/docs/memory files cannot pass governance with `feat:`, `fix:`, `perf:`, or breaking metadata.
+- Release docs explain that process-only PRs should use `ci:`, `chore:`, or `docs:` titles.
+
+## Verification Notes
+
+- Accidental stable Release PR: https://github.com/Drswith/quantex-cli/pull/23
+- Local validation passed: `bun run memory:check`, `bun run lint`, `bun run typecheck`.
+- Release trigger governance examples passed for release-process-only `feat:`, safe `chore:`/`docs:`, and real product `feat:` cases.
+
+## Non-Goals
+
+- Replacing release-please.
+- Fully automating Release PR merge in this task.
+- Changing beta channel publication semantics.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -84,6 +84,8 @@ Release PR creation relies on merged commit metadata. In practice that means:
 - `BREAKING CHANGE:` or `!` produces a major release
 - `docs:`, `test:`, `ci:`, and `chore:` do not create a release unless the commit metadata is explicitly changed to do so later
 
+For PRs that only touch workflow, documentation, project-memory, or release-please configuration files, use `ci:`, `chore:`, or `docs:` titles. PR Governance blocks release-worthy metadata for those scopes so release-process changes do not accidentally create stable product Release PRs.
+
 ## Repository assets
 
 The repository now includes:

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -70,6 +70,8 @@ Release PR creation uses conventional commits:
 - `BREAKING CHANGE:` footer or `!` => major release
 - `docs:`, `test:`, `ci:`, `chore:` => no release unless the metadata is intentionally changed
 
+Release automation, documentation, and project-memory-only PRs must use non-release-worthy titles such as `ci:`, `chore:`, or `docs:`. PR Governance rejects release-worthy titles for PRs that only change `.github/`, `docs/`, `autonomy/`, or release-please configuration files, because those changes should not create stable product releases by themselves.
+
 ## npm trusted publishing
 
 Quantex publishes to npm through GitHub Actions trusted publishing with OIDC. The release workflow must keep `id-token: write` enabled and use a Node/npm version that supports trusted publishing.


### PR DESCRIPTION
## Summary
- close the accidental stable Release PR path by documenting qtx-0034
- add PR Governance that blocks release-worthy metadata for release/process/docs/memory-only PRs
- document that workflow/docs/project-memory-only PRs should use ci:, chore:, or docs: titles

## Linked Artifacts
- Issue: https://github.com/Drswith/quantex-cli/issues/30
- Task: autonomy/tasks/qtx-0034-harden-release-trigger-governance.md
- Release PR: https://github.com/Drswith/quantex-cli/pull/23

## Validation
- bun run memory:check
- bun run lint
- bun run typecheck
- release trigger governance examples passed locally

## Docs Updated
- docs/runbooks/releasing-quantex.md
- docs/github-collaboration.md
- autonomy/tasks/qtx-0034-harden-release-trigger-governance.md

## Scope Check
- Release governance only; no runtime product behavior changes
- This PR intentionally uses chore: metadata so it does not create another Release PR