### PR TITLE
fix(release): exclude standalone binaries from managed package

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Smoke check current runner release binary
         run: bun run release:smoke
 
+      - name: Verify managed-install package contents
+        run: bun run package:check
+
       - name: Upload release build artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,6 +153,10 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         run: bun run release:smoke
 
+      - name: Verify managed-install package contents
+        if: ${{ steps.release.outputs.release_created }}
+        run: bun run package:check
+
       - name: Publish npm package
         if: ${{ steps.release.outputs.release_created }}
         run: npm publish --access public --ignore-scripts --tag ${{ steps.channel.outputs.npm_tag }}

--- a/docs/runbooks/release-and-self-upgrade-debugging.md
+++ b/docs/runbooks/release-and-self-upgrade-debugging.md
@@ -9,6 +9,7 @@ Provide a repeatable path for debugging Quantex release artifacts, release metad
 - `quantex upgrade` failed and the failure might be in release metadata, download, checksum, verify, or install-source detection
 - a release build completed but you are not sure whether the publishable binary for the current platform is actually runnable
 - `manifest.json` or `SHA256SUMS.txt` looks suspicious or out of sync with built binaries
+- the npm or Bun install package looks much larger than the JS CLI runtime should require
 - you need to validate a release candidate locally before trusting the GitHub workflow
 
 ## Inputs
@@ -17,6 +18,7 @@ Provide a repeatable path for debugging Quantex release artifacts, release metad
 - `bun run build:bin`
 - `bun run release:artifacts`
 - `bun run release:smoke`
+- `bun run package:check`
 - `quantex upgrade --check`
 - `quantex doctor`
 - `dist/bin/manifest.json`
@@ -30,14 +32,16 @@ Prefer this order:
 
 1. Confirm the current self-upgrade view from the CLI.
 2. Rebuild the local release artifacts.
-3. Verify metadata consistency.
-4. Smoke-check the current runner binary.
-5. Only then debug deeper provider or replacement behavior.
+3. Verify managed-install package contents.
+4. Verify metadata consistency.
+5. Smoke-check the current runner binary.
+6. Only then debug deeper provider or replacement behavior.
 
 Why this order:
 
 - `upgrade --check` and `doctor` tell you whether the problem is visible from the user surface
 - local rebuilds separate release-pipeline bugs from machine-specific state
+- package verification catches accidental npm/bun package bloat before you debug release metadata
 - metadata validation catches manifest and checksum drift before you inspect binary replacement logic
 - smoke validation tells you whether the current platform artifact is actually executable
 
@@ -81,6 +85,7 @@ Run:
 bun run build
 bun run build:bin
 bun run release:artifacts
+bun run package:check
 ```
 
 Expected outputs:
@@ -94,7 +99,27 @@ If this fails:
 - `build:bin` failure usually means the compiled release targets are broken
 - `release:artifacts` failure usually means checksum or manifest generation assumptions no longer match produced files
 
-### 3. Inspect manifest and checksum consistency
+### 3. Verify managed-install package contents
+
+Canonical validator:
+
+```bash
+bun run package:check
+```
+
+What this should guarantee:
+
+- the npm tarball excludes every `dist/bin/` entry even if standalone release binaries exist locally
+- the tarball still contains the runtime CLI files needed by managed installs
+
+Common symptoms and likely causes:
+
+- `dist/bin/...` still appears in the pack output:
+  `package.json#files` or another packaging rule started including standalone release artifacts again
+- missing `dist/cli.mjs`, `dist/index.mjs`, or `scripts/postinstall.cjs`:
+  the packlist was tightened too far and now drops files required by Bun/npm installs
+
+### 4. Inspect manifest and checksum consistency
 
 Canonical validator:
 
@@ -120,7 +145,7 @@ Common symptoms and likely causes:
 - invalid asset name:
   build target naming changed without updating release-artifact parsing
 
-### 4. Smoke-check the current runner binary
+### 5. Smoke-check the current runner binary
 
 Canonical smoke command:
 
@@ -149,7 +174,7 @@ If smoke fails:
 - checksum mismatch means metadata and binary contents drifted
 - `--version` execution failure means the produced binary is not publishable even if metadata looks correct
 
