### PR TITLE
docs: trim AGENTS handbook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,329 +1,130 @@
 # AGENTS.md
 
-## Project
-
-Quantex CLI — 统一的 AI Agent CLI 管理工具，支持安装、更新、卸载、查询、快捷启动主流 AI 编程助手。
-
-项目定位补充：
+## Mission
 
 - Quantex 是 `human-friendly + agent-friendly` 的 `agent lifecycle CLI`
 - 主线聚焦 agent 的安装、检查、确保可用、更新、卸载、能力发现与稳定执行契约
 - 不把主线推进成 workflow orchestration platform
 - `batch / stdin pipe / apply / daemon / MCP server` 等能力默认视为扩展议题，不作为主线目标
 
-## Tech Stack
+## Agent Quickstart
 
-- **Runtime**: Bun（运行时、包管理器）
-- **Build**: tsdown（基于 rolldown）
-- **Test**: Vitest
-- **Language**: TypeScript (strict mode)
-- **Lint**: @antfu/eslint-config
-- **Dependencies**: commander, c12, picocolors, prompts
+1. 先分类当前请求，判断是否触发 OpenSpec intake gate。
+2. 只要改动 observable behavior、durable workflow、project memory 或 product-facing docs，就先选择或创建 OpenSpec change。
+3. 用 `bun run openspec:status -- --change <id>` 和 `bun run openspec:instructions -- <artifact> --change <id>` 确认下一步。
+4. 先做最小闭环实现，再同步更新相关 spec、ADR、session、issue 或 docs。
+5. 改完后至少跑 `bun run lint` 和 `bun run typecheck`；如果动了行为，也跑 `bun run test`。
+6. 结束前报告 validation、OpenSpec、git、commit、push、PR、release、archive closure 状态。
 
-## Work Intake Gate
+## Must
 
-Before implementation or file edits, classify the requested work.
+- 实现前先过 intake gate；用户说“直接开始”或“做到闭环”为授权推进，不是授权跳过流程。
+- 非平凡行为或 durable-process 改动必须先有 OpenSpec change，再做文件编辑。
+- GitHub Discussion 不是长期依据；要把结论提升为 issue、OpenSpec、ADR、runbook 或 session summary。
+- `AGENTS.md` 必须保持薄且高信号：只内联立即影响执行的规则，把易漂移细节指向 source of truth。
+- 修改项目记忆、协作流程、发布流程、行为契约时，同步更新对应 repo-native artifacts。
 
-This gate is mandatory for implementation, continuation, completion, and direct-execution requests. User urgency or execution-oriented wording authorizes progress, but it does not skip project workflow.
+## Must Not
 
-Use an existing OpenSpec change or create a new one before editing when the work changes any of these:
+- 不要把 Quantex 主线扩展成 workflow orchestration platform。
+- 不要因为用户催促、测试通过或任务勾选完成，就跳过 commit / push / PR / archive closure 检查。
+- 不要在 `AGENTS.md` 里复制大段目录树、类型定义、完整命令表或其他易漂移内容。
+- 不要新建 ad hoc root-level markdown；先把内容归类到 `openspec/` 或 `docs/`。
 
-- observable CLI behavior
-- stable structured output, schema, command catalog, or machine-readable contract
-- agent registry/catalog fields, install methods, update strategy, or version probing
-- configuration, state, cache, release, publishing, or upgrade behavior
-- architecture boundaries such as `core`, `surface`, services, package-manager, or self-upgrade
-- project memory policy, durable workflow, OPSX/OpenSpec rules, ADR/runbook process, or GitHub collaboration flow
-- product-facing documentation that changes how users understand installation, commands, release, or agent-facing usage
+## Validation
 
