### PR TITLE
ci: include release intent in archive PRs

### DIFF
--- a/.github/workflows/openspec-archive.yml
+++ b/.github/workflows/openspec-archive.yml
@@ -104,6 +104,10 @@ jobs:
           - [ ] \`bun run test\` (if behavior changed)
           - [x] Not run, explained below
 
+          ## Release Intent
+
+          - Release: not applicable - OpenSpec archive closure only
+
           ## Docs Updated
 
           - [ ] Not needed

--- a/openspec/changes/enforce-release-intent/tasks.md
+++ b/openspec/changes/enforce-release-intent/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Add a required `## Release Intent` section to PR body validation.
 - [x] 1.2 Add product-impacting file detection and release-intent enforcement to PR Governance.
 - [x] 1.3 Keep release-please PRs compatible with the updated governance.
+- [x] 1.4 Keep generated OpenSpec archive PRs compatible with the updated governance.
 
 ## 2. Documentation
 

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml', 'utf8')
+const openspecArchiveWorkflow = readFileSync('.github/workflows/openspec-archive.yml', 'utf8')
 const prTemplate = readFileSync('.github/pull_request_template.md', 'utf8')
 
 describe('pr governance release intent', () => {
@@ -32,5 +33,10 @@ describe('pr governance release intent', () => {
       expect(header).toContain('## Release Intent')
       expect(header).toContain('## Closure Check')
     }
+  })
+
+  it('keeps generated OpenSpec archive PR bodies compatible with required governance headings', () => {
+    expect(openspecArchiveWorkflow).toContain('## Release Intent')
+    expect(openspecArchiveWorkflow).toContain('Release: not applicable - OpenSpec archive closure only')
   })
 })


### PR DESCRIPTION
## Summary

- Add `## Release Intent` to the OpenSpec Archive workflow's generated PR body
- Extend PR governance tests so generated archive PRs remain compatible with required headings
- Keep the active `enforce-release-intent` OpenSpec task list aligned with the discovered automation gap

## Linked Artifacts

- OpenSpec: `openspec/changes/enforce-release-intent/`

## Validation

- [x] `bun run openspec:validate`
- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `git diff --check`

## Release Intent

- Release: not applicable - CI/archive workflow compatibility fix; no shipped CLI behavior changes

## Docs Updated

- [x] `openspec/changes/enforce-release-intent/`
- [ ] `docs/...`

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change remains active by design until merge; archive closure is pending after merge.
- [x] Release is not applicable because this is governance/process-only.

## Notes

This fixes the archive PR generated after #65 so future auto-archive PRs satisfy the new PR Governance headings.
