### PR TITLE
docs: promote qtx README entrypoint

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -16,7 +16,7 @@ Manage AI coding assistant CLIs from one lifecycle-focused command line.
 
 </div>
 
-Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding agents. It gives Claude Code, Codex, Gemini, Kilo Code, Cursor, OpenCode, and other assistant CLIs a shared surface for installation, inspection, updates, removal, execution, and machine-readable automation.
+Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding agents. It gives Claude Code, Codex, Gemini, Kilo Code, Cursor, OpenCode, and other assistant CLIs a shared surface for installation, inspection, updates, removal, execution, and machine-readable automation. This README uses the shorter `qtx` form as the recommended entry point, while `quantex` remains the fully equivalent long command name.
 
 ## Why Quantex
 
@@ -42,9 +42,9 @@ npx skills add Drswith/quantex-cli --list
 Then let the agent discover Quantex's stable commands and output contracts:
 
 ```bash
-npm exec --yes --package quantex-cli -- quantex capabilities --json
-npm exec --yes --package quantex-cli -- quantex commands --json
-npm exec --yes --package quantex-cli -- quantex schema --json
+npm exec --yes --package quantex-cli -- qtx capabilities --json
+npm exec --yes --package quantex-cli -- qtx commands --json
+npm exec --yes --package quantex-cli -- qtx schema --json
 ```
 
 If the agent is contributing inside this repository, use this as the bootstrap prompt:
@@ -84,81 +84,99 @@ Windows PowerShell:
 irm https://raw.githubusercontent.com/Drswith/quantex-cli/main/install.ps1 | iex
 ```
 
-After installation, use `quantex` or its short alias `qtx`.
+After installation, prefer `qtx` for the shortest copyable path. If you prefer the explicit long form, `quantex` is fully equivalent.
+
+## Try It Without Installing
+
+If your environment already provides the runtime Quantex currently expects, you can try read-only commands before doing a global install:
+
+```bash
+bunx quantex-cli list
+npx --yes --package quantex-cli qtx capabilities --json
+npm exec --yes --package quantex-cli -- qtx inspect codex --json
+pnpm --package=quantex-cli dlx qtx doctor
+```
+
+Notes:
+
+- These commands are intended for read-only and discovery-oriented flows such as `list`, `info`, `inspect`, `doctor`, `capabilities`, `commands`, and `schema`.
+- The currently published package executes its CLI entrypoint through `bun`, so `npx` / `npm exec` / `pnpm dlx` still require a working `bun` on `PATH`.
+- For `install`, `ensure`, `update`, `uninstall`, `upgrade`, or any flow that should record install-source state, prefer a normal install first.
 
 ## Quick Start
 
 Install and run an agent:
 
 ```bash
-quantex install claude
-quantex exec claude --install if-missing -- --help
+qtx install claude
+qtx exec claude --install if-missing -- --help
 ```
 
 Ensure an agent is available, which is useful for scripts and other agents:
 
 ```bash
-quantex ensure codex --json
+qtx ensure codex --json
 ```
 
 Inspect agent state and resolve its executable:
 
 ```bash
-quantex inspect codex --json
-quantex resolve codex --json
+qtx inspect codex --json
+qtx resolve codex --json
 ```
 
 Update one agent or all installed agents:
 
 ```bash
-quantex update claude
-quantex update --all
+qtx update claude
+qtx update --all
 ```
 
 Upgrade Quantex itself:
 
 ```bash