-Allowed no-OpenSpec cases:
-
-- typo or formatting-only edits
-- small docs wording cleanup that does not change product/process meaning
-- mechanical maintenance with no behavior, contract, or durable-process impact
-- test-only cleanup that does not redefine expected behavior
-
-When proceeding without OpenSpec, briefly state the classification. When uncertain, choose OpenSpec first.
-
-## Delivery Closure Gate
-
-Before saying work is complete, check the delivery state. Do not equate “tests passed” with “closed loop”.
-
-For any turn that changed files, the agent must verify and report:
-
-- validation state: relevant commands run, or why they could not run
-- OpenSpec state: active change complete, not needed, archived, or pending post-merge archive automation
-- git state: working tree clean or exact remaining files
-- commit state: committed or intentionally uncommitted with reason
-- remote state: pushed or not pushed with reason
-- PR state: opened/updated/merged, or not applicable with reason
-- release state: not applicable, pending release automation, or verified release result
-
-Closure levels:
-
-- local implementation: files changed and local validation passed
-- repository delivery: changes committed and working tree clean
-- PR delivery: branch pushed and PR opened with validation and linked artifacts
-- merge delivery: PR merged into the target branch
-- OpenSpec archive closure: accepted spec delta synced and the change archived after merge
-- release closure: release workflow completed when the change is release-worthy
-
-When the user asks for continuation or closure, continue to the next applicable closure level instead of stopping at local implementation. If a protected branch, required check, review, release workflow, or post-merge archive automation prevents immediate closure, state the blocker and the exact remaining owner.
-
-## Commands
+基础命令：
 
 ```bash
 bun install
-bun run dev
-bun run test
-bun run test:watch
 bun run lint
-bun run lint:fix
 bun run typecheck
+bun run test
 bun run openspec:list
 bun run openspec:status -- --change <change-id>
 bun run openspec:validate
+bun run memory:check
 bun run build
 bun run build:bin
 bun run release:artifacts
 ```
 
-Run `bun run lint` and `bun run typecheck` after making changes. If you touched behavior, run `bun run test` too.
+触发规则：
 
-## Code Style
+- 改了任意文件：跑 `bun run lint` 和 `bun run typecheck`
+- 改了 CLI 行为、结构化输出、契约或集成逻辑：再跑 `bun run test`
+- 改了 OpenSpec / docs / project memory 流程：跑 `bun run openspec:validate`，必要时跑 `bun run memory:check`
+- 改了构建、发布、自升级或 release artifacts：补跑 `bun run build`、`bun run build:bin`、`bun run release:artifacts`
 
-- 遵循 `@antfu/eslint-config` 规范
-- 不添加注释，除非用户要求
-- 使用 ESM（`"type": "module"`）
-- TypeScript strict mode + strictNullChecks
+## Work Intake Gate
 
-## Architecture
+实现、续做、收尾、直接执行类请求都必须先分类。
 
-实现与设计原则：
+如果改动涉及以下任一项，先创建或选择 OpenSpec change：
 
-- `core` 负责 agent registry、inspection、services、package-manager、state/self 等生命周期能力
-- `surface` 负责 human CLI、JSON、NDJSON 等对外契约
-- 命令最终产物是 typed result object，CLI 只是 renderer 之一
-- 优先增强单次调用的可靠性、可发现性与非交互契约，不扩张为工作流编排平台
+- observable CLI behavior
+- stable structured output、schema、command catalog 或 machine-readable contract
+- agent registry/catalog fields、install methods、update strategy 或 version probing
+- configuration、state、cache、release、publishing 或 upgrade behavior
+- architecture boundaries，如 `core`、`surface`、services、package-manager、self-upgrade
+- project memory policy、durable workflow、OPSX/OpenSpec rules、ADR/runbook process、GitHub collaboration flow
+- product-facing documentation that changes how users understand installation、commands、release 或 agent-facing usage
 
