### PR TITLE
feat(agent): add Kilo Code CLI support

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -16,7 +16,7 @@ Manage AI coding assistant CLIs from one lifecycle-focused command line.
 
 </div>
 
-Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding agents. It gives Claude Code, Codex, Gemini, Cursor, OpenCode, and other assistant CLIs a shared surface for installation, inspection, updates, removal, execution, and machine-readable automation.
+Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding agents. It gives Claude Code, Codex, Gemini, Kilo Code, Cursor, OpenCode, and other assistant CLIs a shared surface for installation, inspection, updates, removal, execution, and machine-readable automation.
 
 ## Why Quantex
 
@@ -154,6 +154,7 @@ quantex upgrade --channel beta
 | Cursor CLI | `quantex cursor` | Cursor AI coding assistant CLI |
 | Droid | `quantex droid` | Factory AI software engineering agent CLI |
 | Gemini CLI | `quantex gemini` | Google's open-source AI coding assistant CLI |
+| Kilo Code CLI | `quantex kilo` | Kilo's official AI coding assistant CLI |
 | OpenCode | `quantex opencode` | Open-source AI coding CLI |
 | Pi | `quantex pi` | Minimal and extensible terminal coding agent |
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 </div>
 
-Quantex 是一个 `human-friendly + agent-friendly` 的 agent lifecycle CLI。它帮你把 Claude Code、Codex、Gemini、Cursor、OpenCode 等 AI 编程助手的生命周期操作统一到一组稳定命令里：人可以直接用，自动化脚本和 coding agent 也可以用结构化输出可靠调用。
+Quantex 是一个 `human-friendly + agent-friendly` 的 agent lifecycle CLI。它帮你把 Claude Code、Codex、Gemini、Kilo Code、Cursor、OpenCode 等 AI 编程助手的生命周期操作统一到一组稳定命令里：人可以直接用，自动化脚本和 coding agent 也可以用结构化输出可靠调用。
 
 ## 为什么用 Quantex
 
@@ -154,6 +154,7 @@ quantex upgrade --channel beta
 | Cursor CLI | `quantex cursor` | Cursor AI 编程助手命令行工具 |
 | Droid | `quantex droid` | Factory AI 软件工程 Agent CLI |
 | Gemini CLI | `quantex gemini` | Google 开源 AI 编程助手 CLI |
+| Kilo Code CLI | `quantex kilo` | Kilo 官方 AI 编程助手 CLI |
 | OpenCode | `quantex opencode` | 开源 AI 编程 CLI |
 | Pi | `quantex pi` | 极简可扩展的终端编程 Agent |
 

--- a/openspec/changes/add-kilo-code-cli-support/.openspec.yaml
+++ b/openspec/changes/add-kilo-code-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/add-kilo-code-cli-support/design.md
+++ b/openspec/changes/add-kilo-code-cli-support/design.md
@@ -1,0 +1,31 @@
+## Context
+
+Quantex models each supported agent through a catalog entry that drives installation, inspection, update planning, and human-readable guidance. Kilo Code CLI now has stable upstream metadata: the npm package is `@kilocode/cli`, the canonical binary is `kilo`, the package also exposes `kilocode`, and the official docs publish `kilo upgrade` as the self-update command.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a verified Kilo catalog entry that works with the existing lifecycle architecture.
+- Preserve Quantex's current catalog conventions for managed installs, lookup aliases, and self-update metadata.
+- Ensure user-facing surfaces and tests recognize Kilo consistently.
+
+**Non-Goals:**
+
+- Implement a bespoke Kilo integration path outside the existing agent-definition model.
+- Add unsupported install methods that are not yet verified in Quantex's current install abstraction.
+- Change the behavior of lifecycle commands beyond making Kilo selectable as a supported agent.
+
+## Decisions
+
+- Model Kilo as a standard npm/bun-managed agent with `packages.npm = @kilocode/cli`.
+  - Alternative considered: add binary-release install methods immediately. Rejected because npm and Bun are already verified, while binary install support would require additional platform-specific validation and user guidance.
+- Use `kilo` as the canonical agent name and binary, with `kilocode` as a lookup alias.
+  - Alternative considered: use `kilocode` as the primary Quantex identifier. Rejected because the upstream docs instruct users to run `kilo`, and Quantex names should match the most common executable contract.
+- Record `kilo upgrade` as the self-update command.
+  - Alternative considered: rely only on managed package updates. Rejected because the official CLI docs explicitly publish the built-in upgrade path, and Quantex should surface verified upstream self-update metadata when available.
+
+## Risks / Trade-offs
+
+- Upstream may later expand or rename install channels -> Mitigation: start from the documented npm/bun path and keep the agent definition easy to refresh.
+- Adding a lookup alias could conflict with future catalog names -> Mitigation: rely on existing duplicate-identifier tests and keep the alias scoped to the published upstream binary name.

