### PR TITLE
docs(openspec): complete release fix validation

### DIFF
--- a/openspec/changes/pin-release-please-action/tasks.md
+++ b/openspec/changes/pin-release-please-action/tasks.md
@@ -5,4 +5,4 @@
 - [x] Add Closure Check sections to generated stable and beta Release PR headers.
 - [x] Document the verified action pin in the release runbook.
 - [x] Validate OpenSpec, project memory, lint, typecheck, and tests.
-- [ ] Merge the workflow fix and verify the Qoder release path resumes.
+- [x] Merge the workflow fix and verify the Qoder release path resumes.


### PR DESCRIPTION
## Summary
- Mark the release workflow fix validation task complete after v0.4.0 was published.

## Linked Artifacts
- OpenSpec: pin-release-please-action
- Release: https://github.com/Drswith/quantex-cli/releases/tag/v0.4.0
- npm: quantex-cli@0.4.0

## Validation
- bun run openspec:validate
- bun run memory:check
- git diff --check

## Docs Updated
- openspec/changes/pin-release-please-action/tasks.md

## Scope Check
- OpenSpec task state only.
- This PR should not trigger product release.

## Closure Check
- OpenSpec: pin-release-please-action
- Delivery state: archive follow-up should be created after merge.