-quantex upgrade
-quantex upgrade --check
-quantex upgrade --channel beta
+qtx upgrade
+qtx upgrade --check
+qtx upgrade --channel beta
 ```
 
 ## Common Commands
 
-| Command | Description |
-|---------|-------------|
-| `quantex install <agent>` / `qtx i` | Install an agent |
-| `quantex ensure <agent>` | Idempotently ensure an agent is installed |
-| `quantex update <agent>` / `qtx u` | Update an agent |
-| `quantex update --all` | Update all installed agents |
-| `quantex uninstall <agent>` / `qtx rm` | Uninstall an agent |
-| `quantex list` / `qtx ls` | List supported agents |
-| `quantex info <agent>` | Show agent details |
-| `quantex inspect <agent>` | Return structured agent state |
-| `quantex resolve <agent>` | Resolve the executable entrypoint |
-| `quantex exec <agent> -- [args...]` | Run an agent with explicit policy |
-| `quantex <agent> [args...]` | Shortcut-run an agent |
-| `quantex capabilities` | Show environment capabilities |
-| `quantex commands` | Show the stable command catalog |
-| `quantex schema` | Show structured output schemas |
-| `quantex config` | Manage configuration |
-| `quantex doctor` | Diagnose environment and recovery guidance |
+| Preferred Command | Equivalent Long Form | Description |
+|---------|-------------|-------------|
+| `qtx i <agent>` | `quantex install <agent>` | Install an agent |
+| `qtx ensure <agent>` | `quantex ensure <agent>` | Idempotently ensure an agent is installed |
+| `qtx u <agent>` | `quantex update <agent>` | Update an agent |
+| `qtx update --all` | `quantex update --all` | Update all installed agents |
+| `qtx rm <agent>` | `quantex uninstall <agent>` | Uninstall an agent |
+| `qtx ls` | `quantex list` | List supported agents |
+| `qtx info <agent>` | `quantex info <agent>` | Show agent details |
+| `qtx inspect <agent>` | `quantex inspect <agent>` | Return structured agent state |
+| `qtx resolve <agent>` | `quantex resolve <agent>` | Resolve the executable entrypoint |
+| `qtx exec <agent> -- [args...]` | `quantex exec <agent> -- [args...]` | Run an agent with explicit policy |
+| `qtx <agent> [args...]` | `quantex <agent> [args...]` | Shortcut-run an agent |
+| `qtx capabilities` | `quantex capabilities` | Show environment capabilities |
+| `qtx commands` | `quantex commands` | Show the stable command catalog |
+| `qtx schema` | `quantex schema` | Show structured output schemas |
+| `qtx config` | `quantex config` | Manage configuration |
+| `qtx doctor` | `quantex doctor` | Diagnose environment and recovery guidance |
 
 ## Supported Agents
 
 | Agent | Run Command | Description |
 |-------|-------------|-------------|
-| Claude Code | `quantex claude` | Anthropic's official AI coding assistant CLI |
-| Codex CLI | `quantex codex` | OpenAI's official AI coding assistant CLI |
-| GitHub Copilot CLI | `quantex copilot` | GitHub Copilot command-line tool |
-| Cursor CLI | `quantex cursor` | Cursor AI coding assistant CLI |
-| Droid | `quantex droid` | Factory AI software engineering agent CLI |
-| Gemini CLI | `quantex gemini` | Google's open-source AI coding assistant CLI |
-| Kilo Code CLI | `quantex kilo` | Kilo's official AI coding assistant CLI |
-| OpenCode | `quantex opencode` | Open-source AI coding CLI |
-| Pi | `quantex pi` | Minimal and extensible terminal coding agent |
+| Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
+| Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
+| GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
+| Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
+| Droid | `qtx droid` | Factory AI software engineering agent CLI |
+| Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |
+| Kilo Code CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
+| OpenCode | `qtx opencode` | Open-source AI coding CLI |
+| Pi | `qtx pi` | Minimal and extensible terminal coding agent |
+| Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |
 
-`qtx` is the short alias for `quantex`, for example `qtx codex` or `qtx ensure claude`.
+If you prefer the explicit long form, replace `qtx` with `quantex` in the examples above.
 
 ## Automation And Agents
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 </div>
 
-Quantex 是一个 `human-friendly + agent-friendly` 的 agent lifecycle CLI。它帮你把 Claude Code、Codex、Gemini、Kilo Code、Cursor、OpenCode 等 AI 编程助手的生命周期操作统一到一组稳定命令里：人可以直接用，自动化脚本和 coding agent 也可以用结构化输出可靠调用。
+Quantex 是一个 `human-friendly + agent-friendly` 的 agent lifecycle CLI。它帮你把 Claude Code、Codex、Gemini、Kilo Code、Cursor、OpenCode 等 AI 编程助手的生命周期操作统一到一组稳定命令里：人可以直接用，自动化脚本和 coding agent 也可以用结构化输出可靠调用。本文默认使用更短的 `qtx` 作为推荐入口，`quantex` 是完全等价的完整命令名。
 
 ## 为什么用 Quantex
 
@@ -42,9 +42,9 @@ npx skills add Drswith/quantex-cli --list
 随后让 agent 发现 Quantex 的稳定命令和输出契约：
 
 ```bash