--- a/openspec/changes/add-kilo-code-cli-support/proposal.md
+++ b/openspec/changes/add-kilo-code-cli-support/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Quantex currently does not recognize Kilo Code CLI even though it is a mainstream terminal coding agent with a documented npm package, canonical binary name, and self-update command. Adding first-class support keeps Quantex's agent catalog aligned with the tools users actually install and automate today.
+
+## What Changes
+
+- Add Kilo Code CLI to the Quantex agent catalog with verified package metadata, binary name, homepage, install methods, and self-update command.
+- Make Kilo discoverable through Quantex lifecycle commands such as `install`, `ensure`, `list`, `info`, `inspect`, `resolve`, `exec`, and `update`.
+- Cover the new catalog entry with tests and update user-facing supported-agent documentation where needed.
+- Do not change Quantex release automation, configuration shape, or lifecycle semantics.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: Extend the agent catalog contract so newly supported agents like Kilo Code CLI expose verified install, lookup, and update metadata through the lifecycle surface.
+
+## Impact
+
+- Affected files: `src/agents/**`, relevant tests under `test/**`, and product docs that enumerate supported agents.
+- No new runtime dependencies or release-flow changes.

--- a/openspec/changes/add-kilo-code-cli-support/specs/agent-update/spec.md
+++ b/openspec/changes/add-kilo-code-cli-support/specs/agent-update/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Supported agent catalog entries MUST expose verified lifecycle metadata
+
+The supported agent catalog SHALL expose verified canonical names, lookup aliases, install methods, package metadata, binary names, and self-update commands for each newly supported agent when upstream documentation provides them.
+
+#### Scenario: Adding a newly supported agent with documented install and upgrade paths
+
+- **WHEN** Quantex adds support for a newly documented CLI such as Kilo Code CLI
+- **THEN** the catalog entry includes the verified package name, binary name, canonical homepage, and available install methods
+- **AND** the entry exposes any verified self-update command through lifecycle surfaces such as `info`, `list`, and `update`
+
+#### Scenario: Resolving a supported agent by canonical name or published alias
+
+- **WHEN** a user refers to a supported agent by its canonical Quantex name or a published upstream alias
+- **THEN** Quantex resolves the same catalog entry
+- **AND** lifecycle commands operate on that agent without requiring a separate duplicate definition

--- a/openspec/changes/add-kilo-code-cli-support/tasks.md
+++ b/openspec/changes/add-kilo-code-cli-support/tasks.md
@@ -1,0 +1,14 @@
+## 1. Agent Catalog
+
+- [x] 1.1 Add a Kilo Code CLI agent definition with verified metadata, install methods, and self-update command.
+- [x] 1.2 Register the new agent in the exported agent catalog and support lookup by published alias.
+
+## 2. Coverage And Docs
+
+- [x] 2.1 Update tests to cover the new Kilo catalog entry and supported-agent count expectations.
+- [x] 2.2 Update user-facing supported-agent documentation so it reflects the expanded catalog.
+
+## 3. Validation
+
+- [x] 3.1 Run OpenSpec validation for the new change.
+- [x] 3.2 Run lint, typecheck, and test to verify the new agent support end to end.