-```text
-src/
-├── index.ts                # 导出核心 API
-├── cli.ts                  # CLI 入口（commander）
-├── postinstall.ts          # 发布包安装后的 self state best-effort 落盘
-├── generated/
-│   └── build-meta.ts       # 构建时注入的版本与仓库元数据
-├── commands/
-│   ├── install.ts
-│   ├── update.ts
-│   ├── upgrade.ts
-│   ├── uninstall.ts
-│   ├── list.ts
-│   ├── info.ts
-│   ├── inspect.ts
-│   ├── ensure.ts
-│   ├── resolve.ts
-│   ├── exec.ts
-│   ├── capabilities.ts
-│   ├── commands.ts
-│   ├── schema.ts
-│   ├── run.ts
-│   ├── config.ts
-│   └── doctor.ts
-├── agents/
-│   ├── index.ts
-│   ├── types.ts
-│   ├── methods.ts
-│   └── definitions/
-├── agent-update/           # agent 更新策略层（managed/self-update/manual-hint）
-│   ├── index.ts
-│   ├── messages.ts
-│   ├── providers.ts
-│   └── types.ts
-├── inspection/
-│   ├── index.ts
-│   └── agents.ts
-├── package-manager/
-│   ├── index.ts
-│   ├── installers.ts
-│   ├── capabilities.ts
-│   ├── bun.ts
-│   ├── npm.ts
-│   ├── brew.ts
-│   ├── winget.ts
-│   └── binary.ts
-├── planning/
-│   ├── index.ts
-│   └── updates.ts
-├── services/
-│   ├── index.ts
-│   ├── agents.ts
-│   └── update.ts
-├── self/                   # Quantex CLI 自升级
-│   ├── index.ts
-│   ├── types.ts
-│   ├── recovery.ts
-│   ├── release.ts
-│   ├── lock.ts
-│   ├── binary.ts
-│   ├── install-state.ts
-│   └── providers/
-├── release-artifacts/      # release manifest/checksum 生成与校验
-│   └── index.ts
-├── state/
-│   └── index.ts
-├── state.ts
-├── config/
-│   ├── default.ts
-│   └── index.ts
-└── utils/
-    ├── color.ts
-    ├── detect.ts
-    ├── exec.ts
-    ├── install.ts
-    ├── lock.ts
-    ├── lifecycle-errors.ts
-    ├── network.ts
-    ├── user-output.ts
-    └── version.ts
-```
+只有这些情况可以不走 OpenSpec：
 
-## Key Types
+- typo 或 formatting-only edits
+- 不改变产品/流程含义的小型 wording cleanup
+- 没有行为、契约或 durable-process 影响的机械维护
+- 不重定义预期行为的 test-only cleanup
 
-```ts
-type Platform = 'windows' | 'macos' | 'linux'
-type ManagedInstallType = 'bun' | 'npm' | 'brew' | 'winget'
-type InstallType = ManagedInstallType | 'script' | 'binary'
-type PackageTargetKind = 'package' | 'cask' | 'id'
+如果不走 OpenSpec，要先简短说明分类；拿不准时，优先走 OpenSpec。
 
-interface InstallMethod {
-  type: InstallType
-  command?: string
-  packageName?: string
-  packageTargetKind?: PackageTargetKind
-}
+## Delivery Closure Gate
 
-interface AgentSelfUpdate {
-  command: string[]
-  fallbackCommands?: string[][]
-  versionAfter?: 'same-process' | 'respawn'
-}
+任何改过文件的回合，在宣称完成前都要检查并报告：
 
-interface AgentVersionProbe {
-  command?: string[]
-  parser?: (stdout: string) => string | undefined
-}
+- validation state
+- OpenSpec state
+- git state
+- commit state
+- remote state
+- PR state
+- release state
 
-interface AgentDefinition {
-  name: string
-  lookupAliases?: string[]
-  displayName: string
-  homepage: string
-  packages?: {
-    npm?: string
-  }
-  platforms: Partial<Record<Platform, InstallMethod[]>>
-  binaryName: string
-  selfUpdate?: AgentSelfUpdate
-  versionProbe?: AgentVersionProbe
-}
+闭环层级：
 
-type SelfInstallSource = 'bun' | 'npm' | 'binary' | 'source' | 'unknown'
-type SelfUpdateChannel = 'stable' | 'beta'
-type AgentUpdateStrategy = 'managed' | 'self-update' | 'manual-hint'
-```
+- local implementation：文件已改且本地验证通过
+- repository delivery：已提交且 working tree clean
+- PR delivery：分支已推送且 PR 已创建
+- merge delivery：PR 已合入目标分支
+- OpenSpec archive closure：spec delta 已同步且 change 已归档
+- release closure：需要发布时，发布自动化已完成
 
