### PR TITLE
chore(release): automate release PR merge

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -1,0 +1,102 @@
+name: Release PR Automerge
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - main
+      - beta
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  validate-and-enable:
+    if: >-
+      startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Release PR scope
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request
+            const baseBranch = pullRequest.base.ref
+            const headBranch = pullRequest.head.ref
+            const title = pullRequest.title || ''
+            const body = pullRequest.body || ''
+
+            if (pullRequest.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed('Release PR automerge only supports release-please branches from this repository.')
+              return
+            }
+
+            const expectedHeadBranch = `release-please--branches--${baseBranch}--components--quantex-cli`
+            if (headBranch !== expectedHeadBranch) {
+              core.setFailed(`Unexpected release-please branch "${headBranch}". Expected "${expectedHeadBranch}".`)
+              return
+            }
+
+            const titlePattern = baseBranch === 'beta'
+              ? /^chore: release \d+\.\d+\.\d+-beta(?:\.\d+)?$/
+              : /^chore: release \d+\.\d+\.\d+$/
+
+            if (!titlePattern.test(title)) {
+              core.setFailed(`Release PR title "${title}" does not match the expected ${baseBranch} release pattern.`)
+              return
+            }
+
+            if (!body.includes('This PR was generated with [Release Please]')) {
+              core.setFailed('Release PR body does not include the release-please generated marker.')
+              return
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            })
+
+            const changedFiles = files.map(file => file.filename).sort()
+            const allowedFiles = new Set([
+              '.release-please-manifest.json',
+              'CHANGELOG.md',
+              'package.json',
+              'src/generated/build-meta.ts',
+            ])
+            const requiredFiles = new Set([
+              '.release-please-manifest.json',
+              'package.json',
+              'src/generated/build-meta.ts',
+            ])
+
+            const unexpectedFiles = changedFiles.filter(fileName => !allowedFiles.has(fileName))
+            if (unexpectedFiles.length > 0) {
+              core.setFailed(`Release PR changes unexpected files: ${unexpectedFiles.join(', ')}`)
+              return
+            }
+
+            const missingFiles = [...requiredFiles].filter(fileName => !changedFiles.includes(fileName))
+            if (missingFiles.length > 0) {
+              core.setFailed(`Release PR is missing required version files: ${missingFiles.join(', ')}`)
+              return
+            }
+
+      - name: Enable Release PR auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          gh pr merge "$PR_URL" \
+            --squash \
+            --auto \
+            --delete-branch \
+            --subject "$PR_TITLE" \
+            --body "Automated release-please Release PR merge after scoped validation."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}
           config-file: ${{ steps.channel.outputs.config_file }}
           manifest-file: .release-please-manifest.json

--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -12,6 +12,7 @@ This queue is the prioritized entry point for future agent-driven work.
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
+| [qtx-0035](./tasks/qtx-0035-automate-release-pr-merge.md) | `done` | `high` | Automate release PR merge | qtx-0030, qtx-0034 |
 | [qtx-0034](./tasks/qtx-0034-harden-release-trigger-governance.md) | `done` | `high` | Harden release trigger governance | qtx-0030, qtx-0032 |
 | [qtx-0033](./tasks/qtx-0033-standardize-worktree-first-task-execution.md) | `done` | `high` | Standardize worktree-first task execution | - |
 | [qtx-0031](./tasks/qtx-0031-harden-release-artifact-matrix-validation.md) | `done` | `high` | Harden release artifact matrix validation | qtx-0030 |

--- a/autonomy/tasks/qtx-0035-automate-release-pr-merge.md
+++ b/autonomy/tasks/qtx-0035-automate-release-pr-merge.md
@@ -1,0 +1,63 @@
+---
+id: qtx-0035
+title: Automate release PR merge
+status: done
+priority: high
+area: release
+depends_on:
+  - qtx-0030
+  - qtx-0034
+human_review: required
+checks:
+  - bun run memory:check
+  - bun run lint
+  - bun run typecheck
+docs_to_update:
+  - docs/runbooks/releasing-quantex.md
+  - docs/github-collaboration.md
+---
+
+# Task: Automate release PR merge
+
+## Goal
+
+Valid release-please Release PRs should merge automatically after scoped validation and required checks, so release-worthy task PRs can flow from merge to publication without manual Release PR merging.
+
+## Context
+
+Release-please solved source-visible versioning, but it reintroduced a manual merge step for Release PRs. The project goal is agent-led iteration where normal task PRs can trigger safe release publication without local release commands or repeated human intervention.
+
+## Constraints
+
+- Only automate release-please generated PRs from same-repository release branches.
+- Only support the known stable and beta release branches.
+- Validate that Release PRs only modify source-controlled release files before enabling auto-merge.
+- Keep npm trusted publishing in `.github/workflows/release.yml`.
+- Prefer dedicated bot tokens so release-please generated PRs trigger downstream workflows normally.
+
+## Implementation Notes
+
+- GitHub issue: https://github.com/Drswith/quantex-cli/issues/34
+- Add `.github/workflows/release-pr-automerge.yml`.
+- Validate Release PR repository, branch, base, title, release-please marker, and changed files.
+- Enable GitHub auto-merge for valid Release PRs.
+- Let branch protection and required checks decide the final merge timing.
+- Update Release workflow to prefer `RELEASE_PLEASE_TOKEN` over `GITHUB_TOKEN`.
+
+## Done When
+
+- Valid stable and beta release-please PRs are eligible for auto-merge.
+- Invalid Release PRs fail before auto-merge is enabled.
+- Release docs explain the required repository settings and bot-token assumptions.
+
+## Verification Notes
+
+- Local validation passed: `bun run memory:check`, `bun run lint`, `bun run typecheck`.
+- Release PR automerge validation examples passed for stable, beta, cross-repository, bad-title, unexpected-file, and missing-file cases.
+- Repository auto-merge was disabled before this task and must be enabled after the workflow lands.
+
+## Non-Goals
+
+- Publishing releases outside the existing Release workflow.
+- Auto-merging arbitrary product PRs.
+- Changing version calculation rules.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -68,7 +68,7 @@ Quantex uses release-please to keep publishing compatible with protected `main` 
 2. The `Release` workflow runs release-please on the resulting `main` push.
 3. If the merged commits warrant a version bump, release-please creates or updates a Release PR.
 4. The Release PR updates `CHANGELOG.md`, `package.json`, `.release-please-manifest.json`, and `src/generated/build-meta.ts`.
