### PR TITLE
chore(release): anchor stable release scan window

### DIFF
--- a/autonomy/tasks/qtx-0034-harden-release-trigger-governance.md
+++ b/autonomy/tasks/qtx-0034-harden-release-trigger-governance.md
@@ -38,19 +38,24 @@ PR #23 was created because release automation support landed with a `feat(releas
 
 - GitHub issue: https://github.com/Drswith/quantex-cli/issues/30
 - Close accidental stable Release PR #23.
+- Close regenerated accidental stable Release PR #32.
 - Extend PR Governance to inspect changed files and PR release metadata.
 - Reject release-worthy PR titles or breaking metadata when all changed files are limited to workflow, documentation, project-memory, or release configuration files.
+- Anchor stable release-please scanning with `last-release-sha` so the historical accidental `feat(release)` commit is excluded from future stable Release PR calculation.
 - Document the commit-title rule in release and collaboration guidance.
 
 ## Done When
 
 - Accidental Release PR #23 is closed.
+- Regenerated accidental Release PR #32 is closed.
 - A PR that only changes release/process/docs/memory files cannot pass governance with `feat:`, `fix:`, `perf:`, or breaking metadata.
 - Release docs explain that process-only PRs should use `ci:`, `chore:`, or `docs:` titles.
 
 ## Verification Notes
 
 - Accidental stable Release PR: https://github.com/Drswith/quantex-cli/pull/23
+- Regenerated accidental stable Release PR: https://github.com/Drswith/quantex-cli/pull/32
+- Temporary stable release scan anchor: `fcda8f1e3c95f5cf28d5db7a56df900dd8a4060d`.
 - Local validation passed: `bun run memory:check`, `bun run lint`, `bun run typecheck`.
 - Release trigger governance examples passed for release-process-only `feat:`, safe `chore:`/`docs:`, and real product `feat:` cases.
 
@@ -59,3 +64,4 @@ PR #23 was created because release automation support landed with a `feat(releas
 - Replacing release-please.
 - Fully automating Release PR merge in this task.
 - Changing beta channel publication semantics.
+- Keeping `last-release-sha` forever; remove or advance it after the next intentional stable Release PR is merged.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -86,6 +86,8 @@ Release PR creation relies on merged commit metadata. In practice that means:
 
 For PRs that only touch workflow, documentation, project-memory, or release-please configuration files, use `ci:`, `chore:`, or `docs:` titles. PR Governance blocks release-worthy metadata for those scopes so release-process changes do not accidentally create stable product Release PRs.
 
+The stable release-please config may include a temporary `last-release-sha` anchor after release-governance incidents. Treat it as a recovery boundary, not a permanent release policy; remove or advance it after the next intentional stable release lands.
+
 ## Repository assets
 
 The repository now includes:

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -72,6 +72,8 @@ Release PR creation uses conventional commits:
 
 Release automation, documentation, and project-memory-only PRs must use non-release-worthy titles such as `ci:`, `chore:`, or `docs:`. PR Governance rejects release-worthy titles for PRs that only change `.github/`, `docs/`, `autonomy/`, or release-please configuration files, because those changes should not create stable product releases by themselves.
 
+The stable release-please config currently includes a temporary `last-release-sha` anchor to exclude a historical release-process `feat(release)` commit from stable release calculation. Remove or advance that anchor after the next intentional stable Release PR is merged, because release-please treats `last-release-sha` as an explicit scan boundary until it is changed.
+
 ## npm trusted publishing
 
 Quantex publishes to npm through GitHub Actions trusted publishing with OIDC. The release workflow must keep `id-token: write` enabled and use a Node/npm version that supports trusted publishing.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "fcda8f1e3c95f5cf28d5db7a56df900dd8a4060d",
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary
- close the regenerated accidental stable Release PR path
- set a temporary release-please last-release-sha anchor after the release-governance fix
- document that this anchor should be removed or advanced after the next intentional stable release

## Linked Artifacts
- Issue: https://github.com/Drswith/quantex-cli/issues/30
- Task: autonomy/tasks/qtx-0034-harden-release-trigger-governance.md
- Release PR: https://github.com/Drswith/quantex-cli/pull/23
- Release PR: https://github.com/Drswith/quantex-cli/pull/32

## Validation
- bun run memory:check
- bun run lint
- bun run typecheck

## Docs Updated
- docs/runbooks/releasing-quantex.md
- docs/github-collaboration.md
- autonomy/tasks/qtx-0034-harden-release-trigger-governance.md

## Scope Check
- Release governance recovery only; no runtime product behavior changes
- This PR intentionally uses chore: metadata so it does not create another releasable commit