### PR TITLE
fix(update): skip untracked PATH agents in update --all

### DIFF
--- a/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/design.md
+++ b/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/design.md
@@ -1,0 +1,25 @@
+## Context
+
+Quantex uses `simple-git-hooks` and `lint-staged` to run `oxfmt` and `oxlint --fix` on staged files before each commit. The current glob includes YAML, but the installed `oxfmt` invocation fails on `.openspec.yaml`, which blocks commit closure for valid OpenSpec archive changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make pre-commit formatting succeed for normal OpenSpec archive commits.
+- Keep formatter and linter enforcement in place for supported staged source files.
+
+**Non-Goals:**
+
+- Do not replace `oxfmt` or `oxlint`.
+- Do not broaden formatter coverage to file types the current formatter/runtime combination does not support.
+
+## Decisions
+
+- Remove YAML from the `lint-staged` formatter glob so the hook only targets staged file types that `oxfmt` can handle reliably in this repository.
+- Keep JSON and source-file formatting intact so the pre-commit contract remains strong for supported file types.
+- Record the narrower pre-commit target rule in the code-quality-tooling spec.
+
+## Risks / Trade-offs
+
+- YAML files will no longer be auto-formatted by the pre-commit hook, but that is preferable to blocking every commit that archives an OpenSpec change.

--- a/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/proposal.md
+++ b/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The current pre-commit hook routes staged YAML files such as OpenSpec `.openspec.yaml` through `oxfmt --write`, but the installed formatter does not accept those files in this repository setup. That makes otherwise valid commits fail during archive and tooling workflows.
+
+## What Changes
+
+- Narrow the pre-commit formatter target set so `lint-staged` only sends file types that `oxfmt` can actually format in this repository.
+- Keep JavaScript and TypeScript staged files on the existing `oxfmt` then `oxlint --fix` path.
+- Add or update tests/spec coverage for the corrected pre-commit formatting contract.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: pre-commit formatting targets exclude unsupported staged file types that would cause `oxfmt` to fail.
+
+## Impact
+
+- Affected code: `package.json` lint-staged configuration and related tooling specs.
+- Affected workflow: pre-commit behavior for OpenSpec archive files and other staged YAML/config sources.
+- Dependencies: no new runtime dependency.

--- a/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/specs/code-quality-tooling/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Pre-commit lint and format enforcement
+
+The repository SHALL enforce lint and format on staged files before each commit through `simple-git-hooks` and `lint-staged`. The pre-commit hook MUST run `oxfmt` only on staged files supported by the formatter in this repository configuration, and MUST run `oxlint --fix` only on staged JavaScript or TypeScript files after formatting, so that the linter sees post-formatter content without being invoked on unsupported file types.
+
+#### Scenario: Contributor commits a staged file
+
+- **GIVEN** a contributor stages files matched by `lint-staged` globs
+- **WHEN** the pre-commit hook runs
+- **THEN** the hook invokes `oxfmt` on staged formatter-supported files to write formatting fixes
+- **AND** then invokes `oxlint --fix` on staged JavaScript or TypeScript files
+- **AND** if either step fails, the commit is aborted
+
+#### Scenario: Contributor stages OpenSpec archive metadata
+
+- **GIVEN** a contributor stages an OpenSpec archive file such as `.openspec.yaml`
+- **WHEN** the pre-commit hook runs
+- **THEN** the hook does not route that file through an unsupported `oxfmt` invocation
+- **AND** the commit is not blocked solely because the formatter cannot handle that file type in the current repository configuration

--- a/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/tasks.md
+++ b/openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/tasks.md
@@ -1,0 +1,9 @@
+## 1. Tooling
+
+- [x] 1.1 Update `lint-staged` formatter globs to exclude unsupported YAML targets such as `.openspec.yaml`.
+- [x] 1.2 Keep staged source-file formatting and lint-fix behavior intact for supported file types.
+
+## 2. Validation
+
+- [x] 2.1 Validate the OpenSpec change and code-quality-tooling spec.
+- [x] 2.2 Run lint, typecheck, and tests needed to confirm the tooling change does not regress repository validation.

