### PR TITLE
ci(release): split release-please phases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,13 +38,17 @@ jobs:
           HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
           run_release=false
+          is_release_commit=false
+          message="$HEAD_COMMIT_MESSAGE"
+          first_line="${message%%$'\n'*}"
+
+          if [[ "$first_line" =~ ^chore:\ release ]]; then
+            is_release_commit=true
+          fi
 
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             run_release=true
           else
-            message="$HEAD_COMMIT_MESSAGE"
-            first_line="${message%%$'\n'*}"
-
             if [[ "$first_line" =~ ^(feat|fix|perf)(\(.+\))?!?: ]]; then
               run_release=true
             elif [[ "$first_line" =~ ^[a-z]+(\(.+\))?!: ]]; then
@@ -57,6 +61,7 @@ jobs:
           fi
 
           echo "run_release=$run_release" >> "$GITHUB_OUTPUT"
+          echo "is_release_commit=$is_release_commit" >> "$GITHUB_OUTPUT"
 
       - name: Create release bot token
         id: release-bot-token
@@ -66,15 +71,27 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - name: Release Please
-        id: release
-        if: ${{ steps.release-scope.outputs.run_release == 'true' }}
+      - name: Release Please PR
+        id: release-pr
+        if: ${{ steps.release-scope.outputs.run_release == 'true' && steps.release-scope.outputs.is_release_commit != 'true' }}
         uses: googleapis/release-please-action@v4.1.5
         with:
           token: ${{ steps.release-bot-token.outputs.token }}
           target-branch: ${{ github.ref_name }}
           config-file: ${{ steps.channel.outputs.config_file }}
           manifest-file: .release-please-manifest.json
