### PR TITLE
docs(openspec): archive upgrade-commander-assess-c12 change

### DIFF
--- a/openspec/specs/config-surface/spec.md
+++ b/openspec/specs/config-surface/spec.md
@@ -1,8 +1,11 @@
 # config-surface Specification
 
 ## Purpose
-TBD - created by archiving change upgrade-commander-assess-c12. Update Purpose after archive.
+
+Define the current observable contract for Quantex user configuration loading and normalization.
+
 ## Requirements
+
 ### Requirement: User config MUST load from quantex config.json
 
 Quantex SHALL load user configuration from `~/.quantex/config.json`, using the current home-directory resolution rules for the active platform.


### PR DESCRIPTION
## Summary

- sync the accepted `config-surface` capability into `openspec/specs/`
- archive the completed `upgrade-commander-assess-c12` change under `openspec/changes/archive/`
- close the OpenSpec follow-up after the merged commander/c12 product change

## Linked Artifacts

- Merged PR: #95
- OpenSpec archive: `openspec/changes/archive/2026-04-28-upgrade-commander-assess-c12/`
- Spec: `openspec/specs/config-surface/spec.md`

## Validation

- [x] `bun run openspec:validate`
- [ ] Not needed: no product code changed in this archive follow-up

## Release Intent

- Release: not applicable - OpenSpec/spec archive follow-up after an already merged product change

## Docs Updated

- [x] `openspec/specs/config-surface/spec.md`
- [x] `openspec/changes/archive/2026-04-28-upgrade-commander-assess-c12/`

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change will be archived by this PR once merged.
- [x] Release is not applicable for this archive-only follow-up.

## Notes

This PR exists only to close the durable OpenSpec loop after #95 merged.