-- `packages.npm` 表示 agent 对应的 npm 包名
-- `InstallMethod.packageName` 表示安装器专用标识：npm/bun 用包名，brew 用 formula/cask 标识，winget 用 package ID
-- `selfUpdate` 表示 agent 自带更新命令
-- `versionProbe` 用于覆盖默认 `<binary> --version`
+如果用户要求“继续”或“闭环”，就推进到下一个可达层级，而不是停在本地实现。若受保护分支、必需检查、评审、发布流程或 archive follow-up 阻塞，要明确剩余 owner。
 
-## CLI Commands
+## File-Scoped Red Lines
 
-| Command | Description |
-|---------|-------------|
-| `quantex install <agent>` / `quantex i` | 安装 agent |
-| `quantex update <agent>` / `quantex u` | 更新 agent |
-| `quantex update --all` | 更新所有已安装的 agent，按安装来源和策略分组执行 |
-| `quantex upgrade` | 升级 Quantex CLI 自身 |
-| `quantex upgrade --check` | 只检查 Quantex CLI 是否有更新 |
-| `quantex upgrade --channel beta` | 使用 beta channel 检查或升级 |
-| `quantex uninstall <agent>` / `quantex rm` | 卸载 agent |
-| `quantex list` / `quantex ls` | 列出所有 agent |
-| `quantex info <agent>` | 查看 agent 详情 |
-| `quantex inspect <agent>` | 查看 agent 结构化状态 |
-| `quantex ensure <agent>` | 确保 agent 已安装 |
-| `quantex resolve <agent>` | 解析 agent 可执行入口 |
-| `quantex exec <agent> -- [args...]` | 以显式策略运行 agent |
-| `quantex capabilities` | 查看当前环境与 surface 能力 |
-| `quantex commands` | 查看稳定命令目录 |
-| `quantex schema` | 查看结构化输出 schema |
-| `quantex <agent> [args...]` | 快捷启动 agent |
-| `quantex config` | 配置管理 |
-| `quantex doctor` | 环境检查 |
+- `AGENTS.md`：只保留 mission、gates、validation、red lines 和 trigger-based pointers；不要重新长成 README、架构转储或命令镜像。
+- `openspec/specs/`：写当前生效的行为/流程契约，不写临时实现笔记。
+- `openspec/changes/`：存活跃 change；只有合并后且 spec 已同步时才归档到 `openspec/changes/archive/`。
+- `docs/adr/`：只记录会持续影响未来决策的长期选择。
+- `docs/sessions/`：记录讨论摘要；稳定结论继续上升到 ADR、OpenSpec、runbook 或 issue。
+- `src/generated/build-meta.ts`、`dist/`、release artifacts：视为生成物或发布产物，除非任务明确需要，不手工当作 source of truth 改写。
 
-## Config
+## Trigger-Based Pointers
 
