### PR TITLE
feat(agent-catalog): add Qoder CLI support

### DIFF
--- a/openspec/changes/archive/2026-04-28-add-qoder-cli-support/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-add-qoder-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/archive/2026-04-28-add-qoder-cli-support/design.md
+++ b/openspec/changes/archive/2026-04-28-add-qoder-cli-support/design.md
@@ -1,0 +1,32 @@
+## Context
+
+Quantex's agent catalog is defined as typed `AgentDefinition` entries under `src/agents/definitions/` and exported through `src/agents/index.ts`. Qoder CLI is lifecycle-compatible with this model because its official documentation exposes stable install, version, launch, and update commands.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Register Qoder CLI as a first-class supported agent.
+- Preserve the existing agent catalog structure and lookup behavior.
+- Cover the new entry with tests that validate metadata and install method shape.
+
+**Non-Goals:**
+
+- Do not add Qoder-specific workflow orchestration, command automation, or subagent behavior.
+- Do not introduce a new package-manager provider.
+- Do not change global CLI rendering or structured output schemas beyond the existing catalog item.
+
+## Decisions
+
+- Use canonical name `qoder` with display name `Qoder CLI`.
+- Use binary name `qodercli`, matching official launch and version examples.
+- Use npm package `@qoder-ai/qodercli` for Bun and npm managed installs.
+- Include Homebrew as a cask install for macOS and Linux with package name `qoderai/qoder/qodercli`, matching the official tap/cask command.
+- Include the official curl installer as a script fallback on macOS and Linux.
+- Use `qodercli update` as the self-update command because official documentation lists it as the built-in update feature.
+
+## Risks / Trade-offs
+
+- Qoder's Homebrew package is installed with `--cask`, including on Linux per official docs; this depends on Homebrew cask support in the user's environment.
+- The curl installer is macOS/Linux only, so Windows relies on managed npm/Bun installation.
+- Qoder's automatic updates may already be enabled by default, but Quantex still records explicit update metadata for stable lifecycle planning.

