### PR TITLE
fix(config): upgrade commander and remove c12

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,7 @@
     "": {
       "name": "silver-cli",
       "dependencies": {
-        "c12": "^3.0.4",
-        "commander": "^13.1.0",
+        "commander": "^14.0.3",
         "picocolors": "^1.1.1",
         "prompts": "^2.4.2",
       },
@@ -362,8 +361,6 @@
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
-    "c12": ["c12@3.3.4", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.4", "defu": "^6.1.6", "dotenv": "^17.3.1", "exsolve": "^1.0.8", "giget": "^3.2.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.1.0", "pkg-types": "^2.3.0", "rc9": "^3.0.1" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA=="],
-
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
@@ -371,8 +368,6 @@
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
-
-    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
@@ -388,17 +383,11 @@
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 
-    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
-
-    "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
-
-    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
-
-    "dotenv": ["dotenv@17.4.1", "", {}, "sha512-k8DaKGP6r1G30Lx8V4+pCsLzKr8vLmV2paqEj1Y55GdAgJuIqpRp5FfajGF8KtwMxCz9qJc6wUIJnm053d/WCw=="],
 
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
 
@@ -418,8 +407,6 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
-    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
-
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
@@ -433,8 +420,6 @@
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
-
-    "giget": ["giget@3.2.0", "", { "bin": { "giget": "dist/cli.mjs" } }, "sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -484,8 +469,6 @@
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
-    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
-
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
@@ -496,13 +479,9 @@
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
-
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
-
-    "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
@@ -513,10 +492,6 @@
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
-
-    "rc9": ["rc9@3.0.1", "", { "dependencies": { "defu": "^6.1.6", "destr": "^2.0.5" } }, "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ=="],
-
-    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -606,11 +581,7 @@
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "@fission-ai/openspec/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
     "cli-truncate/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
-
-    "lint-staged/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "listr2/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 

--- a/openspec/changes/upgrade-commander-assess-c12/.openspec.yaml
+++ b/openspec/changes/upgrade-commander-assess-c12/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/upgrade-commander-assess-c12/design.md
+++ b/openspec/changes/upgrade-commander-assess-c12/design.md
@@ -1,0 +1,48 @@
+## Context
+
+Quantex documents user configuration as `~/.quantex/config.json`, and the command tests read and write that exact file. Despite that, `src/config/index.ts` currently routes loading through `c12`, which brings support for additional config formats, extends chains, RC files, and runtime loading helpers that Quantex neither documents nor tests.
+
+Separately, the CLI uses `commander@13.1.0`, while upstream `commander` has a stable `14.0.3` release. Upstream documents that Commander 14 requires Node 20+, and Quantex's current local/runtime toolchain already uses Node 22.22.2 and Bun 1.3.9, with CI and release automation on modern Node as well.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move `commander` to the latest stable v14 release without changing Quantex's intended CLI behavior.
+- Remove `c12` and its config-loading surface area when Quantex only needs a JSON file loader plus normalization.
+- Codify the documented config contract in OpenSpec and tests so future changes are explicit.
+
+**Non-Goals:**
+
+- Expanding config support to YAML, TOML, RC files, or `extends`
+- Refactoring the CLI command catalog beyond compatibility changes required by the dependency upgrade
+- Changing user-facing config keys or their normalization rules
+
+## Decisions
+
+### Upgrade Commander to 14.0.3
+
+Use the current stable Commander 14 release because it is the latest supported upstream line before the upcoming Commander 15 ESM-only transition. Quantex is already ESM and runs on Bun/modern Node, so the Node 20 support floor does not conflict with current repository expectations.
+
+Alternative considered:
+
+- Stay on Commander 13: lower churn, but no clear compatibility benefit given the current runtime floor.
+- Jump to Commander 15 prerelease: unnecessary risk for no immediate user benefit.
+
+### Replace c12 with a direct JSON loader
+
+Implement config loading directly in `src/config/index.ts` using `readFile`, `JSON.parse`, and the existing normalization logic. This matches the documented `~/.quantex/config.json` contract and removes unused support for extra config formats and dynamic loaders.
+
+Alternative considered:
+
+- Keep `c12`: simplest short-term path, but it keeps extra dependency weight and a broader implicit config surface than Quantex intends to support.
+
+### Add config-file regression coverage
+
+Update tests so they verify loading from an actual `config.json` file instead of mocking `c12`. This makes the new config surface explicit and catches future drift if the loader changes again.
+
+## Risks / Trade-offs
+
+- [Users may have relied on undocumented non-JSON config formats through c12] -> Quantex docs and tests already point only to `~/.quantex/config.json`; codify that contract in OpenSpec and keep normalization behavior unchanged.
+- [Commander 14 could expose CLI parsing differences] -> run the full existing CLI and contract test suite after upgrading.
+- [Removing c12 changes error behavior for malformed config files] -> preserve a forgiving fallback to `defaultConfig` when the file is missing or unparsable.

--- a/openspec/changes/upgrade-commander-assess-c12/proposal.md
+++ b/openspec/changes/upgrade-commander-assess-c12/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Quantex currently depends on `commander@13.1.0` for the CLI surface and `c12` for config loading. `commander` has a newer stable line compatible with the repository's current Node 22 and Bun 1.3 runtime, while `c12` provides a much broader config system than Quantex actually documents or tests today.
+
+## What Changes
+
+- Upgrade `commander` to the current stable v14 line after validating the Quantex CLI surface against its Node 20+ support floor.
+- Replace the current `c12`-backed config loader with a repo-native JSON loader that matches Quantex's documented `~/.quantex/config.json` contract.
+- Add regression coverage for loading and normalizing config directly from `config.json`.
+
+## Capabilities
+
+### New Capabilities
+
+- `config-surface`: defines the supported on-disk user config format and normalization behavior for Quantex.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- `package.json` and `bun.lock`
+- `src/cli.ts` dependency compatibility via `commander`
+- `src/config/` implementation and config-related tests
+- OpenSpec specs for the documented config contract

--- a/openspec/changes/upgrade-commander-assess-c12/specs/config-surface/spec.md
+++ b/openspec/changes/upgrade-commander-assess-c12/specs/config-surface/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: User config MUST load from quantex config.json
+
+Quantex SHALL load user configuration from `~/.quantex/config.json`, using the current home-directory resolution rules for the active platform.
+
+#### Scenario: User has a config file
+
+- **WHEN** Quantex resolves user configuration
+- **THEN** it reads `config.json` from the Quantex config directory under the active home directory
+- **AND** it does not require RC files, YAML, TOML, or config-extension layers to resolve the documented user config surface
+
+### Requirement: User config MUST normalize supported keys
+
+Quantex SHALL merge the config file with built-in defaults and normalize supported keys into the current runtime contract.
+
+#### Scenario: Config file contains supported overrides
+
+- **WHEN** `config.json` contains supported Quantex config keys
+- **THEN** Quantex applies those overrides on top of the built-in defaults
+- **AND** it normalizes enum and numeric values into the existing runtime shapes used by commands and services
+
+#### Scenario: Config file is missing or invalid
+
+- **WHEN** the user config file does not exist or cannot be parsed as valid JSON
+- **THEN** Quantex falls back to built-in defaults
+- **AND** it does not require the user to repair the file before non-mutating commands can continue with default settings

--- a/openspec/changes/upgrade-commander-assess-c12/tasks.md
+++ b/openspec/changes/upgrade-commander-assess-c12/tasks.md
@@ -1,0 +1,14 @@
+## 1. Dependency And Config Loader
+
+- [x] 1.1 Upgrade `commander` to the latest stable v14 release and refresh the lockfile.
+- [x] 1.2 Replace the `c12` config loader with a direct JSON config loader that preserves the documented `~/.quantex/config.json` contract.
+- [x] 1.3 Remove `c12` from dependencies if the direct loader keeps behavior and tests intact.
+
+## 2. Contract And Regression Coverage
+
+- [x] 2.1 Add or update OpenSpec artifacts to define the supported config file surface.
+- [x] 2.2 Update tests to verify loading and normalizing config directly from `config.json`.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run test`.

--- a/package.json
+++ b/package.json
@@ -58,8 +58,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "c12": "^3.0.4",
-    "commander": "^13.1.0",
+    "commander": "^14.0.3",
     "picocolors": "^1.1.1",
     "prompts": "^2.4.2"
   },

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,11 +1,8 @@
 import type { SelfUpdateChannel } from '../self/types'
-import type { Jiti } from 'jiti'
-import { loadConfig as c12LoadConfig } from 'c12'
 import { mkdir, readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
-import { pathToFileURL } from 'node:url'
 import { normalizeRegistryUrl } from '../utils/registry'
 import { defaultConfig } from './default'
 
@@ -31,24 +28,11 @@ export function getConfigFilePath(): string {
 }
 
 export async function loadConfig(): Promise<QuantexConfig> {
-  const jiti = {
-    import: async (id: string, options?: { default?: boolean }) => {
-      if (id.endsWith('.json')) {
-        return JSON.parse(await readFile(id, 'utf8'))
-      }
+  const normalizedConfig = {
+    ...defaultConfig,
+    ...(await readUserConfig()),
+  } as Record<string, unknown>
 
-      const module = await import(id.startsWith('file:') ? id : pathToFileURL(id).href)
-      return options?.default ? (module.default ?? module) : module
-    },
-  } as unknown as Jiti
-
-  const { config } = await c12LoadConfig({
-    name: 'quantex',
-    defaults: defaultConfig,
-    configFile: getConfigFilePath(),
-    jiti,
-  })
-  const normalizedConfig = config as Record<string, unknown>
   return {
     ...normalizedConfig,
     defaultPackageManager: normalizedConfig.defaultPackageManager === 'npm' ? 'npm' : 'bun',
@@ -74,6 +58,16 @@ export async function saveConfig(config: Record<string, unknown>): Promise<void>
   await Bun.write(getConfigFilePath(), `${JSON.stringify(config, null, 2)}\n`)
 }
 
+async function readUserConfig(): Promise<Record<string, unknown>> {
+  try {
+    const contents = await readFile(getConfigFilePath(), 'utf8')
+    const parsed = JSON.parse(contents) as unknown
+    return isPlainObject(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
 function normalizePositiveInteger(value: unknown, fallback: number): number {
   if (typeof value === 'number' && Number.isInteger(value) && value > 0) return value
 
@@ -83,4 +77,8 @@ function normalizePositiveInteger(value: unknown, fallback: number): number {
   }
 
   return fallback
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -14,8 +14,6 @@ const originalUserProfile = process.env.USERPROFILE
 
 afterAll(() => {
   loadConfigSpy.mockRestore()
-  process.env.HOME = originalHome
-  process.env.USERPROFILE = originalUserProfile
 })
 
 describe('configCommand', () => {
@@ -30,6 +28,8 @@ describe('configCommand', () => {
 
   afterEach(() => {
     logSpy.mockRestore()
+    process.env.HOME = originalHome
+    process.env.USERPROFILE = originalUserProfile
     if (existsSync(tempDir)) {
       rmSync(tempDir, { recursive: true, force: true })
     }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,15 +1,19 @@
-import { describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-vi.mock('c12', () => ({
-  loadConfig: vi.fn(() =>
-    Promise.resolve({
-      config: {
-        defaultPackageManager: 'bun',
-        npmBunUpdateStrategy: 'latest-major',
-      },
-    }),
-  ),
-}))
+const tempHome = join(tmpdir(), `quantex-config-test-${Date.now()}`)
+const configDir = join(tempHome, '.quantex')
+const configPath = join(configDir, 'config.json')
+const originalHome = process.env.HOME
+const originalUserProfile = process.env.USERPROFILE
+
+afterAll(() => {
+  process.env.HOME = originalHome
+  process.env.USERPROFILE = originalUserProfile
+})
 
 describe('defaultConfig', () => {
   it('has defaultPackageManager set to bun', async () => {
@@ -26,6 +30,8 @@ describe('defaultConfig', () => {
 
 describe('getConfigDir', () => {
   it('returns path ending with .quantex', async () => {
+    process.env.HOME = tempHome
+    process.env.USERPROFILE = tempHome
     const { getConfigDir } = await import('../src/config/index')
     const dir = getConfigDir()
     expect(dir.endsWith('.quantex')).toBe(true)
@@ -33,9 +39,63 @@ describe('getConfigDir', () => {
 })
 
 describe('loadConfig', () => {
+  beforeEach(() => {
+    process.env.HOME = tempHome
+    process.env.USERPROFILE = tempHome
+  })
+
+  afterEach(() => {
+    process.env.HOME = originalHome
+    process.env.USERPROFILE = originalUserProfile
+    if (existsSync(configDir)) rmSync(configDir, { recursive: true, force: true })
+  })
+
   it('returns config with normalized defaults', async () => {
     const { loadConfig } = await import('../src/config/index')
     const config = await loadConfig()
+    expect(config.defaultPackageManager).toBe('bun')
+    expect(config.networkRetries).toBe(2)
+    expect(config.networkTimeoutMs).toBe(10000)
+    expect(config.npmBunUpdateStrategy).toBe('latest-major')
+    expect(config.selfUpdateChannel).toBe('stable')
+    expect(config.selfUpdateRegistry).toBeUndefined()
+    expect(config.versionCacheTtlHours).toBe(6)
+  })
+
+  it('loads and normalizes values from config.json', async () => {
+    mkdirSync(configDir, { recursive: true })
+    writeFileSync(
+      configPath,
+      `${JSON.stringify({
+        defaultPackageManager: 'npm',
+        networkRetries: '4',
+        networkTimeoutMs: '15000',
+        npmBunUpdateStrategy: 'respect-semver',
+        selfUpdateChannel: 'beta',
+        selfUpdateRegistry: 'https://registry.npmjs.org/',
+        versionCacheTtlHours: '12',
+      })}\n`,
+    )
+
+    const { loadConfig } = await import('../src/config/index')
+    const config = await loadConfig()
+
+    expect(config.defaultPackageManager).toBe('npm')
+    expect(config.networkRetries).toBe(4)
+    expect(config.networkTimeoutMs).toBe(15000)
+    expect(config.npmBunUpdateStrategy).toBe('respect-semver')
+    expect(config.selfUpdateChannel).toBe('beta')
+    expect(config.selfUpdateRegistry).toBe('https://registry.npmjs.org')
+    expect(config.versionCacheTtlHours).toBe(12)
+  })
+
+  it('falls back to defaults when config.json is invalid', async () => {
+    mkdirSync(configDir, { recursive: true })
+    writeFileSync(configPath, '{invalid json\n')
+
+    const { loadConfig } = await import('../src/config/index')
+    const config = await loadConfig()
+
     expect(config.defaultPackageManager).toBe('bun')
     expect(config.networkRetries).toBe(2)
     expect(config.networkTimeoutMs).toBe(10000)


### PR DESCRIPTION
## Summary

- upgrade `commander` from the v13 line to `14.0.3`
- replace the `c12`-backed config loader with a repo-native `~/.quantex/config.json` loader
- add config-surface OpenSpec coverage plus regression tests for normalized and invalid `config.json` inputs

## Linked Artifacts

- OpenSpec: `openspec/changes/upgrade-commander-assess-c12/`
- Config loader: `src/config/index.ts`
- Tests: `test/config.test.ts`

## Validation

- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run openspec:validate`

## Release Intent

- Release: patch - dependency/config maintenance that changes runtime config loading implementation but preserves the documented `config.json` contract

## Docs Updated

- [x] `openspec/changes/upgrade-commander-assess-c12/`
- [x] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge, spec sync, and archive follow-up.
- [x] Release is delegated to release automation after merge.

## Notes

`c12` was only used in one place and Quantex already documents `~/.quantex/config.json` as the sole supported user config surface, so this PR narrows implementation to the contract the repo already exposes.