-- Path: `~/.quantex/config.json`
-- Loaded via c12 with defaults → user config → env override merging
-- `defaultPackageManager`: 控制托管安装器的优先尝试顺序
-- `npmBunUpdateStrategy`: 控制 npm / Bun 更新时是直接升到最新版本，还是遵循 semver 约束
-- `selfUpdateChannel`: 控制 Quantex CLI 自升级默认 channel
-- `networkRetries`: 网络请求重试次数
-- `networkTimeoutMs`: 网络请求超时时间
-- `versionCacheTtlHours`: registry / release manifest / GitHub release 查询缓存 TTL
-
-## State
-
-- Path: `~/.quantex/state.json`
-- Stores runtime state for:
-  - each agent's actual install source
-  - Quantex CLI 自身的 `self.installSource`
-- Used by:
-  - `quantex update --all` 的分组批量更新
-  - self upgrade 的来源判断
-  - `list` / `info` / `doctor` 的来源与恢复提示
-
-## Ordering Semantics
-
-- Agent 安装方式按定义数组顺序表达回退顺序
-- `defaultPackageManager` 只会把匹配的托管安装器前置，不再依赖单独的 `priority` 字段
-- `npmBunUpdateStrategy` 默认是 `latest-major`
-- agent 更新策略优先级是：
-  - `managed`
-  - `self-update`
-  - `manual-hint`
-- self upgrade provider 按安装来源分派：
-  - `bun`
-  - `npm`
-  - `binary`
-  - `source`
-
-## Release Artifacts
-
-- `scripts/write-release-checksums.ts` 生成 `dist/bin/SHA256SUMS.txt`
-- `scripts/generate-release-manifest.ts` 生成 `dist/bin/manifest.json`
-- `scripts/verify-release-artifacts.ts` 校验 manifest 与 checksum 一致性
-- `bun run release:artifacts` 会串联以上三步
-
-## Project Memory System
-
-- Canonical project memory now lives in:
-  - `docs/`
-  - `openspec/`
-- Before creating a new markdown file, classify it first:
-  - behavior contract or non-trivial change proposal → `openspec/`
-  - durable design decision → `docs/adr/`
-  - troubleshooting or recovery knowledge → `docs/runbooks/`
-  - session summary → `docs/sessions/`
-  - incident review → `docs/postmortems/`
-  - future executable work → GitHub issue
-- Treat discussion notes as an intermediate artifact. Promote stable outcomes into specs, ADRs, runbooks, or GitHub issues.
-- Use OPSX actions for non-trivial changes when supported by the current agent: explore/propose/apply/archive. For CLI-driven work, use `openspec status --json` and `openspec instructions ... --json` to decide the next artifact or implementation step.
-- Treat an OpenSpec-backed change as fully done only after its implementation has merged, its spec delta has been synced, and the change has been archived into `openspec/changes/archive/`.
-- On protected branches, prefer the archive follow-up PR flow instead of leaving completed changes active in `openspec/changes/`.
-- Legacy root markdown files are transition artifacts. Their target homes are tracked in `docs/project-memory-migration.md`.
-- When implementation changes behavior or durable process, update the relevant OpenSpec spec/change, ADR, or runbook in the same change whenever practical.
+- 改 agent catalog、install metadata、version probe、update strategy：
+  `src/agents/types.ts`、`src/agents/definitions/`、`src/agent-update/`、`openspec/specs/agent-catalog/spec.md`、`openspec/specs/agent-update/spec.md`
+- 改 CLI surface、稳定命令目录或 schema：
+  `src/commands/`、`src/cli.ts`、`src/index.ts`、`quantex commands --json`、`quantex schema --json`
+- 改 config、state、self-upgrade、release artifacts：
+  `src/config/`、`src/state/`、`src/self/`、`src/release-artifacts/`、`openspec/specs/self-upgrade/spec.md`、`docs/releases.md`
+- 改 durable workflow、project memory、GitHub collaboration：
+  `openspec/README.md`、`openspec/config.yaml`、`docs/README.md`、`docs/github-collaboration.md`、`openspec/specs/project-memory/spec.md`
+- 改产品介绍、安装方式、用户理解：
+  `README.md`、`README.en.md`、`openspec/specs/product-readme/spec.md`
+- 需要真实类型或默认值时，不要复制片段；直接看源码：
+  `src/agents/types.ts`、`src/self/types.ts`、`src/config/default.ts`
 
 ## Notes
 

--- a/README.en.md
+++ b/README.en.md
@@ -215,7 +215,7 @@ Quantex uses release-please Release PRs. GitHub Releases are the canonical relea
 
 If you are contributing to this repository or letting a coding agent work here, start from these entry points:
 
-- [AGENTS.md](./AGENTS.md): repository-level agent instructions, architecture, and command conventions.
+- [AGENTS.md](./AGENTS.md): repository-level execution handbook with workflow guardrails, validation gates, and trigger-based pointers.
 - [docs/README.md](./docs/README.md): project docs for ADRs, runbooks, sessions, and postmortems.
 - [openspec/README.md](./openspec/README.md): OpenSpec / OPSX change workflow.
 - [docs/github-collaboration.md](./docs/github-collaboration.md): Issue, PR, and Discussion collaboration flow.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Quantex 使用 release-please 维护 Release PR，发布说明以 GitHub Release
 
 如果你要参与开发或让 coding agent 在本仓库内工作，请从这些入口开始：
 