-npm exec --yes --package quantex-cli -- quantex capabilities --json
-npm exec --yes --package quantex-cli -- quantex commands --json
-npm exec --yes --package quantex-cli -- quantex schema --json
+npm exec --yes --package quantex-cli -- qtx capabilities --json
+npm exec --yes --package quantex-cli -- qtx commands --json
+npm exec --yes --package quantex-cli -- qtx schema --json
 ```
 
 如果 agent 正在这个仓库内参与开发，请把下面这段作为启动提示：
@@ -84,81 +84,99 @@ Windows PowerShell：
 irm https://raw.githubusercontent.com/Drswith/quantex-cli/main/install.ps1 | iex
 ```
 
-安装后可以使用完整命令 `quantex`，也可以使用短别名 `qtx`。
+安装后推荐直接使用 `qtx`；如果你更偏好完整命令名，也可以使用完全等价的 `quantex`。
+
+## 免安装试用
+
+如果你已经有 Quantex 当前要求的运行时环境，可以先不做全局安装，直接试用只读命令：
+
+```bash
+bunx quantex-cli list
+npx --yes --package quantex-cli qtx capabilities --json
+npm exec --yes --package quantex-cli -- qtx inspect codex --json
+pnpm --package=quantex-cli dlx qtx doctor
+```
+
+注意事项：
+
+- 这些命令适合 `list`、`info`、`inspect`、`doctor`、`capabilities`、`commands`、`schema` 这类只读或发现型操作。
+- 当前已发布包的 CLI 入口通过 `bun` 执行，所以即使走 `npx` / `npm exec` / `pnpm dlx`，运行环境里也仍然需要可用的 `bun`。
+- `install`、`ensure`、`update`、`uninstall`、`upgrade` 这类会写状态或依赖已记录安装来源的操作，仍然建议先按上面的方式正常安装再执行。
 
 ## 快速开始
 
 安装并启动一个 agent：
 
 ```bash
-quantex install claude
-quantex exec claude --install if-missing -- --help
+qtx install claude
+qtx exec claude --install if-missing -- --help
 ```
 
 确保 agent 可用，适合脚本或其他 agent 调用：
 
 ```bash
-quantex ensure codex --json
+qtx ensure codex --json
 ```
 
 查看 agent 状态和可执行入口：
 
 ```bash
-quantex inspect codex --json
-quantex resolve codex --json
+qtx inspect codex --json
+qtx resolve codex --json
 ```
 
 更新单个 agent 或全部已安装 agent：
 
 ```bash
-quantex update claude
-quantex update --all
+qtx update claude
+qtx update --all
 ```
 
 升级 Quantex 自身：
 
 ```bash
-quantex upgrade
-quantex upgrade --check
-quantex upgrade --channel beta
+qtx upgrade
+qtx upgrade --check
+qtx upgrade --channel beta
 ```
 
 ## 常用命令
 