-5. Merge the Release PR when you are ready to publish.
+5. `Release PR Automerge` validates the generated Release PR and enables auto-merge.
 6. The `Release` workflow creates the tag and GitHub Release, then builds artifacts, publishes npm through trusted publishing, and uploads binaries.
 
 This keeps normal product changes behind PR review while making the release version visible in the source tree at the tagged commit.
@@ -76,6 +76,8 @@ This keeps normal product changes behind PR review while making the release vers
 Release notes are tracked in [CHANGELOG.md](../CHANGELOG.md), summarized in [docs/releases.md](./releases.md), and published on GitHub Releases.
 
 The npm publish step uses GitHub Actions trusted publishing with OIDC rather than a long-lived `NPM_TOKEN`, so npm trusted publisher settings should point at `.github/workflows/release.yml`.
+
+For full unattended publishing, configure `RELEASE_PLEASE_TOKEN` and `RELEASE_AUTOMERGE_TOKEN` as dedicated release bot or GitHub App tokens. The workflows can fall back to `GITHUB_TOKEN`, but that fallback may leave generated Release PR checks in `action_required` because GitHub suppresses many workflow events created by `GITHUB_TOKEN`.
 
 Release PR creation relies on merged commit metadata. In practice that means:
 

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -33,9 +33,19 @@ The Release PR materializes the pending version in:
 - `.release-please-manifest.json`
 - `src/generated/build-meta.ts`
 
-### 3. Merge the Release PR when ready
+### 3. Let Release PR Automerge validate the Release PR
 
-The Release PR is the human/agent review point for the exact version and changelog that will be published.
+The Release PR is the review point for the exact version and changelog that will be published. The `Release PR Automerge` workflow validates release-please generated PRs before enabling auto-merge.
+
+It only enables auto-merge when the PR:
+
+- comes from this repository
+- uses the expected release-please branch for `main` or `beta`
+- has the expected release title shape
+- includes the release-please generated marker
+- only changes `CHANGELOG.md`, `package.json`, `.release-please-manifest.json`, and `src/generated/build-meta.ts`
+
+Branch protection and required checks still decide when the Release PR actually merges.
 
 ### 4. Let the release job validate the merged Release PR
 
@@ -101,6 +111,7 @@ Required Actions workflow permissions:
 
 - default workflow permissions: read and write
 - allow GitHub Actions to create and approve pull requests: enabled
+- repository auto-merge: enabled
 
 If this permission is disabled, release-please can calculate the next version and create its branch, but it fails when opening the Release PR with:
 
@@ -112,7 +123,13 @@ GitHub Actions is not permitted to create or approve pull requests.
 
 Release PRs are created by `github-actions[bot]`. If GitHub marks the generated Release PR checks as `action_required` with no jobs, close and reopen the Release PR from a maintainer account to trigger the required `pull_request` checks.
 
-For a fully non-interactive future flow, prefer replacing `GITHUB_TOKEN` in the release-please step with a dedicated release bot token or GitHub App token that is allowed to create PRs and trigger checks.
+For the non-interactive release flow, configure a dedicated release bot token or GitHub App token:
+
+- `RELEASE_PLEASE_TOKEN` lets release-please create PRs in a way that triggers downstream workflows normally.
+- `RELEASE_AUTOMERGE_TOKEN` lets the automerge workflow enable auto-merge for validated Release PRs.
+- Both tokens need enough permission to read PR files and update/merge pull requests.
+
+The workflows fall back to `GITHUB_TOKEN`, but that fallback is best treated as degraded mode because GitHub suppresses many workflow events created by `GITHUB_TOKEN`.
 
 ## Validation
 
@@ -139,6 +156,7 @@ bun run release:smoke
 ## Related artifacts
 
 - `.github/workflows/release.yml`
+- `.github/workflows/release-pr-automerge.yml`
 - `.github/workflows/ci.yml`
 - `release-please-config.json`
 - `.release-please-manifest.json`


### PR DESCRIPTION
## Summary
- add a Release PR Automerge workflow for release-please generated PRs
- validate release PR branch, title, marker, repository, and changed files before enabling auto-merge
- prefer dedicated release bot tokens for release-please and automerge workflows
- document required repository settings and token assumptions

## Linked Artifacts
- Issue: https://github.com/Drswith/quantex-cli/issues/34
- Task: autonomy/tasks/qtx-0035-automate-release-pr-merge.md

## Validation
- bun run memory:check
- bun run lint
- bun run typecheck
- release PR automerge validation examples passed locally

## Docs Updated
- docs/runbooks/releasing-quantex.md
- docs/github-collaboration.md
- autonomy/tasks/qtx-0035-automate-release-pr-merge.md

## Scope Check
- Release automation only; no runtime product behavior changes
- This PR intentionally uses chore: metadata so it does not create a product release