-- [AGENTS.md](./AGENTS.md)：仓库级 agent 指令、架构和命令约定。
+- [AGENTS.md](./AGENTS.md)：仓库级 agent 执行手册，包含流程守卫、验证门槛和 trigger-based pointers。
 - [docs/README.md](./docs/README.md)：ADR、runbook、session、postmortem 等项目文档入口。
 - [openspec/README.md](./openspec/README.md)：OpenSpec / OPSX 变更流程。
 - [docs/github-collaboration.md](./docs/github-collaboration.md)：Issue、PR、Discussion 协作流程。

--- a/docs/adr/0005-keep-agents-as-a-thin-execution-handbook.md
+++ b/docs/adr/0005-keep-agents-as-a-thin-execution-handbook.md
@@ -1,0 +1,37 @@
+# ADR 0005: Keep AGENTS.md as a Thin Execution Handbook
+
+- Status: Accepted
+- Date: 2026-04-28
+
+## Context
+
+`AGENTS.md` is injected into every coding-agent session that starts in this repository. That makes it a high-leverage document, but also a poor place to maintain large snapshots of content that changes frequently, such as source trees, copied type definitions, and command tables.
+
+As Quantex has added intake and closure gates, `AGENTS.md` has become more important for immediate execution behavior. At the same time, copied reference material inside the file has become more likely to drift away from the real source files, CLI discovery surfaces, and canonical docs.
+
+## Decision
+
+Quantex keeps `AGENTS.md` as a thin but self-contained execution handbook.
+
+- Inline only the content that must influence agent behavior immediately: mission, non-goals, quickstart, hard constraints, validation triggers, intake and closure gates, file-scoped red lines, and trigger-based pointers.
+- Route volatile or detailed knowledge to source-of-truth artifacts in `src/`, `openspec/`, `docs/`, or CLI discovery commands such as `quantex commands` and `quantex schema`.
+- Do not use `AGENTS.md` as a copied directory tree, type reference, command catalog mirror, or product README substitute.
+
+## Consequences
+
+- Agents see the highest-priority execution rules with less noise at session start.
+- Drift-prone content moves back to the artifacts best suited to keep it current.
+- Contributors need to maintain clear pointer targets in source files and docs instead of relying on one oversized handbook.
+- Some context that was previously one scroll away in `AGENTS.md` now requires following a pointer, so the pointer language must stay explicit.
+
+## Alternatives Considered
+
+- Keep expanding `AGENTS.md` as a self-contained mega-handbook.
+- Replace `AGENTS.md` with a thin directory of links and rely on agents to expand every reference.
+- Move all agent guidance into OpenSpec-generated files and remove most project-specific repository instructions.
+
+## Follow-up
+
+- Rewrite `AGENTS.md` to match the thin-handbook shape.
+- Update any inaccurate references that still describe `AGENTS.md` as an architecture or command dump.
+- Keep the handbook rule synchronized with the `project-memory` OpenSpec capability.

--- a/docs/sessions/2026-04-28-agents-handbook-discussion-68.md
+++ b/docs/sessions/2026-04-28-agents-handbook-discussion-68.md
@@ -1,0 +1,22 @@
+# Session: 2026-04-28 AGENTS Handbook Discussion 68
+
+## Context
+
+Discussion 68 reviewed the current `AGENTS.md` and found that it mixed execution rules with product intro, architecture snapshots, copied types, and command tables. That made the file heavier for agents to ingest and increased drift risk for sections that already had stronger sources of truth elsewhere in the repository.
+
+## Decisions
+
+- `AGENTS.md` should remain a thin but self-contained execution handbook, not a README clone or architecture dump.
+- Hard constraints stay inline: mission, non-goals, quickstart, intake gate, validation triggers, closure gate, and file-scoped red lines.
+- Volatile details move behind trigger-based pointers to source files, docs, and discovery commands.
+- The discussion outcome should be promoted into repo-native memory and executable workflow artifacts instead of living only in GitHub Discussion.
+
+## Open Questions
+
+- None at the time of summary.
+
+## Follow-up
+
+- GitHub issue created: `#70`
+- OpenSpec change created: `trim-agents-handbook`
+- ADR added: `docs/adr/0005-keep-agents-as-a-thin-execution-handbook.md`