-### 5. Debug binary self-upgrade replacement behavior
+### 6. Debug binary self-upgrade replacement behavior
 
 If metadata and smoke validation are already green, move into runtime replacement debugging.
 
@@ -172,7 +197,7 @@ Focus areas:
 - post-replacement `--version` verification
 - rollback from `.bak` when verification fails
 
-### 6. Debug install-source detection and state drift
+### 7. Debug install-source detection and state drift
 
 If the wrong provider is chosen, inspect install-source detection before touching release code.
 

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -66,6 +66,7 @@ When release-please reports that a GitHub Release was created, the workflow:
 - builds binaries
 - generates release artifacts
 - runs `release:smoke`
+- runs `package:check`
 - publishes to npm
 - uploads binaries to the GitHub Release
 
@@ -152,6 +153,7 @@ bun run build
 bun run build:bin
 bun run release:artifacts
 bun run release:smoke
+bun run package:check
 ```
 
 `release:artifacts` must fail if the release manifest is missing any required platform binary:
@@ -161,6 +163,8 @@ bun run release:smoke
 - `quantex-linux-arm64`
 - `quantex-linux-x64`
 - `quantex-windows-x64.exe`
+
+`package:check` must fail if the managed-install tarball still contains any `dist/bin/` entries after `build:bin` has populated standalone release outputs.
 
 ## CI coverage split
 

--- a/openspec/changes/reduce-release-artifact-size/.openspec.yaml
+++ b/openspec/changes/reduce-release-artifact-size/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/reduce-release-artifact-size/design.md
+++ b/openspec/changes/reduce-release-artifact-size/design.md
@@ -1,0 +1,48 @@
+## Context
+
+The release workflow builds both the JS package (`bun run build`) and standalone binaries (`bun run build:bin`) before running `npm publish --ignore-scripts`. Because `package.json` currently publishes the whole `dist/` tree, the managed-install tarball includes `dist/bin/manifest.json`, `SHA256SUMS.txt`, and every standalone binary for macOS, Linux, and Windows.
+
+That behavior is not needed for Bun/npm installs. Managed installs execute `dist/cli.mjs`; standalone binaries are distributed separately through GitHub Releases and used by the binary self-upgrade path. The problem is therefore in package distribution boundaries, not in binary compilation itself.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the npm package for Bun/npm installs limited to the JS CLI runtime and required install scripts.
+- Preserve the existing standalone release binary workflow under `dist/bin` for release metadata, smoke checks, and GitHub Releases.
+- Add a regression check that catches package bloat if `dist/bin` is accidentally re-included later.
+
+**Non-Goals:**
+
+- Changing standalone binary filenames, manifest structure, or self-upgrade download behavior
+- Reworking the release workflow order or removing `build:bin`
+- Optimizing Bun-compiled binary size itself
+
+## Decisions
+
+### Use `package.json` packlist exclusions as the source of truth
+
+The published package should be fixed where npm determines package contents: `package.json#files`. This keeps the release workflow intact while ensuring that even if `dist/bin` exists locally, it is omitted from the tarball shipped to npm and then consumed by `bun add -g` / `npm i -g`.
+
+Alternative considered:
+
+- Move standalone binaries outside `dist/`: works, but creates broader churn across release scripts and docs for no user-facing gain.
+- Publish before `build:bin`: avoids the issue in CI, but leaves local `npm pack` and any future workflow changes fragile.
+
+### Verify the packed tarball directly
+
+The regression check should inspect the actual npm pack output instead of only asserting config strings. That makes the validation reflect the real managed-install artifact boundary and catches mistakes in glob semantics.
+
+Alternative considered:
+
+- Test only the `files` array in `package.json`: cheaper, but it would not prove the packlist behaves as intended.
+
+### Keep release-binary docs focused on maintainers
+
+This change does not alter user-facing install commands, so product README updates are unnecessary. The durable knowledge belongs in release/debug runbooks used by maintainers when both publishable package assets and standalone binaries exist in the same working tree.
+
+## Risks / Trade-offs
+
+- [Packlist negation behaves differently than expected] -> Validate with `npm pack --json` in automated checks and local validation.
+- [Future release tooling starts depending on `dist/bin` inside the npm tarball] -> Keep the new package-distribution spec explicit so regressions are treated as contract changes.
+- [Extra validation makes release checks slightly slower] -> Scope the verification to pack metadata inspection, not full install smoke tests.