+          skip-github-release: true
+
+      - name: Release Please GitHub Release
+        id: release
+        if: ${{ steps.release-scope.outputs.is_release_commit == 'true' }}
+        uses: googleapis/release-please-action@v4.1.5
+        with:
+          token: ${{ steps.release-bot-token.outputs.token }}
+          target-branch: ${{ github.ref_name }}
+          config-file: ${{ steps.channel.outputs.config_file }}
+          manifest-file: .release-please-manifest.json
+          skip-github-pull-request: true
 
       - name: Checkout released source
         if: ${{ steps.release.outputs.release_created }}

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -86,6 +86,8 @@ The stable release-please config currently includes a temporary `last-release-sh
 
 The Release workflow pins `googleapis/release-please-action` to a repository-verified tag instead of floating on the major `v4` tag. Before changing that pin, run a dry run against the repository and confirm it can prepare the expected Release PR without GitHub GraphQL errors.
 
+Release PR creation and GitHub Release creation run as separate release-please phases. Product merges use Release PR mode, while `chore: release ...` merges use GitHub Release mode and then continue into build, npm trusted publishing, and artifact upload.
+
 ## npm trusted publishing
 
 Quantex publishes to npm through GitHub Actions trusted publishing with OIDC. The release workflow must keep `id-token: write` enabled and use a Node/npm version that supports trusted publishing.

--- a/openspec/changes/pin-release-please-action/design.md
+++ b/openspec/changes/pin-release-please-action/design.md
@@ -2,18 +2,23 @@
 
 ## Decision
 
-Use an explicit `googleapis/release-please-action@v4.1.5` tag in the Release workflow.
+Use an explicit `googleapis/release-please-action@v4.1.5` tag in the Release workflow, and run release-please in separate phases:
+
+- Release-relevant product merges run the Release PR phase with `skip-github-release: true`.
+- Release PR merges run the GitHub Release phase with `skip-github-pull-request: true`.
 
 ## Rationale
 
 The `@v4` major tag floated to release-please 17.3.0 in the GitHub Action runtime. That version fails on this repository when querying commit history with nested associated pull requests through GitHub GraphQL. A local dry run with the same repository and token reproduced the failure.
 
-The `release-please@16.18.0` dry run completed successfully and produced the expected `0.4.0` Release PR plan. The corresponding action tag is `googleapis/release-please-action@v4.1.5`, so pinning the action restores deterministic release behavior while keeping the release-please Release PR model.
+The `release-please@16.18.0 release-pr` dry run completed successfully and produced the expected `0.4.0` Release PR plan. The corresponding action tag is `googleapis/release-please-action@v4.1.5`.
+
+However, the GitHub Action's default mode runs both release and pull-request logic in one invocation, and that path still hits the GraphQL failure. Splitting the workflow into explicit phases makes the Action follow the same successful `release-pr` path for feature merges and reserves GitHub Release creation for `chore: release ...` commits.
 
 ## Alternatives Considered
 
 - Keep `@v4` and retry failed runs: rejected because repeated retries and local reproduction showed the failure is deterministic for the current latest package.
-- Replace release-please immediately: rejected because the current flow is otherwise aligned with source-visible version PRs, and a smaller pinned-version fix is enough to unblock release closure.
+- Replace release-please immediately: rejected because the current flow is otherwise aligned with source-visible version PRs, and a smaller phased release-please fix should unblock release closure.
 - Build a custom Release PR generator: rejected because it would reintroduce bespoke release automation without first exhausting the standard tool path.
 
 ## Follow-up

--- a/openspec/changes/pin-release-please-action/proposal.md
+++ b/openspec/changes/pin-release-please-action/proposal.md
@@ -9,10 +9,12 @@ The release workflow should use a deterministic release-please action version th
 ## What Changes
 
 - Pin the Release workflow to `googleapis/release-please-action@v4.1.5`, which bundles release-please 16.18.0.
+- Split release-please execution into a Release PR phase and a GitHub Release phase.
 - Update stable and beta Release PR headers to include the required closure section.
 - Document that the Release workflow should not float release-please action versions without verification.
 
 ## Impact
 
 - Release PR creation should recover for the Qoder catalog feature merged in PR #55.
+- Release PR merges should continue to publish through the existing build, npm trusted publishing, and artifact upload path.
 - Generated Release PRs should satisfy PR Governance without manual body edits.

--- a/openspec/changes/pin-release-please-action/specs/release-workflow/spec.md
+++ b/openspec/changes/pin-release-please-action/specs/release-workflow/spec.md
@@ -13,8 +13,15 @@ The Release workflow SHALL skip release-please for pushes that cannot create a r
 #### Scenario: release-worthy merge reaches main
 
 - **WHEN** a push to `main` has a release-worthy conventional commit title such as `feat:`, `fix:`, or `perf:`
-- **THEN** the Release workflow MUST invoke release-please
+- **THEN** the Release workflow MUST invoke release-please in Release PR mode
 - **AND** the release-please action version MUST be pinned to a repository-verified tag
+- **AND** it MUST skip GitHub Release creation in that invocation
+
+#### Scenario: Release PR merge reaches main
+
+- **WHEN** a push to `main` has a Release PR commit title such as `chore: release 0.4.0`
+- **THEN** the Release workflow MUST invoke release-please in GitHub Release mode
+- **AND** it MUST skip Release PR creation in that invocation
 - **AND** downstream build, publish, and artifact upload steps MUST still depend on release-please reporting `release_created`
 
 #### Scenario: manual release dispatch
@@ -22,6 +29,8 @@ The Release workflow SHALL skip release-please for pushes that cannot create a r
 - **WHEN** the Release workflow is started by `workflow_dispatch`
 - **THEN** it MUST invoke release-please regardless of the latest commit metadata
 - **AND** the release-please action version MUST be pinned to a repository-verified tag
+- **AND** it MUST use GitHub Release mode when the current commit is a Release PR commit
+- **AND** it MUST use Release PR mode otherwise
 
 ### Requirement: Generated Release PRs satisfy governance sections
 

--- a/openspec/changes/pin-release-please-action/tasks.md
+++ b/openspec/changes/pin-release-please-action/tasks.md
@@ -1,6 +1,7 @@
 # Tasks
 
 - [x] Pin the Release workflow to the verified release-please action tag.
+- [x] Split release-please into Release PR and GitHub Release phases.
 - [x] Add Closure Check sections to generated stable and beta Release PR headers.
 - [x] Document the verified action pin in the release runbook.
 - [x] Validate OpenSpec, project memory, lint, typecheck, and tests.


### PR DESCRIPTION
## Summary
- Split release-please into explicit Release PR and GitHub Release phases.
- Keep the verified release-please action pin from the previous fix.
- Update the active OpenSpec change and release runbook with the phased release model.

## Linked Artifacts
- OpenSpec: pin-release-please-action
- Failed workflow_dispatch: https://github.com/Drswith/quantex-cli/actions/runs/25011299682

## Validation
- bun run openspec:validate
- bun run memory:check
- bun run lint
- bun run typecheck
- bun run test
- git diff --check

## Docs Updated
- docs/runbooks/releasing-quantex.md
- openspec/changes/pin-release-please-action

## Scope Check
- Release workflow and release documentation only.
- This PR uses `ci:` so it should not create a product Release PR by itself.

## Closure Check
- OpenSpec: pin-release-please-action
- Delivery state: PR delivery pending merge.
- Post-merge check: verify this process-only merge skips product release, then dispatch Release to create the Qoder 0.4.0 Release PR.
