### PR TITLE
ci: enforce release intent for product changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,13 @@ Describe the change and why it exists.
 - [ ] `bun run test` (if behavior changed)
 - [ ] Not run, explained below
 
+## Release Intent
+
+- Release: not applicable - docs/process/test-only change
+- Release: patch - bug fix
+- Release: minor - user-facing feature
+- Release: major - breaking change
+
 ## Docs Updated
 
 - [ ] Not needed

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -25,6 +25,7 @@ jobs:
               '## Summary',
               '## Linked Artifacts',
               '## Validation',
+              '## Release Intent',
               '## Docs Updated',
               '## Scope Check',
               '## Closure Check',
@@ -111,3 +112,71 @@ jobs:
                 `Changed files: ${changedFiles.join(', ')}`,
               ].join('\n'))
             }
+
+      - name: Validate product release intent
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request
+            const title = pullRequest.title || ''
+            const body = pullRequest.body || ''
+            const headBranch = pullRequest.head.ref || ''
+
+            if (headBranch.startsWith('release-please--branches--'))
+              return
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            })
+
+            const changedFiles = files.map(file => file.filename)
+            const productImpactingFiles = changedFiles.filter(fileName => {
+              return fileName.startsWith('src/')
+                || fileName.startsWith('skills/quantex-cli/')
+                || fileName.startsWith('scripts/')
+                || fileName === 'package.json'
+                || fileName === 'bun.lock'
+                || fileName === 'install.sh'
+                || fileName === 'install.ps1'
+                || fileName === 'tsdown.config.ts'
+            })
+
+            if (productImpactingFiles.length === 0)
+              return
+
+            const releaseWorthyTitle = /^(feat|fix|perf)(\(.+\))?!?:/.test(title)
+              || /^[a-z]+(\(.+\))?!:/.test(title)
+            const releaseWorthyBody = /\nBREAKING CHANGE:/.test(`\n${body}`)
+
+            if (releaseWorthyTitle || releaseWorthyBody)
+              return
+
+            const releaseIntentMatch = body.match(/## Release Intent\s*([\s\S]*?)\n## /)
+              ?? body.match(/## Release Intent\s*([\s\S]*)$/)
+            const releaseIntent = releaseIntentMatch ? releaseIntentMatch[1].trim() : ''
+
+            const notApplicableMatch = releaseIntent.match(/release\s*:\s*not applicable\s*[-:]\s*(.+)/i)
+            const reason = notApplicableMatch ? notApplicableMatch[1].trim() : ''
+            const normalizedReason = reason.toLowerCase()
+            const placeholderReasons = new Set([
+              '',
+              'n/a',
+              'none',
+              'not applicable',
+              'tbd',
+              '(none)',
+            ])
+
+            if (notApplicableMatch && !placeholderReasons.has(normalizedReason))
+              return
+
+            core.setFailed([
+              'Product-impacting PRs must not silently skip release automation.',
+              'Use a release-worthy PR title such as feat:, fix:, perf:, or type!: when the change should release.',
+              'If no release is needed, add a meaningful line under "## Release Intent":',
+              'Release: not applicable - <reason>',
+              `Product-impacting files: ${productImpactingFiles.join(', ')}`,
+            ].join('\n'))

--- a/openspec/changes/enforce-release-intent/.openspec.yaml
+++ b/openspec/changes/enforce-release-intent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/enforce-release-intent/design.md
+++ b/openspec/changes/enforce-release-intent/design.md
@@ -1,0 +1,33 @@
+## Context
+
+Release automation is intentionally driven by the final commit metadata that lands on `main` or `beta`. Because PRs are squash-merged, the PR title is effectively the release trigger unless the merge subject is overridden.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Catch product-impacting PRs whose title would not trigger release automation.
+- Preserve an explicit escape hatch for product-adjacent changes that are not release-worthy.
+- Keep Release PR automation compatible with PR Governance.
+
+**Non-Goals:**
+
+- Change release-please versioning rules.
+- Infer exact SemVer level from file paths.
+- Block docs/process-only changes from using non-release metadata.
+
+## Decisions
+
+- Use changed-file paths to detect product-impacting PRs.
+  - Alternative considered: inspect source diffs semantically. Rejected because it is brittle and harder to maintain in GitHub Actions.
+- Require an explicit `## Release Intent` section in all PR bodies.
+  - Alternative considered: infer intent from `Scope Check`. Rejected because release intent is important enough to deserve a dedicated, searchable section.
+- Allow `Release: not applicable - <reason>` as an override for product-impacting non-release PRs.
+  - Alternative considered: require release-worthy titles for every product-impacting file. Rejected because some product-path edits can be test-only, refactors with no shipped behavior, or release-maintenance work.
+- Skip the product-impacting release-intent check for release-please branches.
+  - Alternative considered: force Release PRs through the same check. Rejected because Release PRs have their own dedicated scope validator.
+
+## Risks / Trade-offs
+
+- File-path detection may be conservative -> Mitigation: provide an explicit not-applicable escape hatch with a reason.
+- Contributors may write vague no-release reasons -> Mitigation: reject empty or placeholder no-release values.

--- a/openspec/changes/enforce-release-intent/proposal.md
+++ b/openspec/changes/enforce-release-intent/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The current governance prevents documentation-only PRs from accidentally using release-worthy metadata, but it does not prevent product-impacting PRs from being squash-merged with `docs:` or `chore:` and silently skipping release automation.
+
+## What Changes
+
+- Add a release-intent gate to PR Governance for product-impacting files.
+- Require PR bodies to include a `## Release Intent` section.
+- Allow product-impacting PRs to either use release-worthy conventional metadata or explicitly state that release is not applicable with a reason.
+- Keep release-please generated Release PRs compatible with the updated PR body requirements.
+- Do not change release-please version calculation or publish behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `release-governance`: Defines PR-level release intent checks that reduce accidental release skips.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected files: `.github/workflows/pr-governance.yml`, `.github/pull_request_template.md`, `release-please-config.json`, `release-please-config.beta.json`, `openspec/changes/enforce-release-intent/*`.
+- No CLI runtime behavior, dependency, package artifact, or publish-step change.

--- a/openspec/changes/enforce-release-intent/specs/release-governance/spec.md
+++ b/openspec/changes/enforce-release-intent/specs/release-governance/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: PRs Must Declare Release Intent
+
+Every pull request SHALL include a dedicated release-intent section in its body.
+
+#### Scenario: PR body is validated
+
+- **WHEN** PR Governance validates a pull request body
+- **THEN** it requires a `## Release Intent` section alongside the standard summary, artifacts, validation, docs, scope, and closure sections.
+
+### Requirement: Product-Impacting PRs Must Not Silently Skip Release
+
+PR Governance SHALL reject product-impacting pull requests whose title is not release-worthy unless the PR explicitly declares that release is not applicable with a non-placeholder reason.
+
+#### Scenario: Product-impacting PR has release-worthy title
+
+- **WHEN** a pull request changes product-impacting files
+- **AND** its title uses release-worthy conventional metadata such as `feat:`, `fix:`, `perf:`, `type!:` or a breaking-change footer
+- **THEN** PR Governance allows the release intent check to pass.
+
+#### Scenario: Product-impacting PR has explicit no-release reason
+
+- **WHEN** a pull request changes product-impacting files
+- **AND** its title is not release-worthy
+- **AND** its release-intent section says release is not applicable with a meaningful reason
+- **THEN** PR Governance allows the release intent check to pass.
+
+#### Scenario: Product-impacting PR has non-release title and no reason
+
+- **WHEN** a pull request changes product-impacting files
+- **AND** its title is not release-worthy
+- **AND** its release-intent section is missing, empty, or only says a placeholder such as `n/a`
+- **THEN** PR Governance fails with guidance to use release-worthy metadata or provide a reason.
+
+### Requirement: Release PRs Keep Dedicated Validation
+
+Release-please generated Release PRs SHALL remain governed by the dedicated Release PR validator instead of the product-impacting release-intent check.
+
+#### Scenario: Release-please PR opens
+
+- **WHEN** a pull request comes from a release-please branch
+- **THEN** PR Governance does not require product-impacting release intent for the version-file changes
+- **AND** Release PR Automerge validates the release branch, title, generated marker, and changed file scope.

--- a/openspec/changes/enforce-release-intent/tasks.md
+++ b/openspec/changes/enforce-release-intent/tasks.md
@@ -1,0 +1,15 @@
+## 1. Governance
+
+- [x] 1.1 Add a required `## Release Intent` section to PR body validation.
+- [x] 1.2 Add product-impacting file detection and release-intent enforcement to PR Governance.
+- [x] 1.3 Keep release-please PRs compatible with the updated governance.
+
+## 2. Documentation
+
+- [x] 2.1 Update the PR template with release-intent guidance.
+- [x] 2.2 Update release-please PR headers to include release intent.
+
+## 3. Validation
+
+- [x] 3.1 Run OpenSpec validation.
+- [x] 3.2 Run project memory, lint, typecheck, and tests.

--- a/release-please-config.beta.json
+++ b/release-please-config.beta.json
@@ -14,7 +14,7 @@
         "src/generated/build-meta.ts"
       ],
       "pull-request-title-pattern": "chore: release ${version}",
-      "pull-request-header": "## Summary\n- materialize the next Quantex beta release version in source-controlled files\n- update the repository changelog for the pending beta release\n\n## Linked Artifacts\n- Release automation: release-please beta channel\n\n## Validation\n- CI must pass before merging this beta Release PR\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Beta Release PR only; merge this PR to publish the prepared beta version\n\n## Closure Check\n- OpenSpec: release-workflow\n- Delivery state: Beta Release PR pending merge and publication\n"
+      "pull-request-header": "## Summary\n- materialize the next Quantex beta release version in source-controlled files\n- update the repository changelog for the pending beta release\n\n## Linked Artifacts\n- Release automation: release-please beta channel\n\n## Validation\n- CI must pass before merging this beta Release PR\n\n## Release Intent\n- Release: beta - release-please generated prerelease version PR\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Beta Release PR only; merge this PR to publish the prepared beta version\n\n## Closure Check\n- OpenSpec: release-workflow\n- Delivery state: Beta Release PR pending merge and publication\n"
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,7 @@
         "src/generated/build-meta.ts"
       ],
       "pull-request-title-pattern": "chore: release ${version}",