-| 命令 | 作用 |
-|------|------|
-| `quantex install <agent>` / `qtx i` | 安装 agent |
-| `quantex ensure <agent>` | 幂等确保 agent 已安装 |
-| `quantex update <agent>` / `qtx u` | 更新 agent |
-| `quantex update --all` | 更新所有已安装 agent |
-| `quantex uninstall <agent>` / `qtx rm` | 卸载 agent |
-| `quantex list` / `qtx ls` | 列出所有支持的 agent |
-| `quantex info <agent>` | 查看 agent 详情 |
-| `quantex inspect <agent>` | 查看结构化状态 |
-| `quantex resolve <agent>` | 解析可执行入口 |
-| `quantex exec <agent> -- [args...]` | 以显式策略运行 agent |
-| `quantex <agent> [args...]` | 快捷启动 agent |
-| `quantex capabilities` | 查看当前环境能力 |
-| `quantex commands` | 查看稳定命令目录 |
-| `quantex schema` | 查看结构化输出 schema |
-| `quantex config` | 管理配置 |
-| `quantex doctor` | 检查环境和恢复建议 |
+| 推荐命令 | 等价长命令 | 作用 |
+|------|------|------|
+| `qtx i <agent>` | `quantex install <agent>` | 安装 agent |
+| `qtx ensure <agent>` | `quantex ensure <agent>` | 幂等确保 agent 已安装 |
+| `qtx u <agent>` | `quantex update <agent>` | 更新 agent |
+| `qtx update --all` | `quantex update --all` | 更新所有已安装 agent |
+| `qtx rm <agent>` | `quantex uninstall <agent>` | 卸载 agent |
+| `qtx ls` | `quantex list` | 列出所有支持的 agent |
+| `qtx info <agent>` | `quantex info <agent>` | 查看 agent 详情 |
+| `qtx inspect <agent>` | `quantex inspect <agent>` | 查看结构化状态 |
+| `qtx resolve <agent>` | `quantex resolve <agent>` | 解析可执行入口 |
+| `qtx exec <agent> -- [args...]` | `quantex exec <agent> -- [args...]` | 以显式策略运行 agent |
+| `qtx <agent> [args...]` | `quantex <agent> [args...]` | 快捷启动 agent |
+| `qtx capabilities` | `quantex capabilities` | 查看当前环境能力 |
+| `qtx commands` | `quantex commands` | 查看稳定命令目录 |
+| `qtx schema` | `quantex schema` | 查看结构化输出 schema |
+| `qtx config` | `quantex config` | 管理配置 |
+| `qtx doctor` | `quantex doctor` | 检查环境和恢复建议 |
 
 ## 支持的 Agent
 
 | Agent | 启动命令 | 描述 |
 |-------|----------|------|
-| Claude Code | `quantex claude` | Anthropic 官方 AI 编程助手 CLI |
-| Codex CLI | `quantex codex` | OpenAI 官方 AI 编程助手 CLI |
-| GitHub Copilot CLI | `quantex copilot` | GitHub Copilot 命令行工具 |
-| Cursor CLI | `quantex cursor` | Cursor AI 编程助手命令行工具 |
-| Droid | `quantex droid` | Factory AI 软件工程 Agent CLI |
-| Gemini CLI | `quantex gemini` | Google 开源 AI 编程助手 CLI |
-| Kilo Code CLI | `quantex kilo` | Kilo 官方 AI 编程助手 CLI |
-| OpenCode | `quantex opencode` | 开源 AI 编程 CLI |
-| Pi | `quantex pi` | 极简可扩展的终端编程 Agent |
+| Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
+| Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
+| GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
+| Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
+| Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
+| Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |
+| Kilo Code CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
+| OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
+| Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
+| Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |
 
-`qtx` 是 `quantex` 的短别名，例如 `qtx codex`、`qtx ensure claude`。
+如果你更偏好显式长命令，上表里的 `qtx` 都可以直接替换成 `quantex`。
 
 ## 面向自动化和 Agent
 