--- a/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/design.md
+++ b/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/design.md
@@ -1,0 +1,28 @@
+## Context
+
+Quantex separates a supported agent's canonical catalog name from the executable binary it launches. Qoder CLI already fits this pattern: the Quantex slug is `qoder`, while the executable binary is `qodercli`, similar to how Cursor keeps the slug `cursor` while launching the `agent` binary.
+
+`update --all` currently plans updates for any agent that is merely detected in `PATH`, even when Quantex has no recorded install state for it. For self-updating tools, that means a PATH-only binary can get pulled into the batch update flow and trigger installation or upgrade behavior that the user did not explicitly ask Quantex to manage.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `update --all` respect Quantex-managed install state before scheduling batch updates.
+- Keep the existing `qoder` slug while making the slug-to-binary contract explicit in tests.
+
+**Non-Goals:**
+
+- Do not add a second Qoder-related agent entry for the IDE launcher.
+- Do not change Qoder's install methods, package metadata, or self-update command.
+- Do not remove the ability to explicitly run or explicitly update a supported agent that is available in `PATH`.
+
+## Decisions
+
+- Change batch update planning so `update --all` only schedules agents with a recorded Quantex install state; PATH-only detections become manual informational results instead of executable update entries.
+- Keep the supported agent definition on the canonical name `qoder` and continue launching the binary `qodercli`.
+- Add tests that assert `qoder` resolves to the `qodercli` binary and PATH-only self-updating agents are skipped by `update --all`.
+
+## Risks / Trade-offs
+
+- Users who relied on `update --all` touching untracked PATH installs will now need to use explicit single-agent update or reinstall via Quantex, but that behavior is safer and matches the intended lifecycle boundary.

--- a/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/proposal.md
+++ b/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Quantex already models Qoder CLI with the correct executable binary `qodercli`, but the batch update flow can still treat a PATH-detected Qoder binary as a managed update target even when Quantex never installed or tracked it. We need to keep the `qoder` agent slug while preventing `update --all` from auto-updating untracked PATH-only agents.
+
+## What Changes
+
+- Change `quantex update --all` so it skips agents that are only detected in `PATH` and are not tracked through Quantex state.
+- Keep Qoder CLI lifecycle metadata aligned with the existing `qoder` slug plus `qodercli` executable-binary contract.
+- Add tests that verify `qoder` continues to resolve to the `qodercli` binary and untracked PATH-only agents are not auto-updated by `update --all`.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: batch update planning skips PATH-only agents that have no recorded Quantex install state.
+
+## Impact
+
+- Affected code: `src/agents/definitions/`, agent registry exports, and tests.
+- Affected contracts: batch update behavior for untracked PATH installs and the Qoder slug-to-binary execution contract.
+- Dependencies: no new runtime dependency.

--- a/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/specs/agent-update/spec.md
+++ b/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/specs/agent-update/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Batch update MUST plan from recorded install sources
+
+Batch agent updates SHALL prioritize recorded actual install sources over candidate install methods declared for the agent.
+
+#### Scenario: Updating all installed agents
+
+- GIVEN the user runs `quantex update --all`
+- WHEN Quantex builds the update plan
+- THEN it groups work by the recorded actual install source where available
+- AND it does not rely only on the agent definition's possible install methods
+
+#### Scenario: Skipping untracked PATH detections during batch update
+
+- GIVEN a supported agent binary is available in `PATH`
+- AND Quantex has no recorded install state for that agent
+- WHEN the user runs `quantex update --all`
+- THEN Quantex does not execute managed update or self-update operations for that agent
+- AND the batch result explains that the agent was detected in `PATH` but is not tracked as a Quantex-managed install

--- a/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/tasks.md
+++ b/openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/tasks.md
@@ -1,0 +1,14 @@
+## 1. Catalog
+
+- [x] 1.1 Keep Qoder CLI on the `qoder` slug while verifying it executes the `qodercli` binary.
+- [x] 1.2 Add regression coverage for the Qoder slug-to-binary contract.
+
+## 2. Batch Update Safety
+
+- [x] 2.1 Change `update --all` planning so PATH-only untracked agents are skipped instead of updated.
+- [x] 2.2 Add or update tests for the corrected batch update behavior.
+
+## 3. Validation
+
+- [x] 3.1 Run OpenSpec validation.
+- [x] 3.2 Run lint, typecheck, and behavior-focused tests.

