### PR TITLE
docs(openspec): archive reduce-release-artifact-size change

### DIFF
--- a/openspec/specs/package-distribution/spec.md
+++ b/openspec/specs/package-distribution/spec.md
@@ -1,8 +1,11 @@
 # package-distribution Specification
 
 ## Purpose
-TBD - created by archiving change reduce-release-artifact-size. Update Purpose after archive.
+
+Define the current observable contract for what the managed-install npm package may ship when standalone release binaries also exist in the working tree.
+
 ## Requirements
+
 ### Requirement: Managed-install package MUST exclude standalone release binaries
 
 The npm package consumed by Bun and npm managed installs SHALL exclude standalone release binaries and release-only metadata, even when those files exist locally because release assets were built before publish.


### PR DESCRIPTION
## Summary

- sync the accepted `package-distribution` capability into `openspec/specs/`
- archive the completed `reduce-release-artifact-size` change under `openspec/changes/archive/`
- complete the post-merge OpenSpec closure step for the managed-package-size fix

## Linked Artifacts

- Merged PR: #91
- OpenSpec archive: `openspec/changes/archive/2026-04-28-reduce-release-artifact-size/`
- Spec: `openspec/specs/package-distribution/spec.md`

## Validation

- [x] `bun run openspec:validate`
- [ ] Not needed: no product code changed in this archive follow-up

## Release Intent

- Release: not applicable - OpenSpec/spec archive follow-up after an already merged product change

## Docs Updated

- [x] `openspec/specs/package-distribution/spec.md`
- [x] `openspec/changes/archive/2026-04-28-reduce-release-artifact-size/`

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change will be archived by this PR once merged.
- [x] Release is not applicable for this archive-only follow-up.

## Notes

This PR exists only to close the durable OpenSpec loop after #91 merged.