--- a/openspec/changes/promote-qtx-readme-surface/.openspec.yaml
+++ b/openspec/changes/promote-qtx-readme-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/promote-qtx-readme-surface/design.md
+++ b/openspec/changes/promote-qtx-readme-surface/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Issue #75 promotes the accepted direction from Discussion #69 into implementation. The work changes product-facing documentation rather than CLI code, but it spans three surfaces with different audiences: the Chinese README, the English README, and the repo-published Quantex skill for coding agents.
+
+The main ambiguity is not wording alone. The no-install commands must reflect how the published package actually executes today. Validation showed that:
+
+- `npx --package quantex-cli qtx ...` and `npm exec --package quantex-cli -- qtx ...` work when the runtime environment includes `bun`.
+- `pnpm dlx quantex-cli ...` is ambiguous because the package exposes multiple bins, so the explicit `pnpm --package=quantex-cli dlx qtx ...` form is safer.
+- `bunx -p quantex-cli qtx ...` can resolve to an already installed global `qtx`, while `bunx quantex-cli ...` correctly executes the published package.
+- The published CLI entrypoint uses `#!/usr/bin/env bun`, so “no-install” still assumes the machine has the required runtime available on `PATH`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `qtx` the recommended short entry point in product-facing README examples.
+- Keep `quantex` explicitly visible as the equivalent long-form command for searchability and self-explanatory examples.
+- Add a first-class no-install section that only promotes read-only discovery commands and uses validated command forms.
+- Keep README and skill wording aligned enough that users and agents do not infer contradictory guidance.
+
+**Non-Goals:**
+
+- Change CLI behavior, binary layout, or self-upgrade semantics.
+- Guarantee a truly dependency-free tryout path.
+- Rewrite the skill to prefer the short alias for automation where the explicit `quantex` form is still clearer.
+
+## Decisions
+
+### Prefer `qtx` in user-facing quick paths, keep `quantex` visible elsewhere
+
+The README hero, quick start, and supported-agent examples will prefer `qtx` because that is the project's desired ergonomic entry point. The command overview will continue to show `quantex` alongside `qtx` where discoverability and grep-ability matter.
+
+Alternative considered: switch every example to `qtx`.
+Rejected because the long form remains valuable for search, scripts, and self-explanatory reference snippets.
+
+### Promote no-install usage only for read-only commands
+
+The new no-install section will focus on commands such as `list`, `info`, `inspect`, `doctor`, `capabilities`, `commands`, and `schema`. Commands that install, update, uninstall, or write Quantex state will continue to route users to normal installation guidance.
+
+Alternative considered: promote no-install execution for the whole CLI.
+Rejected because it conflicts with the tracked-install-source and self-upgrade story already documented elsewhere in the product.
+
+### Document verified package-manager forms instead of assuming symmetry
+
+The no-install section will only recommend command forms that were validated against the published package behavior:
+
+- `npx --yes --package quantex-cli qtx ...`
+- `npm exec --yes --package quantex-cli -- qtx ...`
+- `pnpm --package=quantex-cli dlx qtx ...`
+- `bunx quantex-cli ...`
+
+The docs will also state that the current published package executes through `bun`, so these trial commands still require the runtime environment Quantex expects today.
+
+Alternative considered: present `npx`, `bunx`, and `pnpm dlx` as interchangeable variants of the same syntax.
+Rejected because the package exposes multiple bins and current `bunx` / `pnpm` invocation forms are not symmetric in practice.
+
+## Risks / Trade-offs
+
+- [Users may read “no-install” as “no prerequisites”] → Clarify that the commands avoid global Quantex installation, not runtime prerequisites.
+- [The validated package-manager forms may drift as packaging changes] → Capture the expectation in OpenSpec and keep examples narrowly focused on read-only discovery commands.
+- [README and skill wording could diverge again later] → Update both in one change and keep the skill aligned on equivalence and discovery guidance.

--- a/openspec/changes/promote-qtx-readme-surface/proposal.md
+++ b/openspec/changes/promote-qtx-readme-surface/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Discussion #69 identified that Quantex's product-facing documentation no longer matches the project's preferred onboarding path. The published README surfaces `quantex` as the dominant entry point and treats no-install trial commands as incidental, even though the package already ships both `quantex` and `qtx` binaries and read-only discovery commands are well suited to zero-install evaluation.
+
+## What Changes
+
+- Recommend `qtx` as the preferred short entry point in product-facing README examples while keeping `quantex` visibly documented as the equivalent long form.
+- Add a first-class no-install try-it-out section for read-only commands and document which command forms are supported and safe to recommend.
+- Keep `README.md`, `README.en.md`, and `skills/quantex-cli/SKILL.md` aligned so the human-facing and agent-facing surfaces do not drift.
+- Record the documentation contract changes in OpenSpec so future README edits keep the preferred entry point and no-install guidance accurate.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `product-readme`: README requirements will define `qtx` as the recommended short entry point, preserve `quantex` discoverability, and require first-class read-only no-install guidance that matches verified command forms.
+
+## Impact
+
+- Affected artifacts: `README.md`, `README.en.md`, `skills/quantex-cli/SKILL.md`, and `openspec/specs/product-readme/spec.md`.
+- Affected workflow: Issue #75 delivers the README work from Discussion #69; Issue #76 tracks the separate Windows binary consistency follow-up outside this documentation-scoped change.

