### PR TITLE
ci(release): use release app client id

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -92,7 +92,7 @@ jobs:
         id: release-bot-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Enable Release PR auto-merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         id: release-bot-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Release Please

--- a/autonomy/tasks/qtx-0037-adopt-github-app-release-bot.md
+++ b/autonomy/tasks/qtx-0037-adopt-github-app-release-bot.md
@@ -38,7 +38,7 @@ The release-please Release PR flow needs a real bot identity so generated Releas
 
 - GitHub issue: https://github.com/Drswith/quantex-cli/issues/37
 - Create GitHub App `quantex-cli-release-bot`.
-- Store `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` as repository secrets.
+- Store `RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY` as repository secrets.
 - Update release workflows to use `actions/create-github-app-token`.
 - Remove `RELEASE_PLEASE_TOKEN` and `RELEASE_AUTOMERGE_TOKEN` from the normal documented path.
 
@@ -50,7 +50,7 @@ The release-please Release PR flow needs a real bot identity so generated Releas
 
 ## Verification Notes
 
-- Repository secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY` were configured.
+- Repository secrets `RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY` were configured.
 - Local validation passed: `bun run memory:check`, `bun run lint`, `bun run typecheck`.
 - GitHub PR validation and a post-merge Release workflow run must confirm the App token works end to end.
 

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -77,7 +77,7 @@ Release notes are tracked in [CHANGELOG.md](../CHANGELOG.md), summarized in [doc
 
 The npm publish step uses GitHub Actions trusted publishing with OIDC rather than a long-lived `NPM_TOKEN`, so npm trusted publisher settings should point at `.github/workflows/release.yml`.
 
-For full unattended publishing, configure the release GitHub App secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`. The workflows use `actions/create-github-app-token` to mint short-lived installation tokens for Release PR creation, Release PR auto-merge, GitHub Release creation, and artifact upload.
+For full unattended publishing, configure the release GitHub App secrets `RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY`. The workflows use `actions/create-github-app-token` to mint short-lived installation tokens for Release PR creation, Release PR auto-merge, GitHub Release creation, and artifact upload.
 
 Avoid using `GITHUB_TOKEN` as the normal release identity because GitHub suppresses many workflow events created by `GITHUB_TOKEN`, which can leave generated Release PR checks in `action_required`.
 

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -125,7 +125,7 @@ Release PRs are created by the configured release GitHub App. If GitHub marks a 
 
 For the non-interactive release flow, configure a dedicated GitHub App installation token:
 
-- `RELEASE_APP_ID` stores the GitHub App ID.
+- `RELEASE_APP_CLIENT_ID` stores the GitHub App client ID.
 - `RELEASE_APP_PRIVATE_KEY` stores the GitHub App private key PEM.
 - `.github/workflows/release.yml` uses `actions/create-github-app-token` to create or update Release PRs, create releases, and upload artifacts.
 - `.github/workflows/release-pr-automerge.yml` uses the same GitHub App token to enable auto-merge for validated Release PRs.


### PR DESCRIPTION
## Summary

Follow up on the GitHub App release bot rollout by switching `actions/create-github-app-token@v3` from deprecated `app-id` input to `client-id`.

## Linked Artifacts

- Issue: https://github.com/Drswith/quantex-cli/issues/37
- Task: `autonomy/tasks/qtx-0037-adopt-github-app-release-bot.md`
- ADR: N/A
- OpenSpec: N/A
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `autonomy/...`
- [ ] `openspec/...`
- [ ] Follow-up task created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant task, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Notes

`RELEASE_APP_CLIENT_ID` is configured as a repository secret. `bun run test` was not run because this only updates workflow token input naming and release docs.
