### PR TITLE
ci(release): skip release-please for non-release pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,35 @@ jobs:
             echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Detect release relevance
+        id: release-scope
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          run_release=false
+
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            run_release=true
+          else
+            message="$HEAD_COMMIT_MESSAGE"
+            first_line="${message%%$'\n'*}"
+
+            if [[ "$first_line" =~ ^(feat|fix|perf)(\(.+\))?!?: ]]; then
+              run_release=true
+            elif [[ "$first_line" =~ ^[a-z]+(\(.+\))?!: ]]; then
+              run_release=true
+            elif [[ "$first_line" =~ ^chore:\ release ]]; then
+              run_release=true
+            elif grep -q '^BREAKING CHANGE:' <<< "$message"; then
+              run_release=true
+            fi
+          fi
+
+          echo "run_release=$run_release" >> "$GITHUB_OUTPUT"
+
       - name: Create release bot token
         id: release-bot-token
+        if: ${{ steps.release-scope.outputs.run_release == 'true' }}
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
@@ -41,6 +68,7 @@ jobs:
 
       - name: Release Please
         id: release
+        if: ${{ steps.release-scope.outputs.run_release == 'true' }}
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.release-bot-token.outputs.token }}

--- a/openspec/changes/skip-release-please-for-nonrelease-pushes/.openspec.yaml
+++ b/openspec/changes/skip-release-please-for-nonrelease-pushes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-27

--- a/openspec/changes/skip-release-please-for-nonrelease-pushes/design.md
+++ b/openspec/changes/skip-release-please-for-nonrelease-pushes/design.md
@@ -1,0 +1,33 @@
+## Context
+
+The Release workflow currently runs release-please on every push to `main` and `beta`. release-please normally decides whether a release is needed, but it can still fail before reaching a no-op result because it must query GitHub release and commit history.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Avoid release-please API calls for pushes that cannot produce a release.
+- Preserve normal stable and beta release behavior for release-worthy commits and release PR merges.
+- Keep manual dispatch as an escape hatch that always runs release-please.
+
+**Non-Goals:**
+
+- Replace release-please.
+- Change versioning, trusted publishing, artifacts, or release PR automation.
+- Infer releases from changed file paths.
+
+## Decisions
+
+- Gate release-please on commit metadata rather than changed files.
+  Rationale: release-please itself is conventional-commit driven, and PR Governance already protects docs/process-only PRs from release-worthy metadata.
+- Treat `chore: release ...` as release-relevant.
+  Rationale: release PR merges use chore release commits and must still create tags/releases.
+- Keep all build/publish steps behind `release_created`.
+  Rationale: the relevance gate only decides whether release-please should run; release-please remains the source of truth for whether a release was created.
+
+## Risks / Trade-offs
+
+- Risk: a malformed release-worthy commit title could skip release-please.
+  Mitigation: keep PR Governance responsible for commit metadata and allow manual dispatch to force release-please.
+- Risk: multi-commit direct pushes may need broader detection.
+  Mitigation: protected branches normally receive squash merges; manual dispatch remains available for exceptional recovery.

--- a/openspec/changes/skip-release-please-for-nonrelease-pushes/proposal.md
+++ b/openspec/changes/skip-release-please-for-nonrelease-pushes/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+After a docs/process-only merge, the `Release` workflow still invoked release-please and failed on a GitHub GraphQL query even though no release was possible. Non-release pushes should exit successfully before release-please so process-only merges do not leave main red.
+
+Work-intake classification: this changes release workflow behavior, so OpenSpec is required before implementation.
+
+## What Changes
+
+- Add a release relevance check before creating the release bot token or running release-please.
+- Run release-please only for manual dispatch, release PR merges, release-worthy conventional commit messages, or explicit breaking-change metadata.
+- Treat docs/process/archive-only pushes as successful no-release runs.
+- Keep release artifact build and publish steps gated on `release_created`.
+
+## Capabilities
+
+### New Capabilities
+
+- `release-workflow`: Defines when the Release workflow should invoke release-please and publishing steps.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected files: `.github/workflows/release.yml` and OpenSpec artifacts.
+- No runtime CLI behavior or package dependency changes.

--- a/openspec/changes/skip-release-please-for-nonrelease-pushes/specs/release-workflow/spec.md
+++ b/openspec/changes/skip-release-please-for-nonrelease-pushes/specs/release-workflow/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Release Workflow Skips Non-release Pushes
+
+The Release workflow SHALL skip release-please for pushes that cannot create a release.
+
+#### Scenario: Documentation-only push reaches main
+
+- **GIVEN** a push to a release branch has a non-release conventional commit such as documentation, workflow, or OpenSpec archive maintenance
+- **WHEN** the Release workflow runs
+- **THEN** it MUST complete successfully without invoking release-please
+- **AND** it MUST skip release artifact, publish, and upload steps
+
+#### Scenario: Release-worthy push reaches main
+
+- **GIVEN** a push to a release branch has release-worthy conventional commit metadata, breaking-change metadata, or a release PR merge commit
+- **WHEN** the Release workflow runs
+- **THEN** it MUST invoke release-please
+- **AND** downstream build, publish, and artifact upload steps MUST still depend on release-please reporting `release_created`
+
+#### Scenario: Manual release workflow dispatch
+
+- **GIVEN** a maintainer manually dispatches the Release workflow
+- **WHEN** the workflow starts
+- **THEN** it MUST invoke release-please regardless of the latest commit metadata

--- a/openspec/changes/skip-release-please-for-nonrelease-pushes/tasks.md
+++ b/openspec/changes/skip-release-please-for-nonrelease-pushes/tasks.md
@@ -1,0 +1,11 @@
+## 1. Workflow
+
+- [x] 1.1 Add release relevance detection to `.github/workflows/release.yml`.
+- [x] 1.2 Gate release bot token creation and release-please execution on that relevance result.
+- [x] 1.3 Keep release artifact, publish, and upload steps gated on `release_created`.
+
+## 2. Validation And Delivery
+
+- [x] 2.1 Run OpenSpec validation.
+- [x] 2.2 Run project memory, lint, typecheck, and test checks.
+- [x] 2.3 Record that delivery reports must state merge, release, and archive closure state explicitly.


### PR DESCRIPTION
## Summary

Skip release-please for push events that cannot create a release, so docs/process/archive-only merges do not leave `main` red because release-please queried GitHub for a no-op release.

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: `openspec/changes/skip-release-please-for-nonrelease-pushes/`
- Discussion: current Codex workflow closure review thread

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [x] `bun run openspec:validate`
- [ ] Not run, explained below

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge; archive closure should be handled by post-merge archive automation.
- [x] Release is delegated to this PR's workflow change and will be verified after merge.

## Notes

This is a release workflow reliability fix. It should not create a product release.