--- a/openspec/changes/trim-agents-handbook/.openspec.yaml
+++ b/openspec/changes/trim-agents-handbook/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/trim-agents-handbook/design.md
+++ b/openspec/changes/trim-agents-handbook/design.md
@@ -1,0 +1,42 @@
+## Context
+
+`AGENTS.md` currently succeeds at surfacing hard workflow rules such as the intake gate and delivery closure gate, but it also carries content that drifts quickly: a copied source tree, copied type definitions, command catalog snapshots, and detailed config/state notes. That increases prompt weight and makes the highest-priority rules less obvious to agents at session start.
+
+The repository already has better homes for the volatile material: source files for types and defaults, `quantex commands` and `quantex schema` for command discovery, OpenSpec for durable behavior contracts, and `docs/` for workflow and release context.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep `AGENTS.md` self-contained for the rules that must influence agent behavior immediately.
+- Replace drift-prone inline reference material with trigger-based pointers to source-of-truth artifacts.
+- Promote the discussion outcome into issue, session, ADR, and OpenSpec artifacts so the rationale does not live only in GitHub Discussion.
+- Keep the resulting workflow compatible with the current OpenSpec and GitHub-native collaboration flow.
+
+**Non-Goals:**
+
+- Change Quantex runtime behavior or CLI contracts.
+- Replace `AGENTS.md` with a link-only index that depends on agents always expanding references.
+- Add new repo-local workflow commands or automation just to manage handbook content.
+
+## Decisions
+
+- Keep hard constraints inline inside `AGENTS.md`.
+  Rationale: the intake gate, validation triggers, closure gate, and non-goals are the content most likely to affect immediate agent behavior.
+- Remove copied trees, copied types, and full command tables from `AGENTS.md`.
+  Rationale: those sections drift quickly and already have stronger sources of truth elsewhere in the repo or CLI.
+- Use trigger-based pointers instead of a generic links section.
+  Rationale: "when X, consult Y" is easier for agents to operationalize than a flat list of documentation links.
+- Record the decision as an ADR and summarize the discussion in `docs/sessions/`.
+  Rationale: the issue tracks executable work, but the rationale and durable direction also need repo-native memory.
+- Limit collateral updates to references whose wording would become inaccurate after the handbook rewrite.
+  Rationale: keep the change focused and avoid turning a handbook trim into a broad documentation rewrite.
+
+## Risks / Trade-offs
+
+- Risk: over-thinning `AGENTS.md` could hide rules agents need without loading other files.
+  Mitigation: keep mission, gates, validation, red lines, and quickstart inline.
+- Risk: pointer targets may still drift or be too broad.
+  Mitigation: point to specific source files, command discovery surfaces, and canonical docs instead of generic directory roots when possible.
+- Risk: some contributors may rely on `AGENTS.md` as an architecture dump.
+  Mitigation: keep architecture-adjacent pointers in the handbook and leave durable details in `README`, `docs/`, OpenSpec, and source files.

--- a/openspec/changes/trim-agents-handbook/proposal.md
+++ b/openspec/changes/trim-agents-handbook/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Discussion 68 concluded that `AGENTS.md` has become a mixed document that combines hard execution rules with drift-prone product, architecture, type, and command snapshots. Because the file is injected into every agent session, the project needs a thinner, higher-signal handbook that keeps critical constraints inline and routes volatile details to source-of-truth artifacts.
+
+Work-intake classification: this is a durable-process and project-memory change, so OpenSpec is required before implementation.
+
+## What Changes
+
+- Rewrite `AGENTS.md` into a thin but self-contained execution handbook.
+- Keep mission, non-goals, quickstart, hard constraints, validation triggers, intake gate, closure gate, file-scoped red lines, and trigger-based pointers inline.
+- Remove copied directory trees, copied type definitions, and full command tables from `AGENTS.md` in favor of pointers to source files, commands, or docs.
+- Promote the discussion outcome into repo-native artifacts, including a session summary, ADR, GitHub issue, and OpenSpec delta.
+- Update references that describe what `AGENTS.md` is responsible for so they match the thinner handbook role.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `project-memory`: Adds a durable requirement that `AGENTS.md` stays a thin execution handbook with trigger-based pointers to volatile source-of-truth details.
+
+## Impact
+
+- Affected files: `AGENTS.md`, `README.md`, `README.en.md`, `docs/sessions/`, `docs/adr/`, and the `project-memory` OpenSpec change/spec artifacts.
+- GitHub collaboration artifacts: issue `#70` promoted from discussion `#68`.
+- No runtime CLI behavior, dependency, or release automation changes.