--- a/openspec/changes/archive/2026-04-28-add-qoder-cli-support/proposal.md
+++ b/openspec/changes/archive/2026-04-28-add-qoder-cli-support/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Qoder CLI is another mainstream AI coding assistant that users may want to manage through Quantex's lifecycle commands. Adding it to the catalog lets users install, inspect, ensure, update, uninstall, resolve, and shortcut-launch Qoder with the same stable Quantex contract as existing agents.
+
+## What Changes
+
+- Add Qoder CLI as a supported agent catalog entry.
+- Expose Qoder through existing lookup, list, info, inspect, resolve, ensure, install, update, uninstall, and shortcut execution surfaces.
+- Include Qoder's lifecycle metadata: canonical name, display name, homepage, npm package, binary name, supported install methods, and self-update command.
+- Add tests covering the new catalog entry and registry export.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-catalog`: the supported agent catalog includes Qoder CLI as a lifecycle-managed agent.
+
+## Impact
+
+- Affected code: `src/agents/definitions/`, `src/agents/index.ts`, and agent registry tests.
+- Affected contracts: supported agent catalog output and any CLI command that enumerates or resolves supported agents.
+- Dependencies: no new runtime dependency.

--- a/openspec/changes/archive/2026-04-28-add-qoder-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/archive/2026-04-28-add-qoder-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Qoder CLI MUST be a supported lifecycle agent
+Quantex SHALL include Qoder CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Qoder CLI
+- **WHEN** a user or machine consumer looks up the canonical agent name `qoder`
+- **THEN** Quantex returns a supported agent entry for Qoder CLI
+- **AND** the entry identifies `qodercli` as the executable binary
+- **AND** the entry identifies `@qoder-ai/qodercli` as its npm package metadata
+
+#### Scenario: Installing Qoder CLI through supported methods
+- **WHEN** Quantex renders or executes install options for Qoder CLI
+- **THEN** the catalog includes npm-compatible managed install methods
+- **AND** macOS and Linux include the official Homebrew cask and curl installer options
+- **AND** Windows includes npm-compatible managed install methods
+
+#### Scenario: Planning Qoder CLI updates
+- **WHEN** Quantex plans an update for a Qoder CLI installation that supports self-update
+- **THEN** the catalog exposes `qodercli update` as the agent self-update command

--- a/openspec/changes/archive/2026-04-28-add-qoder-cli-support/tasks.md
+++ b/openspec/changes/archive/2026-04-28-add-qoder-cli-support/tasks.md
@@ -1,0 +1,14 @@
+## 1. Catalog
+
+- [x] 1.1 Add a Qoder CLI agent definition with lifecycle metadata and install methods.
+- [x] 1.2 Register and export Qoder CLI through the agent registry.
+
+## 2. Tests
+
+- [x] 2.1 Add registry tests for Qoder CLI metadata, install methods, and update command.
+- [x] 2.2 Run agent-focused tests.
+
+## 3. Validation
+
+- [x] 3.1 Run OpenSpec validation.
+- [x] 3.2 Run lint and typecheck.

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -24,3 +24,26 @@ Quantex lifecycle inspection surfaces SHALL expose stable agent identifiers and 
 - **WHEN** Quantex returns human-readable or structured agent metadata
 - **THEN** the result includes the identifiers and lifecycle fields needed to install, inspect, or update the agent
 - **AND** the result does not depend on a free-form `description` field to remain valid
+
+### Requirement: Qoder CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Qoder CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Qoder CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `qoder`
+- **THEN** Quantex returns a supported agent entry for Qoder CLI
+- **AND** the entry identifies `qodercli` as the executable binary
+- **AND** the entry identifies `@qoder-ai/qodercli` as its npm package metadata
+
+#### Scenario: Installing Qoder CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Qoder CLI
+- **THEN** the catalog includes npm-compatible managed install methods
+- **AND** macOS and Linux include the official Homebrew cask and curl installer options
+- **AND** Windows includes npm-compatible managed install methods
+
+#### Scenario: Planning Qoder CLI updates
+
+- **WHEN** Quantex plans an update for a Qoder CLI installation that supports self-update
+- **THEN** the catalog exposes `qodercli update` as the agent self-update command

--- a/src/agents/definitions/qoder.ts
+++ b/src/agents/definitions/qoder.ts
@@ -1,0 +1,33 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, bunInstall, npmInstall, scriptInstall } from '../methods'
+
+export const qoder: AgentDefinition = {
+  name: 'qoder',
+  displayName: 'Qoder CLI',
+  homepage: 'https://docs.qoder.com/cli/quick-start',
+  packages: {
+    npm: '@qoder-ai/qodercli',
+  },
+  binaryName: 'qodercli',
+  selfUpdate: {
+    command: ['qodercli', 'update'],
+  },
+  platforms: {
+    windows: [
+      bunInstall(),
+      npmInstall(),
+    ],
+    macos: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://qoder.com/install | bash'),
+      brewInstall('qoderai/qoder/qodercli', 'cask'),
+    ],
+    linux: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://qoder.com/install | bash'),
+      brewInstall('qoderai/qoder/qodercli', 'cask'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -8,6 +8,7 @@ import { gemini } from './definitions/gemini'
 import { kilo } from './definitions/kilo'
 import { opencode } from './definitions/opencode'
 import { pi } from './definitions/pi'
+import { qoder } from './definitions/qoder'
 
 const agents: AgentDefinition[] = [
   claude,
@@ -19,6 +20,7 @@ const agents: AgentDefinition[] = [
   kilo,
   opencode,
   pi,
+  qoder,
 ]
 
 export function getAllAgents(): AgentDefinition[] {
@@ -33,7 +35,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
   return getAgentByLookupName(name)
 }
 
-export { claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi }
+export { claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi, qoder }
 export type {
   AgentDefinition,
   AgentPackageMetadata,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -10,12 +10,13 @@ import { gemini } from '../src/agents/definitions/gemini'
 import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
 import { pi } from '../src/agents/definitions/pi'
+import { qoder } from '../src/agents/definitions/qoder'
 import { formatInstallMethodCommand } from '../src/utils/install'
 
 describe('agent registry', () => {
-  it('returns array with at least 9 agents', () => {
+  it('returns array with at least 10 agents', () => {
     const agents = getAllAgents()
-    expect(agents.length).toBeGreaterThanOrEqual(9)
+    expect(agents.length).toBeGreaterThanOrEqual(10)
   })
 
   it('finds agent by name', () => {
@@ -249,6 +250,34 @@ describe('pi', () => {
         expect(['bun', 'npm']).toContain(method.type)
       }
     }
+  })
+})
+
+describe('qoder', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('qoder')).toBe(qoder)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(qoder)
+    expect(qoder.name).toBe('qoder')
+    expect(qoder.displayName).toBe('Qoder CLI')
+    expect(qoder.packages?.npm).toBe('@qoder-ai/qodercli')
+    expect(qoder.binaryName).toBe('qodercli')
+    expect(qoder.homepage).toBe('https://docs.qoder.com/cli/quick-start')
+    expect(qoder.selfUpdate?.command).toEqual(['qodercli', 'update'])
+  })
+
+  it('curl install returns correct strings per platform', () => {
+    expect(qoder.platforms.macos!.find(m => m.type === 'script' && m.command.includes('qoder.com/install'))).toBeDefined()
+    expect(qoder.platforms.linux!.find(m => m.type === 'script' && m.command.includes('qoder.com/install'))).toBeDefined()
+    expect(qoder.platforms.windows!.find(m => m.type === 'script')).toBeUndefined()
+  })
+
+  it('brew install returns correct strings per platform', () => {
+    expect(qoder.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'qoderai/qoder/qodercli' && m.packageTargetKind === 'cask')).toBeDefined()
+    expect(qoder.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'qoderai/qoder/qodercli' && m.packageTargetKind === 'cask')).toBeDefined()
+    expect(qoder.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary
- Add Qoder CLI to the supported agent catalog with npm/Bun, Homebrew cask, curl installer, binary, and self-update metadata.
- Register and export Qoder through the existing agent registry.
- Sync and archive the OpenSpec change for the agent-catalog contract.

## Linked Artifacts
- OpenSpec: add-qoder-cli-support

## Validation
- bun run openspec:validate
- bun run memory:check
- bun run lint
- bun run typecheck
- bun run test

## Docs Updated
- OpenSpec agent-catalog spec updated and archived with this PR.
- No separate user-facing README change is needed for this catalog addition.

## Scope Check
- Product behavior: adds Qoder as a supported agent catalog entry.
- Release scope: feature release is expected from the merge-to-main release workflow.
- Workflow scope: no workflow/process rule changes are included.

## Closure Check
- OpenSpec: add-qoder-cli-support
- Delivery state: PR delivery pending merge; archive artifacts are included in this PR because the change predates the archive follow-up PR flow.
- Post-merge check: verify main CI, Release workflow, OpenSpec active changes, and branch cleanup.
