### PR TITLE
docs(openspec): archive prioritize english product copy

### DIFF
--- a/openspec/specs/project-memory/spec.md
+++ b/openspec/specs/project-memory/spec.md
@@ -15,6 +15,17 @@ The project SHALL store long-lived project memory in versioned repository artifa
 - THEN the contributor writes it into the canonical directory defined in `docs/README.md`
 - AND does not create a new root-level ad hoc markdown file for that category
 
+### Requirement: Root markdown allowlist SHALL track canonical README entry points
+
+Repository-native project-memory checks MUST allow the current canonical root README files used for the product landing page and language switching.
+
+#### Scenario: Repository checks root markdown files
+
+- **WHEN** `bun run memory:check` evaluates root-level markdown files
+- **THEN** it allows `README.md` as the canonical English landing page
+- **AND** it allows `README.zh-CN.md` as the Simplified Chinese product entry point
+- **AND** it may continue allowing compatibility README aliases that remain intentionally present
+
 ### Requirement: AGENTS.md must stay a thin execution handbook
 
 The project SHALL keep `AGENTS.md` as a thin but self-contained execution handbook for coding agents. The file SHALL inline only the mission, non-goals, quickstart, hard constraints, validation triggers, intake and closure gates, file-scoped red lines, and trigger-based pointers needed to route detailed knowledge.


### PR DESCRIPTION
## Summary
- sync the accepted README language-entry requirements into the main OpenSpec specs
- move `prioritize-english-product-copy` from active changes into `openspec/changes/archive/`
- complete the post-merge OpenSpec archive closure for PR #86

## Linked Artifacts
- PR: #86
- OpenSpec archive change: `openspec/changes/archive/2026-04-28-prioritize-english-product-copy/`
- Product README spec: `openspec/specs/product-readme/spec.md`
- Project memory spec: `openspec/specs/project-memory/spec.md`

## Validation
- `bun run openspec:validate`
- `bun run memory:check`

## Release Intent
Release: not applicable - this PR only performs OpenSpec archive closure and main-spec sync for an already merged documentation change.

## Docs Updated
- [x] `openspec/...`
- [x] Follow-up issue or OpenSpec change created instead

## Scope Check
- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check
- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, or already archived.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes
This PR is the required archive follow-up because `main` is protected and does not allow direct post-merge archive commits.