--- a/src/agents/definitions/kilo.ts
+++ b/src/agents/definitions/kilo.ts
@@ -1,0 +1,31 @@
+import type { AgentDefinition } from '../types'
+import { bunInstall, npmInstall } from '../methods'
+
+export const kilo: AgentDefinition = {
+  name: 'kilo',
+  lookupAliases: ['kilocode'],
+  displayName: 'Kilo Code CLI',
+  description: 'Kilo 官方 AI 编程助手 CLI',
+  homepage: 'https://kilo.ai/docs/cli',
+  packages: {
+    npm: '@kilocode/cli',
+  },
+  binaryName: 'kilo',
+  selfUpdate: {
+    command: ['kilo', 'upgrade'],
+  },
+  platforms: {
+    windows: [
+      bunInstall(),
+      npmInstall(),
+    ],
+    macos: [
+      bunInstall(),
+      npmInstall(),
+    ],
+    linux: [
+      bunInstall(),
+      npmInstall(),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -5,6 +5,7 @@ import { copilot } from './definitions/copilot'
 import { cursor } from './definitions/cursor'
 import { droid } from './definitions/droid'
 import { gemini } from './definitions/gemini'
+import { kilo } from './definitions/kilo'
 import { opencode } from './definitions/opencode'
 import { pi } from './definitions/pi'
 
@@ -15,6 +16,7 @@ const agents: AgentDefinition[] = [
   cursor,
   droid,
   gemini,
+  kilo,
   opencode,
   pi,
 ]
@@ -31,7 +33,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
   return getAgentByLookupName(name)
 }
 
-export { claude, codex, copilot, cursor, droid, gemini, opencode, pi }
+export { claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi }
 export type {
   AgentDefinition,
   AgentPackageMetadata,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export { agentUpdateProviders, canResolveAgentUpdate, getAgentUpdateFailureHint, getAgentUpdateStrategy, getManualAgentUpdateMessage, resolveAgentUpdateProvider } from './agent-update'
 export type { AgentUpdateContext, AgentUpdateProvider, AgentUpdateStrategy } from './agent-update'
-export { claude, codex, copilot, cursor, droid, gemini, getAgentByLookupName, getAgentByNameOrAlias, getAllAgents, opencode, pi } from './agents'
+export { claude, codex, copilot, cursor, droid, gemini, getAgentByLookupName, getAgentByNameOrAlias, getAllAgents, kilo, opencode, pi } from './agents'
 export type {
   AgentDefinition,
   AgentPackageMetadata,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -7,14 +7,15 @@ import { copilot } from '../src/agents/definitions/copilot'
 import { cursor } from '../src/agents/definitions/cursor'
 import { droid } from '../src/agents/definitions/droid'
 import { gemini } from '../src/agents/definitions/gemini'
+import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
 import { pi } from '../src/agents/definitions/pi'
 import { formatInstallMethodCommand } from '../src/utils/install'
 
 describe('agent registry', () => {
-  it('returns array with at least 8 agents', () => {
+  it('returns array with at least 9 agents', () => {
     const agents = getAllAgents()
-    expect(agents.length).toBeGreaterThanOrEqual(8)
+    expect(agents.length).toBeGreaterThanOrEqual(9)
   })
 
   it('finds agent by name', () => {
@@ -209,6 +210,27 @@ describe('opencode', () => {
     expect(opencode.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'anomalyco/tap/opencode')).toBeDefined()
     expect(opencode.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'anomalyco/tap/opencode')).toBeDefined()
     expect(opencode.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('kilo', () => {
+  it('has valid structure', () => {
+    validateAgent(kilo)
+    expect(kilo.name).toBe('kilo')
+    expect(kilo.lookupAliases).toEqual(['kilocode'])
+    expect(kilo.displayName).toBe('Kilo Code CLI')
+    expect(kilo.packages?.npm).toBe('@kilocode/cli')
+    expect(kilo.binaryName).toBe('kilo')
+    expect(kilo.homepage).toBe('https://kilo.ai/docs/cli')
+    expect(kilo.selfUpdate?.command).toEqual(['kilo', 'upgrade'])
+  })
+
+  it('has only bun/npm methods on all platforms', () => {
+    for (const methods of Object.values(kilo.platforms)) {
+      for (const method of methods!) {
+        expect(['bun', 'npm']).toContain(method.type)
+      }
+    }
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { codex, copilot, createUpdatePlan, cursor, droid, gemini, getAgentByLookupName, getAgentByNameOrAlias, getAllAgents, inspectAgent, opencode, pi } from '../src/index'
+import { codex, copilot, createUpdatePlan, cursor, droid, gemini, getAgentByLookupName, getAgentByNameOrAlias, getAllAgents, inspectAgent, kilo, opencode, pi } from '../src/index'
 
 describe('agent registry', () => {
   it('returns all agents', () => {
     const agents = getAllAgents()
-    expect(agents.length).toBeGreaterThanOrEqual(8)
+    expect(agents.length).toBeGreaterThanOrEqual(9)
   })
 
   it('finds agent by name', () => {
@@ -21,6 +21,11 @@ describe('agent registry', () => {
   it('re-exports lookup-based resolution', () => {
     const agent = getAgentByLookupName('agent')
     expect(agent?.name).toBe('cursor')
+  })
+
+  it('resolves Kilo by published alias', () => {
+    const agent = getAgentByLookupName('kilocode')
+    expect(agent?.name).toBe('kilo')
   })
 })
 
@@ -50,12 +55,21 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('opencode')
   })
 
+  it('kilo has correct structure', () => {
+    const agent = getAgentByNameOrAlias('kilo')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('Kilo Code CLI')
+    expect(agent!.packages?.npm).toBe('@kilocode/cli')
+    expect(agent!.binaryName).toBe('kilo')
+  })
+
   it('re-exports all built-in agents from root index', () => {
     expect(codex.name).toBe('codex')
     expect(copilot.name).toBe('copilot')
     expect(cursor.name).toBe('cursor')
     expect(droid.name).toBe('droid')
     expect(gemini.name).toBe('gemini')
+    expect(kilo.name).toBe('kilo')
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')
   })


### PR DESCRIPTION
## Summary

Add first-class Quantex support for Kilo Code CLI so users can install, ensure, inspect, resolve, update, and run it through the existing lifecycle surface. The new catalog entry uses verified upstream metadata for the npm package, canonical binary, published alias, homepage, and self-update command.

## Linked Artifacts

- Issue: #47
- ADR: N/A
- OpenSpec: `openspec/changes/add-kilo-code-cli-support/`
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [x] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Notes

- Kilo is modeled as a managed npm/Bun agent with `kilo` as the canonical binary and `kilocode` as a lookup alias.
- The user-facing supported-agent lists were updated in both `README.md` and `README.en.md`.

Closes #47