--- a/openspec/changes/reduce-release-artifact-size/proposal.md
+++ b/openspec/changes/reduce-release-artifact-size/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`npm publish` currently runs after `build:bin`, so the package tarball for managed installs picks up `dist/bin` and ships every standalone release binary for every platform. A local `npm pack --json` on April 28, 2026 showed a 169 MB tarball with 445 MB unpacked size, which is unnecessary for Bun/npm users and makes managed installs much heavier than the actual JS CLI package.
+
+## What Changes
+
+- Exclude `dist/bin` and other standalone release-only outputs from the published npm package used by Bun/npm installs.
+- Add a regression check that proves the managed-install tarball still includes the CLI runtime entrypoints while excluding standalone release binaries.
+- Update release/debug runbooks so maintainers know how to validate managed-install package contents when release assets have also been built locally.
+
+## Capabilities
+
+### New Capabilities
+
+- `package-distribution`: Define what the published managed-install package may and may not ship when release-only binaries exist in the working tree.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `package.json` packlist behavior for npm/Bun managed installs
+- release packaging validation and related tests
+- release/debug runbook guidance for validating published package contents

--- a/openspec/changes/reduce-release-artifact-size/specs/package-distribution/spec.md
+++ b/openspec/changes/reduce-release-artifact-size/specs/package-distribution/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Managed-install package MUST exclude standalone release binaries
+
+The npm package consumed by Bun and npm managed installs SHALL exclude standalone release binaries and release-only metadata, even when those files exist locally because release assets were built before publish.
+
+#### Scenario: Release binaries exist before npm publish
+
+- **WHEN** Quantex packs or publishes the managed-install package after `build:bin` has produced files under `dist/bin`
+- **THEN** the resulting npm tarball does not contain platform binaries from `dist/bin`
+- **AND** it does not contain release-only metadata such as `dist/bin/manifest.json` or `dist/bin/SHA256SUMS.txt`
+
+### Requirement: Managed-install package MUST keep runtime CLI files
+
+The npm package consumed by Bun and npm managed installs SHALL still include the runtime files needed to execute the CLI and postinstall entrypoints.
+
+#### Scenario: User installs Quantex from npm or Bun
+
+- **WHEN** the managed-install package is packed for publication
+- **THEN** it still contains the runtime CLI files under `dist/` needed for `qtx` and `quantex`
+- **AND** it still contains any install-time entrypoints required by the published package contract