-      "pull-request-header": "## Summary\n- materialize the next Quantex release version in source-controlled files\n- update the repository changelog for the pending release\n\n## Linked Artifacts\n- Release automation: release-please\n\n## Validation\n- CI must pass before merging this Release PR\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Release PR only; merge this PR to publish the prepared version\n\n## Closure Check\n- OpenSpec: release-workflow\n- Delivery state: Release PR pending merge and publication\n"
+      "pull-request-header": "## Summary\n- materialize the next Quantex release version in source-controlled files\n- update the repository changelog for the pending release\n\n## Linked Artifacts\n- Release automation: release-please\n\n## Validation\n- CI must pass before merging this Release PR\n\n## Release Intent\n- Release: patch/minor/major - release-please generated version PR\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Release PR only; merge this PR to publish the prepared version\n\n## Closure Check\n- OpenSpec: release-workflow\n- Delivery state: Release PR pending merge and publication\n"
     }
   }
 }

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml', 'utf8')
+const prTemplate = readFileSync('.github/pull_request_template.md', 'utf8')
+
+describe('pr governance release intent', () => {
+  it('requires a release intent section in PR bodies', () => {
+    expect(prGovernanceWorkflow).toContain('\'## Release Intent\'')
+    expect(prTemplate).toContain('## Release Intent')
+  })
+
+  it('guards product-impacting files from silently skipping release automation', () => {
+    expect(prGovernanceWorkflow).toContain('Validate product release intent')
+    expect(prGovernanceWorkflow).toContain('headBranch.startsWith(\'release-please--branches--\')')
+    expect(prGovernanceWorkflow).toContain('fileName.startsWith(\'src/\')')
+    expect(prGovernanceWorkflow).toContain('fileName.startsWith(\'skills/quantex-cli/\')')
+    expect(prGovernanceWorkflow).toContain('Release: not applicable - <reason>')
+  })
+
+  it('keeps release-please PR bodies compatible with required governance headings', () => {
+    for (const fileName of ['release-please-config.json', 'release-please-config.beta.json']) {
+      const config = JSON.parse(readFileSync(fileName, 'utf8')) as {
+        packages: {
+          '.': {
+            'pull-request-header': string
+          }
+        }
+      }
+      const header = config.packages['.']['pull-request-header']
+
+      expect(header).toContain('## Release Intent')
+      expect(header).toContain('## Closure Check')
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add a dedicated `## Release Intent` PR section
- Fail product-impacting PRs that would silently skip release automation unless they use release-worthy metadata or provide a meaningful no-release reason
- Keep release-please generated Release PRs compatible with the updated body requirements
- Add tests that lock the governance expectations in place

## Linked Artifacts

- OpenSpec: `openspec/changes/enforce-release-intent/`

## Validation

- [x] `bun run openspec:validate`
- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `git diff --check`

## Release Intent

- Release: not applicable - CI governance/process-only change; no shipped CLI behavior changes

## Docs Updated

- [x] `openspec/changes/enforce-release-intent/`
- [x] `.github/pull_request_template.md`

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change remains active by design until merge; archive closure is pending after merge.
- [x] Release is not applicable because this is governance/process-only.

## Notes

This PR intentionally strengthens release governance without changing release-please version calculation or publish behavior.
