### PR TITLE
docs: archive trim-agents-handbook change

### DIFF
--- a/openspec/specs/project-memory/spec.md
+++ b/openspec/specs/project-memory/spec.md
@@ -15,6 +15,26 @@ The project SHALL store long-lived project memory in versioned repository artifa
 - THEN the contributor writes it into the canonical directory defined in `docs/README.md`
 - AND does not create a new root-level ad hoc markdown file for that category
 
+### Requirement: AGENTS.md must stay a thin execution handbook
+
+The project SHALL keep `AGENTS.md` as a thin but self-contained execution handbook for coding agents. The file SHALL inline only the mission, non-goals, quickstart, hard constraints, validation triggers, intake and closure gates, file-scoped red lines, and trigger-based pointers needed to route detailed knowledge.
+
+#### Scenario: Agent starts a repository session
+
+- **WHEN** a coding agent reads `AGENTS.md` at the start of repository work
+- **THEN** the file exposes the hard execution constraints without requiring another document to understand the guardrails
+- **AND** the file does not depend on copied source trees, copied type definitions, or full command catalogs to remain useful
+
+### Requirement: AGENTS.md pointers must route volatile details to source-of-truth artifacts
+
+Drift-prone details referenced by `AGENTS.md` SHALL live in source-of-truth code, docs, or discovery commands and SHALL be reached through trigger-based pointers.
+
+#### Scenario: Agent needs current source details
+
+- **WHEN** the current task depends on up-to-date type definitions, command catalogs, schema surfaces, release workflow details, or architecture boundaries
+- **THEN** `AGENTS.md` points the agent to the relevant source file, canonical doc, or discovery command
+- **AND** the volatile detail is not duplicated inline inside `AGENTS.md`
+
 ### Requirement: Discussion outcomes must be promoted
 
 The project SHALL treat session summaries as an intermediate artifact and promote stable conclusions into more durable documents when appropriate.


### PR DESCRIPTION
## Summary

Archive the completed `trim-agents-handbook` OpenSpec change after PR #71 merged. Sync the accepted AGENTS handbook requirements into `openspec/specs/project-memory/spec.md` and move the change into `openspec/changes/archive/2026-04-28-trim-agents-handbook/`.

## Linked Artifacts

- Issue: #70 (closed by #71)
- ADR: `docs/adr/0005-keep-agents-as-a-thin-execution-handbook.md`
- OpenSpec: `openspec/changes/archive/2026-04-28-trim-agents-handbook/`
- Discussion: https://github.com/Drswith/quantex-cli/discussions/68

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - archive and project-memory sync only

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is already archived in this branch.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- `bun run test` was not run because this follow-up only syncs an accepted spec delta and archives the completed change.
- The archive command initially duplicated the new AGENTS requirements in `project-memory`; this PR keeps the synced requirement once and removes the duplicate.