--- a/openspec/specs/agent-update/spec.md
+++ b/openspec/specs/agent-update/spec.md
@@ -61,6 +61,14 @@ Batch agent updates SHALL prioritize recorded actual install sources over candid
 - THEN it groups work by the recorded actual install source where available
 - AND it does not rely only on the agent definition's possible install methods
 
+#### Scenario: Skipping untracked PATH detections during batch update
+
+- GIVEN a supported agent binary is available in `PATH`
+- AND Quantex has no recorded install state for that agent
+- WHEN the user runs `quantex update --all`
+- THEN Quantex does not execute managed update or self-update operations for that agent
+- AND the batch result explains that the agent was detected in `PATH` but is not tracked as a Quantex-managed install
+
 ### Requirement: Agent update state MUST remain visible in diagnostics
 
 Agent update behavior SHALL be inspectable through user-facing diagnostic commands.

--- a/openspec/specs/code-quality-tooling/spec.md
+++ b/openspec/specs/code-quality-tooling/spec.md
@@ -70,7 +70,7 @@ The oxfmt configuration SHALL enable `package.json` script sorting to minimize m
 
 ### Requirement: Pre-commit lint and format enforcement
 
-The repository SHALL enforce lint and format on staged files before each commit through `simple-git-hooks` and `lint-staged`. The pre-commit hook MUST run `oxfmt` on staged files supported by the formatter, and MUST run `oxlint --fix` only on staged JavaScript or TypeScript files after formatting, so that the linter sees post-formatter content without being invoked on unsupported file types.
+The repository SHALL enforce lint and format on staged files before each commit through `simple-git-hooks` and `lint-staged`. The pre-commit hook MUST run `oxfmt` only on staged files supported by the formatter in this repository configuration, and MUST run `oxlint --fix` only on staged JavaScript or TypeScript files after formatting, so that the linter sees post-formatter content without being invoked on unsupported file types.
 
 #### Scenario: Contributor commits a staged file
 
@@ -79,6 +79,13 @@ The repository SHALL enforce lint and format on staged files before each commit 
 - **THEN** the hook invokes `oxfmt` on staged formatter-supported files to write formatting fixes
 - **AND** then invokes `oxlint --fix` on staged JavaScript or TypeScript files
 - **AND** if either step fails, the commit is aborted
+
+#### Scenario: Contributor stages OpenSpec archive metadata
+
+- **GIVEN** a contributor stages an OpenSpec archive file such as `.openspec.yaml`
+- **WHEN** the pre-commit hook runs
+- **THEN** the hook does not route that file through an unsupported `oxfmt` invocation
+- **AND** the commit is not blocked solely because the formatter cannot handle that file type in the current repository configuration
 
 ### Requirement: CI lint and format gate
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
       "oxfmt --write",
       "oxlint --fix"
     ],
-    "*.{json,jsonc,json5,yml,yaml,html,css,scss,less}": [
+    "*.{json,jsonc,json5,html,css,scss,less}": [
       "oxfmt --write"
     ]
   },