--- a/openspec/changes/reduce-release-artifact-size/tasks.md
+++ b/openspec/changes/reduce-release-artifact-size/tasks.md
@@ -1,0 +1,13 @@
+## 1. Managed Package Boundary
+
+- [x] 1.1 Exclude standalone release binaries under `dist/bin` from the published npm package while keeping the runtime CLI files publishable.
+- [x] 1.2 Add a regression check or automated test that validates the actual packed tarball does not contain `dist/bin` entries.
+
+## 2. Maintainer Guidance
+
+- [x] 2.1 Update release/debug runbooks to document how to validate managed-install package contents when `build:bin` has also been run locally.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run test`.
+- [x] 3.2 Run a pack verification command that proves the npm tarball excludes `dist/bin`.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
   },
   "files": [
     "dist",
+    "!dist/bin",
+    "!dist/bin/**",
     "scripts/postinstall.cjs"
   ],
   "type": "module",
@@ -44,6 +46,7 @@
     "openspec:show": "openspec show --no-interactive",
     "openspec:status": "openspec status --json",
     "openspec:validate": "openspec validate --all --no-interactive",
+    "package:check": "bun run scripts/verify-package-distribution.ts",
     "postinstall": "node scripts/postinstall.cjs",
     "prebuild": "bun run scripts/write-build-metadata.ts",
     "prepare": "simple-git-hooks",

--- a/scripts/verify-package-distribution.ts
+++ b/scripts/verify-package-distribution.ts
@@ -1,0 +1,64 @@
+import { rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import process from 'node:process'
+
+interface PackedFile {
+  path: string
+}
+
+interface PackedPackage {
+  files?: PackedFile[]
+  filename?: string
+}
+
+const proc = Bun.spawn(['npm', 'pack', '--dry-run', '--json'], {
+  cwd: process.cwd(),
+  env: process.env,
+  stdio: ['ignore', 'pipe', 'pipe'] as const,
+})
+
+const [stdout, stderr, exitCode] = await Promise.all([
+  proc.stdout ? new Response(proc.stdout).text() : Promise.resolve(''),
+  proc.stderr ? new Response(proc.stderr).text() : Promise.resolve(''),
+  proc.exited,
+])
+
+if (exitCode !== 0) {
+  throw new Error(`npm pack --dry-run --json failed with exit code ${exitCode}.\n${stderr.trim() || stdout.trim()}`)
+}
+
+const packedPackages = parsePackOutput(stdout)
+const packedPackage = packedPackages[0]
+
+if (!packedPackage) throw new Error('npm pack --dry-run --json did not return package metadata.')
+
+const packedFiles = packedPackage.files ?? []
+const forbiddenFiles = packedFiles.filter(file => file.path.startsWith('dist/bin/'))
+
+if (forbiddenFiles.length > 0) {
+  throw new Error(
+    `Managed-install package unexpectedly includes standalone release artifacts:\n${forbiddenFiles
+      .map(file => `- ${file.path}`)
+      .join('\n')}`,
+  )
+}
+
+const requiredFiles = ['dist/cli.mjs', 'dist/index.mjs', 'scripts/postinstall.cjs']
+const missingFiles = requiredFiles.filter(requiredPath => !packedFiles.some(file => file.path === requiredPath))
+
+if (missingFiles.length > 0) {
+  throw new Error(`Managed-install package is missing required runtime files:\n${missingFiles.join('\n')}`)
+}
+
+if (packedPackage.filename) {
+  await rm(join(process.cwd(), packedPackage.filename), { force: true })
+}
+
+console.log(`Managed-install package excludes dist/bin and keeps runtime files (${requiredFiles.join(', ')}).`)
+
+function parsePackOutput(packStdout: string): PackedPackage[] {
+  const jsonStart = packStdout.lastIndexOf('\n[')
+  const jsonText = (jsonStart >= 0 ? packStdout.slice(jsonStart + 1) : packStdout).trim()
+
+  return JSON.parse(jsonText) as PackedPackage[]
+}


### PR DESCRIPTION
## Summary

- exclude `dist/bin` from the managed-install npm package so Bun/npm users do not download standalone binaries for every platform
- add a `package:check` validator that inspects `npm pack --dry-run --json` after release binaries have been built
- wire the new validator into release workflows and document the package-boundary check in the release runbooks

## Linked Artifacts

- OpenSpec: `openspec/changes/reduce-release-artifact-size/`
- Runbook: `docs/runbooks/releasing-quantex.md`
- Runbook: `docs/runbooks/release-and-self-upgrade-debugging.md`

## Validation

- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run build:bin`
- [x] `bun run release:artifacts`
- [x] `bun run release:smoke`
- [x] `bun run package:check`
- [x] `bun run openspec:validate`

## Release Intent

- Release: patch - fixes managed-install package bloat by preventing release-only binaries from shipping in the npm tarball

## Docs Updated

- [x] `docs/runbooks/releasing-quantex.md`
- [x] `docs/runbooks/release-and-self-upgrade-debugging.md`
- [x] `openspec/changes/reduce-release-artifact-size/`

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge, spec sync, and archive follow-up.
- [x] Release is delegated to release automation after merge.

## Notes

`npm pack --json` dropped from roughly 169 MB packed / 445 MB unpacked to about 45 KB packed / 167 KB unpacked once `dist/bin` was excluded from the managed-install tarball.
