### PR TITLE
ci(release): adopt GitHub App release bot

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -88,9 +88,16 @@ jobs:
               return
             }
 
+      - name: Create release bot token
+        id: release-bot-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Enable Release PR auto-merge
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-bot-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,18 @@ jobs:
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Create release bot token
+        id: release-bot-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Release Please
         id: release
         uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.release-bot-token.outputs.token }}
           target-branch: ${{ github.ref_name }}
           config-file: ${{ steps.channel.outputs.config_file }}
           manifest-file: .release-please-manifest.json
@@ -104,5 +111,5 @@ jobs:
       - name: Upload release artifacts
         if: ${{ steps.release.outputs.release_created }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.release-bot-token.outputs.token }}
         run: gh release upload ${{ steps.release.outputs.tag_name }} dist/bin/* --clobber

--- a/autonomy/queue.md
+++ b/autonomy/queue.md
@@ -12,6 +12,7 @@ This queue is the prioritized entry point for future agent-driven work.
 
 | ID | Status | Priority | Title | Depends on |
 |---|---|---|---|---|
+| [qtx-0037](./tasks/qtx-0037-adopt-github-app-release-bot.md) | `done` | `high` | Adopt GitHub App release bot | qtx-0030, qtx-0035 |
 | [qtx-0036](./tasks/qtx-0036-speed-up-windows-ci-and-align-registry.md) | `done` | `high` | Speed up Windows CI and align registry usage | qtx-0034 |
 | [qtx-0035](./tasks/qtx-0035-automate-release-pr-merge.md) | `done` | `high` | Automate release PR merge | qtx-0030, qtx-0034 |
 | [qtx-0034](./tasks/qtx-0034-harden-release-trigger-governance.md) | `done` | `high` | Harden release trigger governance | qtx-0030, qtx-0032 |

--- a/autonomy/tasks/qtx-0037-adopt-github-app-release-bot.md
+++ b/autonomy/tasks/qtx-0037-adopt-github-app-release-bot.md
@@ -1,0 +1,61 @@
+---
+id: qtx-0037
+title: Adopt GitHub App release bot
+status: done
+priority: high
+area: release
+depends_on:
+  - qtx-0030
+  - qtx-0035
+human_review: required
+checks:
+  - bun run memory:check
+  - bun run lint
+  - bun run typecheck
+docs_to_update:
+  - docs/runbooks/releasing-quantex.md
+  - docs/github-collaboration.md
+---
+
+# Task: Adopt GitHub App release bot
+
+## Goal
+
+Release automation should use a scoped GitHub App installation token instead of long-lived release bot tokens or the degraded `GITHUB_TOKEN` fallback.
+
+## Context
+
+The release-please Release PR flow needs a real bot identity so generated Release PRs trigger downstream checks and can be auto-merged after validation. A GitHub App gives the release system a narrow permission set and short-lived tokens without tying automation to a personal access token.
+
+## Constraints
+
+- Keep npm publishing on GitHub Actions trusted publishing with OIDC.
+- Install the GitHub App only on the `Drswith/quantex-cli` repository.
+- Give the App only the repository permissions required for release-please and Release PR automerge.
+- Do not store the private key in the repository.
+
+## Implementation Notes
+
+- GitHub issue: https://github.com/Drswith/quantex-cli/issues/37
+- Create GitHub App `quantex-cli-release-bot`.
+- Store `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` as repository secrets.
+- Update release workflows to use `actions/create-github-app-token`.
+- Remove `RELEASE_PLEASE_TOKEN` and `RELEASE_AUTOMERGE_TOKEN` from the normal documented path.
+
+## Done When
+
+- The GitHub App is installed on `Drswith/quantex-cli`.
+- Release workflows mint GitHub App installation tokens during execution.
+- Release documentation describes the App-based identity.
+
+## Verification Notes
+
+- Repository secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` were configured.
+- Local validation passed: `bun run memory:check`, `bun run lint`, `bun run typecheck`.
+- GitHub PR validation and a post-merge Release workflow run must confirm the App token works end to end.
+
+## Non-Goals
+
+- Changing release version calculation.
+- Changing npm trusted publisher configuration.
+- Granting the GitHub App administration, secrets, workflows, or all-repository access.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -77,7 +77,9 @@ Release notes are tracked in [CHANGELOG.md](../CHANGELOG.md), summarized in [doc
 
 The npm publish step uses GitHub Actions trusted publishing with OIDC rather than a long-lived `NPM_TOKEN`, so npm trusted publisher settings should point at `.github/workflows/release.yml`.
 
-For full unattended publishing, configure `RELEASE_PLEASE_TOKEN` and `RELEASE_AUTOMERGE_TOKEN` as dedicated release bot or GitHub App tokens. The workflows can fall back to `GITHUB_TOKEN`, but that fallback may leave generated Release PR checks in `action_required` because GitHub suppresses many workflow events created by `GITHUB_TOKEN`.
+For full unattended publishing, configure the release GitHub App secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`. The workflows use `actions/create-github-app-token` to mint short-lived installation tokens for Release PR creation, Release PR auto-merge, GitHub Release creation, and artifact upload.
+
+Avoid using `GITHUB_TOKEN` as the normal release identity because GitHub suppresses many workflow events created by `GITHUB_TOKEN`, which can leave generated Release PR checks in `action_required`.
 
 Release PR creation relies on merged commit metadata. In practice that means:
 

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -121,15 +121,18 @@ GitHub Actions is not permitted to create or approve pull requests.
 
 ## Release PR checks
 
-Release PRs are created by `github-actions[bot]`. If GitHub marks the generated Release PR checks as `action_required` with no jobs, close and reopen the Release PR from a maintainer account to trigger the required `pull_request` checks.
+Release PRs are created by the configured release GitHub App. If GitHub marks a generated Release PR check as `action_required` with no jobs, verify the workflow still uses the GitHub App token instead of `GITHUB_TOKEN`, then close and reopen the Release PR from a maintainer account only as a recovery step.
 
-For the non-interactive release flow, configure a dedicated release bot token or GitHub App token:
+For the non-interactive release flow, configure a dedicated GitHub App installation token:
 
-- `RELEASE_PLEASE_TOKEN` lets release-please create PRs in a way that triggers downstream workflows normally.
-- `RELEASE_AUTOMERGE_TOKEN` lets the automerge workflow enable auto-merge for validated Release PRs.
-- Both tokens need enough permission to read PR files and update/merge pull requests.
+- `RELEASE_APP_ID` stores the GitHub App ID.
+- `RELEASE_APP_PRIVATE_KEY` stores the GitHub App private key PEM.
+- `.github/workflows/release.yml` uses `actions/create-github-app-token` to create or update Release PRs, create releases, and upload artifacts.
+- `.github/workflows/release-pr-automerge.yml` uses the same GitHub App token to enable auto-merge for validated Release PRs.
 
-The workflows fall back to `GITHUB_TOKEN`, but that fallback is best treated as degraded mode because GitHub suppresses many workflow events created by `GITHUB_TOKEN`.
+The GitHub App should be installed only on `Drswith/quantex-cli` and only needs repository permissions for read-only actions/metadata plus read-write contents, issues, and pull requests.
+
+Do not use `GITHUB_TOKEN` as the normal release identity because GitHub suppresses many workflow events created by `GITHUB_TOKEN`.
 
 ## Validation
 


### PR DESCRIPTION
## Summary

Adopt `quantex-cli-release-bot` as the canonical GitHub App identity for release automation. The release workflows now mint short-lived installation tokens with `actions/create-github-app-token` instead of relying on long-lived bot token secrets or `GITHUB_TOKEN` fallback behavior.

## Linked Artifacts

- Issue: https://github.com/Drswith/quantex-cli/issues/37
- Task: `autonomy/tasks/qtx-0037-adopt-github-app-release-bot.md`
- ADR: N/A
- OpenSpec: N/A
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `autonomy/...`
- [ ] `openspec/...`
- [ ] Follow-up task created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant task, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Notes

The GitHub App has been installed only on `Drswith/quantex-cli`; repository secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` are configured. `bun run test` was not run because this change only touches workflow identity and release documentation.