--- a/src/agent-update/index.ts
+++ b/src/agent-update/index.ts
@@ -1,4 +1,4 @@
-export { getAgentUpdateFailureHint, getManualAgentUpdateMessage } from './messages'
+export { getAgentUpdateFailureHint, getManualAgentUpdateMessage, getUntrackedPathAgentUpdateMessage } from './messages'
 export {
   agentUpdateProviders,
   canResolveAgentUpdate,

--- a/src/agent-update/messages.ts
+++ b/src/agent-update/messages.ts
@@ -5,6 +5,10 @@ export function getManualAgentUpdateMessage(agent: Pick<AgentDefinition, 'displa
   return `${agent.displayName} uses a manually managed install source. Please check for updates manually.`
 }
 
+export function getUntrackedPathAgentUpdateMessage(agent: Pick<AgentDefinition, 'displayName' | 'name'>): string {
+  return `${agent.displayName} is detected in PATH but not tracked as a Quantex-managed install. Use \`quantex inspect ${agent.name} --json\` to confirm the source, then reinstall through Quantex if you want \`quantex update --all\` to manage it.`
+}
+
 export function getAgentUpdateFailureHint(
   agent: Pick<AgentDefinition, 'displayName' | 'homepage' | 'selfUpdate'>,
   strategy: AgentUpdateStrategy,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -2,7 +2,12 @@ import type { AgentDefinition, InstallMethod, ManagedInstallType } from '../agen
 import type { CommandResult } from '../output/types'
 import type { ManagedPackageSpec } from '../package-manager'
 import type { InstalledAgentState } from '../state'
-import { getAgentUpdateFailureHint, getAgentUpdateStrategy, getManualAgentUpdateMessage } from '../agent-update'
+import {
+  getAgentUpdateFailureHint,
+  getAgentUpdateStrategy,
+  getManualAgentUpdateMessage,
+  getUntrackedPathAgentUpdateMessage,
+} from '../agent-update'
 import { createErrorResult, createSuccessResult, emitCommandEvent, emitCommandResult } from '../output'
 import { updateAgent, updateAgentsByType } from '../package-manager'
 import { resolveAgent } from '../services/agents'
@@ -245,6 +250,15 @@ async function executePlannedUpdates(
     pushUpdateResult(results, {
       displayName: inspection.agent.displayName,
       message: getManualAgentUpdateMessage(inspection.agent),
+      name: inspection.agent.name,
+      status: 'manual-required',
+    })
+  }
+
+  for (const inspection of plan.untrackedInPath) {
+    pushUpdateResult(results, {
+      displayName: inspection.agent.displayName,
+      message: getUntrackedPathAgentUpdateMessage(inspection.agent),
       name: inspection.agent.name,
       status: 'manual-required',
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
   kilo,
   opencode,
   pi,
+  qoder,
 } from './agents'
 export type {
   AgentDefinition,

--- a/src/planning/updates.ts
+++ b/src/planning/updates.ts
@@ -14,10 +14,16 @@ export interface UpdatePlan {
   grouped: Record<ManagedInstallType, UpdatePlanEntry[]>
   manual: UpdatePlanEntry[]
   skippedManualCheck: AgentInspection[]
+  untrackedInPath: AgentInspection[]
   upToDate: AgentInspection[]
 }
 
-export function createUpdatePlan(inspections: AgentInspection[]): UpdatePlan {
+export function createUpdatePlan(
+  inspections: AgentInspection[],
+  options: {
+    skipUntrackedInPath?: boolean
+  } = {},
+): UpdatePlan {
   const grouped: Record<ManagedInstallType, UpdatePlanEntry[]> = {
     bun: [],
     npm: [],
@@ -26,10 +32,16 @@ export function createUpdatePlan(inspections: AgentInspection[]): UpdatePlan {
   }
   const manual: UpdatePlanEntry[] = []
   const skippedManualCheck: AgentInspection[] = []
+  const untrackedInPath: AgentInspection[] = []
   const upToDate: AgentInspection[] = []
 
   for (const inspection of inspections) {
     if (!inspection.inPath) continue
+
+    if (options.skipUntrackedInPath && !inspection.installedState) {
+      untrackedInPath.push(inspection)
+      continue
+    }
 
     if (shouldSkipUnknownManualUpdate(inspection)) {
       skippedManualCheck.push(inspection)
@@ -76,6 +88,7 @@ export function createUpdatePlan(inspections: AgentInspection[]): UpdatePlan {
     grouped,
     manual,
     skippedManualCheck,
+    untrackedInPath,
     upToDate,
   }
 }

--- a/src/services/update.ts
+++ b/src/services/update.ts
@@ -30,6 +30,7 @@ export interface PlannedAgentUpdates {
   grouped: ManagedUpdateBucket[]
   manual: PendingAgentUpdate[]
   skippedManualCheck: AgentInspection[]
+  untrackedInPath: AgentInspection[]
   upToDate: AgentInspection[]
 }
 
@@ -51,7 +52,9 @@ export async function getSingleAgentUpdateStatus(agent: AgentDefinition): Promis
 }
 
 export async function planAgentUpdates(): Promise<PlannedAgentUpdates> {
-  return buildPlannedAgentUpdates(await inspectRegisteredAgents())
+  return buildPlannedAgentUpdates(await inspectRegisteredAgents(), {
+    skipUntrackedInPath: true,
+  })
 }
 
 export async function planSingleAgentUpdate(
@@ -64,8 +67,13 @@ export async function planSingleAgentUpdate(
   }
 }
 
-function buildPlannedAgentUpdates(inspections: AgentInspection[]): PlannedAgentUpdates {
-  const plan = updatePlanning.createUpdatePlan(inspections)
+function buildPlannedAgentUpdates(
+  inspections: AgentInspection[],
+  options: {
+    skipUntrackedInPath?: boolean
+  } = {},
+): PlannedAgentUpdates {
+  const plan = updatePlanning.createUpdatePlan(inspections, options)
   const grouped = groupedInstallerOrder
     .map(type => createManagedUpdateBucket(type, plan.grouped[type]))
     .filter((bucket): bucket is ManagedUpdateBucket => bucket !== undefined)
@@ -75,6 +83,7 @@ function buildPlannedAgentUpdates(inspections: AgentInspection[]): PlannedAgentU
     grouped,
     manual: plan.manual.map(entry => toPendingAgentUpdate(entry.inspection)),
     skippedManualCheck: plan.skippedManualCheck,
+    untrackedInPath: plan.untrackedInPath,
     upToDate: plan.upToDate,
   }
 }

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -319,6 +319,11 @@ describe('qoder', () => {
     ).toBeDefined()
     expect(qoder.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
   })
+
+  it('uses qodercli as the executable binary while keeping qoder as the slug', () => {
+    expect(qoder.name).toBe('qoder')
+    expect(qoder.binaryName).toBe('qodercli')
+  })
 })
 
 describe('install command formatting', () => {

--- a/test/commands/update.test.ts
+++ b/test/commands/update.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as agents from '../../src/agents'
-import { setCliContext } from '../../src/cli-context'
+import { resetCliContext, setCliContext } from '../../src/cli-context'
 import { updateCommand } from '../../src/commands/update'
 import * as pm from '../../src/package-manager'
 import * as state from '../../src/state'
@@ -47,6 +47,7 @@ describe('updateCommand', () => {
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    resetCliContext()
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
     agentSpy.mockClear()
@@ -60,6 +61,7 @@ describe('updateCommand', () => {
   })
 
   afterEach(() => {
+    resetCliContext()
     logSpy.mockRestore()
     stdoutWriteSpy.mockRestore()
   })
@@ -128,13 +130,13 @@ describe('updateCommand', () => {
     await updateCommand(undefined, true)
     expect(updateAgentsByTypeSpy).toHaveBeenCalledWith('bun', [
       { packageName: 'test-pkg', packageTargetKind: undefined },
-      { packageName: 'pkg2', packageTargetKind: undefined },
     ])
     expect(updateSpy).not.toHaveBeenCalled()
     const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
     expect(output).toContain('Updating Test Agent via managed/bun... (1.0.0 -> 2.0.0)')
-    expect(output).toContain('Updating Agent 2 via managed/bun... (1.0.0 -> 2.0.0)')
-    expect(output).toContain('Summary: updated 2')
+    expect(output).toContain('Agent 2: manual action required.')
+    expect(output).toContain('detected in PATH but not tracked as a Quantex-managed install')
+    expect(output).toContain('Summary: updated 1, manual 1')
   })
 
   it('skips detected PATH installs without auto-update support for --all', async () => {
@@ -164,12 +166,12 @@ describe('updateCommand', () => {
 
     const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
     expect(output).toContain('Manual Agent: manual action required.')
-    expect(output).toContain('Next step: Manual Agent uses a manually managed install source')
+    expect(output).toContain('detected in PATH but not tracked as a Quantex-managed install')
     expect(output).not.toContain('Updating Manual Agent')
     expect(output).not.toContain('Failed to update Manual Agent')
   })
 
-  it('updates detected PATH installs through the agent update command for --all', async () => {
+  it('skips detected PATH installs with self-update support for --all when they are untracked', async () => {
     const selfUpdatingAgent = {
       ...testAgent,
       name: 'self-updating-agent',
@@ -195,8 +197,42 @@ describe('updateCommand', () => {
 
     await updateCommand(undefined, true)
 
-    expect(updateSpy).toHaveBeenCalledWith(selfUpdatingAgent, undefined)
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(updateAgentsByTypeSpy).not.toHaveBeenCalled()
 
+    const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
+    expect(output).toContain('Self Updating Agent: manual action required.')
+    expect(output).toContain('detected in PATH but not tracked as a Quantex-managed install')
+    expect(output).toContain('quantex inspect self-updating-agent --json')
+  })
+
+  it('still allows explicit single-agent updates for untracked PATH installs with self-update support', async () => {
+    const selfUpdatingAgent = {
+      ...testAgent,
+      name: 'self-updating-agent',
+      binaryName: 'self-updating-bin',
+      displayName: 'Self Updating Agent',
+      packages: undefined,
+      selfUpdate: {
+        command: ['self-updating-bin', 'update'],
+      },
+      platforms: {
+        linux: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+        macos: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+        windows: [{ type: 'script' as const, command: 'irm https://example.com/install | iex' }],
+      },
+    }
+
+    agentSpy.mockReturnValue(selfUpdatingAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    installedVerSpy.mockResolvedValue('1.0.0')
+    latestVerSpy.mockResolvedValue(undefined)
+    installedStateSpy.mockResolvedValue(undefined)
+    updateSpy.mockResolvedValue({ success: true })
+
+    await updateCommand('self-updating-agent', false)
+
+    expect(updateSpy).toHaveBeenCalledWith(selfUpdatingAgent, undefined)
     const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
     expect(output).toContain('Updating Self Updating Agent via self-update... (1.0.0 -> latest)')
     expect(output).toContain('Self Updating Agent updated successfully')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,6 +13,7 @@ import {
   kilo,
   opencode,
   pi,
+  qoder,
 } from '../src/index'
 
 describe('agent registry', () => {
@@ -77,6 +78,14 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('kilo')
   })
 
+  it('qoder has correct structure', () => {
+    const agent = getAgentByNameOrAlias('qoder')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('Qoder CLI')
+    expect(agent!.packages?.npm).toBe('@qoder-ai/qodercli')
+    expect(agent!.binaryName).toBe('qodercli')
+  })
+
   it('re-exports all built-in agents from root index', () => {
     expect(codex.name).toBe('codex')
     expect(copilot.name).toBe('copilot')
@@ -86,6 +95,7 @@ describe('agent definitions', () => {
     expect(kilo.name).toBe('kilo')
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')
+    expect(qoder.name).toBe('qoder')
   })
 })
 


### PR DESCRIPTION
## Summary
- keep Qoder on the existing `qoder` slug while locking in that it executes the `qodercli` binary
- change `qtx update --all` to skip agents that are only detected in PATH and are not tracked by Quantex state
- narrow pre-commit `oxfmt` targets so archived OpenSpec `.openspec.yaml` files do not block commit closure
- sync and archive the related OpenSpec changes

## Linked Artifacts
- Issue: N/A
- ADR: N/A
- OpenSpec: `openspec/changes/archive/2026-04-28-fix-qodercli-canonical-command/`
- OpenSpec: `openspec/changes/archive/2026-04-28-fix-precommit-oxfmt-yaml-targets/`
- Discussion: N/A

## Validation
- [x] `bun run openspec:validate`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test`
- [ ] Not run, explained below

## Release Intent
- Release: not applicable - this fixes guarded lifecycle/update behavior and commit-hook targeting without changing the published command surface beyond the bugfix.

## Docs Updated
- [x] Not needed
- [x] `openspec/...`
- [ ] `docs/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check
- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check
- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is already archived by this PR.
- [x] Release is not applicable.