--- a/openspec/changes/promote-qtx-readme-surface/specs/product-readme/spec.md
+++ b/openspec/changes/promote-qtx-readme-surface/specs/product-readme/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: README Recommends The Preferred Short Entry Point
+
+The product README SHALL present `qtx` as the recommended short command entry point for human-facing onboarding while explicitly identifying `quantex` as the equivalent long-form command.
+
+#### Scenario: User scans the onboarding path
+
+- **WHEN** a user reads the install, quick start, or supported-agent sections in `README.md` or `README.en.md`
+- **THEN** the primary examples use `qtx` for the shortest copyable path
+- **AND** the documentation states that `qtx` and `quantex` are equivalent entry points
+
+### Requirement: README Documents Verified Read-Only No-Install Usage
+
+The product README SHALL include a first-class no-install try-it-out section that promotes only read-only or discovery-oriented commands and uses command forms verified against the published package behavior.
+
+#### Scenario: User evaluates Quantex without a global install
+
+- **WHEN** a user opens the no-install try-it-out section
+- **THEN** the README shows copyable commands for read-only surfaces such as `list`, `info`, `inspect`, `doctor`, `capabilities`, `commands`, or `schema`
+- **AND** each recommended package-manager form matches a currently working invocation for the published package
+- **AND** the section states any current runtime prerequisite needed to execute those commands
+
+#### Scenario: User looks for mutating no-install commands
+
+- **WHEN** a user reads the no-install try-it-out guidance
+- **THEN** the README directs install, update, uninstall, and other state-writing flows back to the normal installation paths instead of promoting them as first-class no-install usage