--- a/openspec/changes/trim-agents-handbook/specs/project-memory/spec.md
+++ b/openspec/changes/trim-agents-handbook/specs/project-memory/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: AGENTS.md MUST stay a thin execution handbook
+
+The repository SHALL keep `AGENTS.md` as a thin but self-contained execution handbook for coding agents. The file SHALL inline only the mission, non-goals, quickstart, hard constraints, validation triggers, intake and closure gates, file-scoped red lines, and trigger-based pointers needed to route detailed knowledge.
+
+#### Scenario: Agent starts a repository session
+
+- **WHEN** a coding agent reads `AGENTS.md` at the start of repository work
+- **THEN** the file exposes the hard execution constraints without requiring another document to understand the guardrails
+- **AND** the file does not depend on copied source trees, copied type definitions, or full command catalogs to remain useful
+
+### Requirement: AGENTS.md pointers MUST route volatile details to source-of-truth artifacts
+
+Drift-prone details referenced by `AGENTS.md` SHALL live in source-of-truth code, docs, or discovery commands and SHALL be reached through trigger-based pointers.
+
+#### Scenario: Agent needs current source details
+
+- **WHEN** the current task depends on up-to-date type definitions, command catalogs, schema surfaces, release workflow details, or architecture boundaries
+- **THEN** `AGENTS.md` points the agent to the relevant source file, canonical doc, or discovery command
+- **AND** the volatile detail is not duplicated inline inside `AGENTS.md`

--- a/openspec/changes/trim-agents-handbook/tasks.md
+++ b/openspec/changes/trim-agents-handbook/tasks.md
@@ -1,0 +1,14 @@
+## 1. Promotion And Contract
+
+- [x] 1.1 Promote discussion `#68` into issue `#70`, a session summary, an ADR, and an OpenSpec `project-memory` delta.
+- [x] 1.2 Define the thin-handbook requirement and trigger-based pointer rule in the OpenSpec change artifacts.
+
+## 2. Handbook Rewrite
+
+- [x] 2.1 Rewrite `AGENTS.md` so hard execution rules stay inline while copied trees, copied types, and command tables are removed.
+- [x] 2.2 Update repo references that describe `AGENTS.md` so they match the new handbook role.
+
+## 3. Validation And Delivery
+
+- [x] 3.1 Run `bun run openspec:validate`, `bun run memory:check`, `bun run lint`, and `bun run typecheck`.
+- [ ] 3.2 Commit, push, and open the implementation PR while reporting any remaining merge or archive closure.

--- a/openspec/changes/trim-agents-handbook/tasks.md
+++ b/openspec/changes/trim-agents-handbook/tasks.md
@@ -11,4 +11,4 @@
 ## 3. Validation And Delivery
 
 - [x] 3.1 Run `bun run openspec:validate`, `bun run memory:check`, `bun run lint`, and `bun run typecheck`.
-- [ ] 3.2 Commit, push, and open the implementation PR while reporting any remaining merge or archive closure.
+- [x] 3.2 Commit, push, and open the implementation PR while reporting any remaining merge or archive closure.


### PR DESCRIPTION
## Summary

Closes #70.

Rewrite `AGENTS.md` into a thin execution handbook that keeps hard workflow constraints inline and routes drift-prone details through trigger-based pointers. Promote discussion 68 into issue, session, ADR, and OpenSpec artifacts so the rationale and contract live in the repository.

## Linked Artifacts

- Issue: #70
- ADR: `docs/adr/0005-keep-agents-as-a-thin-execution-handbook.md`
- OpenSpec: `openspec/changes/trim-agents-handbook/`
- Discussion: https://github.com/Drswith/quantex-cli/discussions/68

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process-only handbook and project-memory change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- `bun run test` was not run because this change does not alter runtime CLI behavior.
- OpenSpec archive closure remains post-merge work; the change should be archived after the accepted spec delta is synced on the protected branch.