--- a/openspec/changes/promote-qtx-readme-surface/tasks.md
+++ b/openspec/changes/promote-qtx-readme-surface/tasks.md
@@ -1,0 +1,21 @@
+## 1. Product Surface Updates
+
+- [x] 1.1 Update `README.md` to recommend `qtx` in onboarding paths while keeping `quantex` visibly equivalent.
+- [x] 1.2 Add a read-only no-install try-it-out section to `README.md` with validated command forms and runtime caveats.
+- [x] 1.3 Mirror the same entry-point and no-install guidance in `README.en.md`.
+
+## 2. Agent Surface Alignment
+
+- [x] 2.1 Update `skills/quantex-cli/SKILL.md` so the agent-facing guidance acknowledges the preferred `qtx` entry point without weakening the explicit automation recommendations.
+- [x] 2.2 Sync `openspec/specs/product-readme/spec.md` with the accepted README contract changes.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint` and `bun run typecheck`.
+- [x] 3.2 Run `bun run openspec:validate`.
+
+## 4. Delivery Closure
+
+- [ ] 4.1 Commit the README change set with linked issue/OpenSpec context.
+- [ ] 4.2 Push the branch and open a PR linked to Issue #75 and the OpenSpec change.
+- [ ] 4.3 Comment on Discussion #69 with the issue/PR/follow-up links and close it once the implementation handoff is durable.

--- a/openspec/changes/promote-qtx-readme-surface/tasks.md
+++ b/openspec/changes/promote-qtx-readme-surface/tasks.md
@@ -16,6 +16,6 @@
 
 ## 4. Delivery Closure
 
-- [ ] 4.1 Commit the README change set with linked issue/OpenSpec context.
-- [ ] 4.2 Push the branch and open a PR linked to Issue #75 and the OpenSpec change.
-- [ ] 4.3 Comment on Discussion #69 with the issue/PR/follow-up links and close it once the implementation handoff is durable.
+- [x] 4.1 Commit the README change set with linked issue/OpenSpec context.
+- [x] 4.2 Push the branch and open a PR linked to Issue #75 and the OpenSpec change.
+- [x] 4.3 Comment on Discussion #69 with the issue/PR/follow-up links and close it once the implementation handoff is durable.

--- a/openspec/specs/product-readme/spec.md
+++ b/openspec/specs/product-readme/spec.md
@@ -56,3 +56,29 @@ The root README MUST use command examples and supported-agent references that ma
 
 - **WHEN** a user copies an install, inspect, ensure, update, upgrade, or execution example from `README.md`
 - **THEN** the command reflects an existing Quantex command or documented alias.
+
+### Requirement: README Recommends The Preferred Short Entry Point
+
+The product README SHALL present `qtx` as the recommended short command entry point for human-facing onboarding while explicitly identifying `quantex` as the equivalent long-form command.
+
+#### Scenario: User scans the onboarding path
+
+- **WHEN** a user reads the install, quick start, or supported-agent sections in `README.md` or `README.en.md`
+- **THEN** the primary examples use `qtx` for the shortest copyable path
+- **AND** the documentation states that `qtx` and `quantex` are equivalent entry points
+
+### Requirement: README Documents Verified Read-Only No-Install Usage
+
+The product README SHALL include a first-class no-install try-it-out section that promotes only read-only or discovery-oriented commands and uses command forms verified against the published package behavior.
+
+#### Scenario: User evaluates Quantex without a global install
+
+- **WHEN** a user opens the no-install try-it-out section
+- **THEN** the README shows copyable commands for read-only surfaces such as `list`, `info`, `inspect`, `doctor`, `capabilities`, `commands`, or `schema`
+- **AND** each recommended package-manager form matches a currently working invocation for the published package
+- **AND** the section states any current runtime prerequisite needed to execute those commands
+
+#### Scenario: User looks for mutating no-install commands
+
+- **WHEN** a user reads the no-install try-it-out guidance
+- **THEN** the README directs install, update, uninstall, and other state-writing flows back to the normal installation paths instead of promoting them as first-class no-install usage

--- a/skills/quantex-cli/SKILL.md
+++ b/skills/quantex-cli/SKILL.md
@@ -7,6 +7,8 @@ description: Use this skill when working with Quantex CLI to install, inspect, e
 
 Use this skill when the task is about operating AI agent CLIs through Quantex rather than invoking each agent tool ad hoc.
 
+`qtx` is the preferred short user-facing entry point in the product README. This skill keeps the explicit `quantex` form in automation examples because it is clearer in prompts, logs, and durable runbooks; treat the two names as equivalent unless a command example explicitly depends on the published package-manager shim form.
+
 ## When to use
 
 Reach for this skill when you need to:
@@ -53,7 +55,7 @@ Prefer `inspect`, `ensure`, `resolve`, and `exec` over scraping human-readable `
 
 Quantex is `human-friendly + agent-friendly`.
 
-- Use `quantex <agent>` for human shortcut flows
+- Use `qtx <agent>` or `quantex <agent>` for human shortcut flows; the README prefers `qtx` as the shorter copyable path
 - Use `quantex exec <agent> -- [args...]` for automation and agent-safe invocation
 - Use `--json` or `--output ndjson` when another agent or tool will parse the result
 - Use `--non-interactive` when prompts would be unsafe


### PR DESCRIPTION
## Summary

- recommend `qtx` as the primary user-facing README entry point while keeping `quantex` explicitly equivalent
- add a first-class read-only no-install try-it-out section with validated package-manager command forms and current runtime caveats
- sync the Quantex skill wording and `product-readme` OpenSpec requirements with the accepted documentation contract

## Linked Artifacts

- Issue: #75
- ADR: N/A
- OpenSpec: `openspec/changes/promote-qtx-readme-surface/`
- Discussion: #69

## Validation

- [ ] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [x] Not run, explained below
- [x] `bun run openspec:validate`

## Release Intent

- [x] Release: not applicable - docs/process/test-only change
- [ ] Release: patch - bug fix
- [ ] Release: minor - user-facing feature
- [ ] Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [x] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, or already archived.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- `bun run memory:check` was not needed because this change does not alter project-memory rules or durable workflow artifacts beyond the OpenSpec/README updates included here.
- `bun run test` was not run because the implementation only changes README, skill wording, and OpenSpec documentation; no CLI behavior changed in source code.
- Follow-up Issue #76 tracks the Windows `qtx.exe` / `quantex.exe` consistency work that Discussion #69 explicitly split out of this docs-scoped change.