### PR TITLE
fix: adopt untracked existing installs for managed updates

### DIFF
--- a/openspec/changes/adopt-untracked-agent-installs/.openspec.yaml
+++ b/openspec/changes/adopt-untracked-agent-installs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/adopt-untracked-agent-installs/design.md
+++ b/openspec/changes/adopt-untracked-agent-installs/design.md
@@ -1,0 +1,35 @@
+## Context
+
+Quantex already distinguishes between recorded install state and a bare `PATH` detection. That lets `update --all` avoid mutating binaries that Quantex did not install or track. The bug is that the prescribed recovery path does not work for single-method unmanaged agents such as Cursor CLI: `install` and `ensure` return early as soon as the binary is in `PATH`, so they never persist the script install state that batch update planning requires.
+
+The fix needs to preserve the existing safety boundary. A `PATH` hit alone is not enough to infer whether an agent came from Bun, npm, Homebrew, a vendor script, or some other manual setup. If Quantex guesses wrong, later update or uninstall operations could target the wrong lifecycle source.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let `install` / `ensure` reconcile an existing install into Quantex state when the current platform exposes one safe, unambiguous unmanaged install method.
+- Preserve the rule that `update --all` only acts on recorded install state.
+- Make ambiguous `PATH` detections clearly explain why they remain untracked.
+
+**Non-Goals:**
+
+- Do not auto-adopt agents with multiple plausible install sources.
+- Do not change batch update planning to act on untracked `PATH` detections again.
+- Do not introduce new interactive prompts or workflow-orchestration behavior.
+
+## Decisions
+
+- Treat an existing install as safely adoptable only when the current platform resolves exactly one supported install method and that method is unmanaged (`script` or `binary`). This is narrow, but it covers Cursor CLI and avoids inventing package-manager ownership.
+- Add a package-manager helper that persists the derived install state without re-running an installer. Command handlers will call it only after inspection proves the install is already present in `PATH`.
+- Keep the existing state model. Adopted installs will reuse the same `InstalledAgentState` shape as regular installs, including the unmanaged install command when available.
+- For `install` / `ensure`, distinguish three cases:
+  - tracked install already exists: no-op "already installed"
+  - untracked but safely adoptable existing install: record state and report that Quantex is now tracking it
+  - untracked and ambiguous existing install: no state change, and output explains that Quantex refused to guess the source
+
+## Risks / Trade-offs
+
+- [Narrow adoption scope] → Some existing installs with multiple supported methods will still require manual reinstall through Quantex. This is intentional; clearer messaging will explain why Quantex did not guess.
+- [State drift after adoption] → A user could later replace the binary outside Quantex. This is an existing lifecycle risk; future inspections still compare recorded state with runtime detection before choosing update behavior.
+- [Different human output paths] → Install and ensure now have a third "tracked existing install" outcome. Regression tests will pin the wording and structured result shape.

--- a/openspec/changes/adopt-untracked-agent-installs/proposal.md
+++ b/openspec/changes/adopt-untracked-agent-installs/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`quantex update --all` intentionally skips supported agents that are only detected in `PATH` and have no recorded Quantex install state. That safety boundary is correct, but the current remediation loop breaks for agents like Cursor CLI: `quantex install cursor` and `quantex ensure cursor` stop at "already installed" instead of recording the existing install, so the agent can never graduate from untracked `PATH` detection into Quantex-managed lifecycle state.
+
+## What Changes
+
+- Allow `quantex install <agent>` and `quantex ensure <agent>` to adopt an existing supported install into Quantex state when the current platform exposes exactly one unambiguous unmanaged install method for that agent.
+- Keep refusing to guess install ownership for ambiguous `PATH` detections, but replace the misleading "already installed" no-op with output that explains the install is still untracked.
+- Add regression coverage for Cursor-like script installs so a pre-existing binary can become tracked and then participate in `quantex update --all`.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: install-source reconciliation may record a safely identifiable existing install so later batch updates can use tracked state without guessing.
+
+## Impact
+
+- Affected code: `src/commands/install.ts`, `src/commands/ensure.ts`, `src/package-manager/`, `src/utils/install.ts`, and update-related command tests.
+- Affected contracts: the user-visible behavior of `install` / `ensure` for untracked `PATH` installs and the install-state precondition for `update --all`.
+- Dependencies: no new runtime dependency.

--- a/openspec/changes/adopt-untracked-agent-installs/specs/agent-update/spec.md
+++ b/openspec/changes/adopt-untracked-agent-installs/specs/agent-update/spec.md
@@ -1,0 +1,38 @@
+## MODIFIED Requirements
+
+### Requirement: Batch update MUST plan from recorded install sources
+
+Batch agent updates SHALL prioritize recorded actual install sources over candidate install methods declared for the agent.
+
+#### Scenario: Updating all installed agents
+
+- GIVEN the user runs `quantex update --all`
+- WHEN Quantex builds the update plan
+- THEN it groups work by the recorded actual install source where available
+- AND it does not rely only on the agent definition's possible install methods
+
+#### Scenario: Skipping untracked PATH detections during batch update
+
+- GIVEN a supported agent binary is available in `PATH`
+- AND Quantex has no recorded install state for that agent
+- WHEN the user runs `quantex update --all`
+- THEN Quantex does not execute managed update or self-update operations for that agent
+- AND the batch result explains that the agent was detected in `PATH` but is not tracked as a Quantex-managed install
+
+#### Scenario: Adopting a safely identifiable existing install
+
+- GIVEN a supported agent binary is available in `PATH`
+- AND Quantex has no recorded install state for that agent
+- AND the current platform exposes exactly one supported unmanaged install method for that agent
+- WHEN the user runs `quantex install <agent>` or `quantex ensure <agent>`
+- THEN Quantex records that install method as the agent's install state without re-running an installer
+- AND later `quantex update --all` plans updates from that recorded state
+
+#### Scenario: Refusing to guess an ambiguous existing install source
+
+- GIVEN a supported agent binary is available in `PATH`
+- AND Quantex has no recorded install state for that agent
+- AND the current platform exposes multiple plausible install methods or no unambiguous unmanaged install method
+- WHEN the user runs `quantex install <agent>` or `quantex ensure <agent>`
+- THEN Quantex does not invent or overwrite install state for that agent
+- AND the command explains that the install remains untracked

--- a/openspec/changes/adopt-untracked-agent-installs/tasks.md
+++ b/openspec/changes/adopt-untracked-agent-installs/tasks.md
@@ -1,0 +1,14 @@
+## 1. Existing Install Reconciliation
+
+- [x] 1.1 Add a safe adoption path that records an existing untracked install when the current platform exposes exactly one unmanaged install method.
+- [x] 1.2 Update `install` and `ensure` output so adopted installs and still-untracked installs are distinguished clearly.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add command tests for adopting an existing script install and for leaving ambiguous existing installs untracked.
+- [x] 2.2 Add update regression coverage proving a tracked script install participates in `quantex update --all`.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run openspec:validate`.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run test`.

--- a/src/commands/ensure.ts
+++ b/src/commands/ensure.ts
@@ -1,8 +1,9 @@
 import type { CommandResult } from '../output/types'
 import { createErrorResult, createSuccessResult, emitCommandEvent, emitCommandResult } from '../output'
-import { installAgent } from '../package-manager'
+import { installAgent, trackInstalledAgent } from '../package-manager'
 import { resolveAgentInspection } from '../services/agents'
 import { pc } from '../utils/color'
+import { getAdoptableExistingInstallMethod } from '../utils/install'
 import { createResourceLockedError } from '../utils/lifecycle-errors'
 import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
@@ -44,6 +45,134 @@ export async function ensureCommand(agentName: string): Promise<CommandResult<En
 
   const { agent, inspection } = resolved
   if (inspection.inPath) {
+    if (inspection.installedState) {
+      return emitCommandResult(
+        createSuccessResult<EnsureCommandData>({
+          action: 'ensure',
+          data: {
+            agent: {
+              displayName: agent.displayName,
+              name: agent.name,
+            },
+            changed: false,
+            installed: true,
+          },
+          target: {
+            kind: 'agent',
+            name: agent.name,
+          },
+          warnings: [
+            {
+              code: 'ALREADY_INSTALLED',
+              message: `${agent.displayName} is already installed.`,
+            },
+          ],
+        }),
+        renderEnsureHuman,
+      )
+    }
+
+    const adoptableMethod = getAdoptableExistingInstallMethod(inspection.methods)
+    if (adoptableMethod) {
+      if (isDryRunEnabled()) {
+        return emitCommandResult(
+          createSuccessResult<EnsureCommandData>({
+            action: 'ensure',
+            data: {
+              agent: {
+                displayName: agent.displayName,
+                name: agent.name,
+              },
+              changed: false,
+              installed: true,
+            },
+            target: {
+              kind: 'agent',
+              name: agent.name,
+            },
+            warnings: [
+              {
+                code: 'DRY_RUN',
+                message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
+              },
+            ],
+          }),
+          renderEnsureHuman,
+        )
+      }
+
+      emitCommandEvent({
+        action: 'ensure',
+        data: {
+          agent: {
+            displayName: agent.displayName,
+            name: agent.name,
+          },
+        },
+        target: {
+          kind: 'agent',
+          name: agent.name,
+        },
+        type: 'started',
+      })
+
+      try {
+        const installedState = await trackInstalledAgent(agent, adoptableMethod)
+
+        return emitCommandResult(
+          createSuccessResult<EnsureCommandData>({
+            action: 'ensure',
+            data: {
+              agent: {
+                displayName: agent.displayName,
+                name: agent.name,
+              },
+              changed: true,
+              installState: {
+                installType: installedState.installType,
+                packageName: installedState.packageName,
+              },
+              installed: true,
+            },
+            target: {
+              kind: 'agent',
+              name: agent.name,
+            },
+            warnings: [
+              {
+                code: 'TRACKED_EXISTING_INSTALL',
+                message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
+              },
+            ],
+          }),
+          renderEnsureHuman,
+        )
+      } catch (error) {
+        if (isResourceLockError(error)) {
+          return emitCommandResult(
+            createErrorResult<EnsureCommandData>({
+              action: 'ensure',
+              data: {
+                agent: {
+                  displayName: agent.displayName,
+                  name: agent.name,
+                },
+                changed: false,
+                installed: true,
+              },
+              ...createResourceLockedError(error, {
+                kind: 'agent',
+                name: agent.name,
+              }),
+            }),
+            renderEnsureHuman,
+          )
+        }
+
+        throw error
+      }
+    }
+
     return emitCommandResult(
       createSuccessResult<EnsureCommandData>({
         action: 'ensure',
@@ -61,8 +190,8 @@ export async function ensureCommand(agentName: string): Promise<CommandResult<En
         },
         warnings: [
           {
-            code: 'ALREADY_INSTALLED',
-            message: `${agent.displayName} is already installed.`,
+            code: 'UNTRACKED_EXISTING_INSTALL',
+            message: `${agent.displayName} is already installed but not tracked by Quantex. Quantex could not safely determine the supported install source, so the existing install remains unmanaged.`,
           },
         ],
       }),
@@ -194,7 +323,7 @@ export async function ensureCommand(agentName: string): Promise<CommandResult<En
 function renderEnsureHuman(result: {
   data?: EnsureCommandData
   error: { message: string } | null
-  warnings: Array<{ message: string }>
+  warnings: Array<{ code?: string; message: string }>
 }): void {
   if (result.error) {
     printError(pc.red(result.error.message))
@@ -204,7 +333,19 @@ function renderEnsureHuman(result: {
   if (!result.data) return
 
   if (result.warnings.length > 0) {
-    for (const warning of result.warnings) printWarn(pc.yellow(warning.message))
+    for (const warning of result.warnings) {
+      if (warning.code === 'TRACKED_EXISTING_INSTALL') {
+        printInfo(pc.green(warning.message))
+        continue
+      }
+
+      if (warning.code === 'DRY_RUN') {
+        printWarn(pc.cyan(warning.message))
+        continue
+      }
+
+      printWarn(pc.yellow(warning.message))
+    }
     return
   }
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,8 +1,9 @@
 import type { CommandResult } from '../output/types'
 import { createErrorResult, createSuccessResult, emitCommandEvent, emitCommandResult } from '../output'
-import { installAgent } from '../package-manager'
+import { installAgent, trackInstalledAgent } from '../package-manager'
 import { resolveAgentInspection } from '../services/agents'
 import { pc } from '../utils/color'
+import { getAdoptableExistingInstallMethod } from '../utils/install'
 import { createResourceLockedError } from '../utils/lifecycle-errors'
 import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
@@ -44,6 +45,134 @@ export async function installCommand(agentName: string): Promise<CommandResult<I
 
   const { agent, inspection } = resolved
   if (inspection.inPath) {
+    if (inspection.installedState) {
+      return emitCommandResult(
+        createSuccessResult<InstallCommandData>({
+          action: 'install',
+          data: {
+            agent: {
+              displayName: agent.displayName,
+              name: agent.name,
+            },
+            changed: false,
+            installed: true,
+          },
+          target: {
+            kind: 'agent',
+            name: agent.name,
+          },
+          warnings: [
+            {
+              code: 'ALREADY_INSTALLED',
+              message: `${agent.displayName} is already installed.`,
+            },
+          ],
+        }),
+        renderInstallHuman,
+      )
+    }
+
+    const adoptableMethod = getAdoptableExistingInstallMethod(inspection.methods)
+    if (adoptableMethod) {
+      if (isDryRunEnabled()) {
+        return emitCommandResult(
+          createSuccessResult<InstallCommandData>({
+            action: 'install',
+            data: {
+              agent: {
+                displayName: agent.displayName,
+                name: agent.name,
+              },
+              changed: false,
+              installed: true,
+            },
+            target: {
+              kind: 'agent',
+              name: agent.name,
+            },
+            warnings: [
+              {
+                code: 'DRY_RUN',
+                message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
+              },
+            ],
+          }),
+          renderInstallHuman,
+        )
+      }
+
+      emitCommandEvent({
+        action: 'install',
+        data: {
+          agent: {
+            displayName: agent.displayName,
+            name: agent.name,
+          },
+        },
+        target: {
+          kind: 'agent',
+          name: agent.name,
+        },
+        type: 'started',
+      })
+
+      try {
+        const installedState = await trackInstalledAgent(agent, adoptableMethod)
+
+        return emitCommandResult(
+          createSuccessResult<InstallCommandData>({
+            action: 'install',
+            data: {
+              agent: {
+                displayName: agent.displayName,
+                name: agent.name,
+              },
+              changed: true,
+              installState: {
+                installType: installedState.installType,
+                packageName: installedState.packageName,
+              },
+              installed: true,
+            },
+            target: {
+              kind: 'agent',
+              name: agent.name,
+            },
+            warnings: [
+              {
+                code: 'TRACKED_EXISTING_INSTALL',
+                message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
+              },
+            ],
+          }),
+          renderInstallHuman,
+        )
+      } catch (error) {
+        if (isResourceLockError(error)) {
+          return emitCommandResult(
+            createErrorResult<InstallCommandData>({
+              action: 'install',
+              data: {
+                agent: {
+                  displayName: agent.displayName,
+                  name: agent.name,
+                },
+                changed: false,
+                installed: true,
+              },
+              ...createResourceLockedError(error, {
+                kind: 'agent',
+                name: agent.name,
+              }),
+            }),
+            renderInstallHuman,
+          )
+        }
+
+        throw error
+      }
+    }
+
     return emitCommandResult(
       createSuccessResult<InstallCommandData>({
         action: 'install',
@@ -61,8 +190,8 @@ export async function installCommand(agentName: string): Promise<CommandResult<I
         },
         warnings: [
           {
-            code: 'ALREADY_INSTALLED',
-            message: `${agent.displayName} is already installed.`,
+            code: 'UNTRACKED_EXISTING_INSTALL',
+            message: `${agent.displayName} is already installed but not tracked by Quantex. Quantex could not safely determine the supported install source, so the existing install remains unmanaged.`,
           },
         ],
       }),
@@ -194,7 +323,7 @@ export async function installCommand(agentName: string): Promise<CommandResult<I
 function renderInstallHuman(result: {
   data?: InstallCommandData
   error: { message: string } | null
-  warnings: Array<{ message: string }>
+  warnings: Array<{ code?: string; message: string }>
 }): void {
   if (result.error) {
     printError(pc.red(result.error.message))
@@ -204,7 +333,19 @@ function renderInstallHuman(result: {
   if (!result.data) return
 
   if (result.warnings.length > 0) {
-    for (const warning of result.warnings) printWarn(pc.yellow(warning.message))
+    for (const warning of result.warnings) {
+      if (warning.code === 'TRACKED_EXISTING_INSTALL') {
+        printInfo(pc.green(warning.message))
+        continue
+      }
+
+      if (warning.code === 'DRY_RUN') {
+        printWarn(pc.cyan(warning.message))
+        continue
+      }
+
+      printWarn(pc.yellow(warning.message))
+    }
     return
   }
 

--- a/src/package-manager/index.ts
+++ b/src/package-manager/index.ts
@@ -128,6 +128,10 @@ async function persistInstalledState(agent: AgentDefinition, method: InstallMeth
   return installedState
 }
 
+export async function trackInstalledAgent(agent: AgentDefinition, method: InstallMethod): Promise<InstalledAgentState> {
+  return withResourceLock(lifecycleLock, async () => persistInstalledState(agent, method))
+}
+
 export async function installAgent(agent: AgentDefinition): Promise<AgentOperationResult> {
   return withResourceLock(lifecycleLock, async () => {
     const methods = await getOrderedInstallMethods(agent)

--- a/src/utils/install.ts
+++ b/src/utils/install.ts
@@ -129,3 +129,12 @@ export function getLatestVersionPackage(
 
   return agent.packages.npm
 }
+
+export function getAdoptableExistingInstallMethod(methods: InstallMethod[]): InstallMethod | undefined {
+  if (methods.length !== 1) return undefined
+
+  const [method] = methods
+  if (method.type !== 'script' && method.type !== 'binary') return undefined
+
+  return method
+}

--- a/test/commands/ensure.test.ts
+++ b/test/commands/ensure.test.ts
@@ -3,16 +3,21 @@ import * as agents from '../../src/agents'
 import { setCliContext } from '../../src/cli-context'
 import { ensureCommand } from '../../src/commands/ensure'
 import * as pm from '../../src/package-manager'
+import * as state from '../../src/state'
 import * as detect from '../../src/utils/detect'
 
 const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
 const installSpy = vi.spyOn(pm, 'installAgent')
+const trackSpy = vi.spyOn(pm, 'trackInstalledAgent')
 const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
+const installedStateSpy = vi.spyOn(state, 'getInstalledAgentState')
 
 afterAll(() => {
   agentSpy.mockRestore()
   installSpy.mockRestore()
+  trackSpy.mockRestore()
   binaryInPathSpy.mockRestore()
+  installedStateSpy.mockRestore()
 })
 
 const testAgent = {
@@ -29,6 +34,22 @@ const testAgent = {
   },
 }
 
+const scriptOnlyAgent = {
+  ...testAgent,
+  name: 'script-agent',
+  displayName: 'Script Agent',
+  binaryName: 'script-bin',
+  packages: undefined,
+  selfUpdate: {
+    command: ['script-bin', 'update'],
+  },
+  platforms: {
+    linux: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+    macos: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+    windows: [{ type: 'script' as const, command: 'irm https://example.com/install | iex' }],
+  },
+}
+
 describe('ensureCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
@@ -38,7 +59,10 @@ describe('ensureCommand', () => {
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
     agentSpy.mockClear()
     installSpy.mockClear()
+    trackSpy.mockClear()
     binaryInPathSpy.mockClear()
+    installedStateSpy.mockClear()
+    installedStateSpy.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -52,14 +76,53 @@ describe('ensureCommand', () => {
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown agent'))
   })
 
-  it('returns already installed without reinstalling', async () => {
+  it('returns already installed without reinstalling when state is already tracked', async () => {
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    installedStateSpy.mockResolvedValue({
+      agentName: 'test-agent',
+      installType: 'bun',
+      packageName: 'test-pkg',
+    })
+
+    await ensureCommand('test-agent')
+
+    expect(installSpy).not.toHaveBeenCalled()
+    expect(trackSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('already installed'))
+  })
+
+  it('tracks an existing script install when ensure can identify the source safely', async () => {
+    agentSpy.mockReturnValue(scriptOnlyAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    trackSpy.mockResolvedValue({
+      agentName: 'script-agent',
+      installType: 'script',
+      command: 'curl https://example.com/install | bash',
+    })
+
+    await ensureCommand('script-agent')
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      scriptOnlyAgent,
+      expect.objectContaining({
+        command: 'curl https://example.com/install | bash',
+        type: 'script',
+      }),
+    )
+    expect(installSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Quantex is now tracking the existing install'))
+  })
+
+  it('explains when an existing install stays untracked', async () => {
     agentSpy.mockReturnValue(testAgent)
     binaryInPathSpy.mockResolvedValue(true)
 
     await ensureCommand('test-agent')
 
+    expect(trackSpy).not.toHaveBeenCalled()
     expect(installSpy).not.toHaveBeenCalled()
-    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('already installed'))
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('not tracked by Quantex'))
   })
 
   it('installs the agent when missing', async () => {

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -3,17 +3,22 @@ import * as agents from '../../src/agents'
 import { setCliContext } from '../../src/cli-context'
 import { installCommand } from '../../src/commands/install'
 import * as pm from '../../src/package-manager'
+import * as state from '../../src/state'
 import * as detect from '../../src/utils/detect'
 import { ResourceLockError } from '../../src/utils/lock'
 
 const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
 const installSpy = vi.spyOn(pm, 'installAgent')
+const trackSpy = vi.spyOn(pm, 'trackInstalledAgent')
 const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
+const installedStateSpy = vi.spyOn(state, 'getInstalledAgentState')
 
 afterAll(() => {
   agentSpy.mockRestore()
   installSpy.mockRestore()
+  trackSpy.mockRestore()
   binaryInPathSpy.mockRestore()
+  installedStateSpy.mockRestore()
 })
 
 const testAgent = {
@@ -30,6 +35,22 @@ const testAgent = {
   },
 }
 
+const scriptOnlyAgent = {
+  ...testAgent,
+  name: 'script-agent',
+  displayName: 'Script Agent',
+  binaryName: 'script-bin',
+  packages: undefined,
+  selfUpdate: {
+    command: ['script-bin', 'update'],
+  },
+  platforms: {
+    linux: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+    macos: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+    windows: [{ type: 'script' as const, command: 'irm https://example.com/install | iex' }],
+  },
+}
+
 describe('installCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
@@ -39,7 +60,10 @@ describe('installCommand', () => {
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
     agentSpy.mockClear()
     installSpy.mockClear()
+    trackSpy.mockClear()
     binaryInPathSpy.mockClear()
+    installedStateSpy.mockClear()
+    installedStateSpy.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -53,12 +77,53 @@ describe('installCommand', () => {
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown agent'))
   })
 
-  it('shows already installed when binary exists', async () => {
+  it('shows already installed when a tracked install exists', async () => {
     agentSpy.mockReturnValue(testAgent)
     binaryInPathSpy.mockResolvedValue(true)
+    installedStateSpy.mockResolvedValue({
+      agentName: 'test-agent',
+      installType: 'bun',
+      packageName: 'test-pkg',
+    })
+
     await installCommand('test-agent')
+
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('already installed'))
     expect(installSpy).not.toHaveBeenCalled()
+    expect(trackSpy).not.toHaveBeenCalled()
+  })
+
+  it('tracks an existing script install when the source is unambiguous', async () => {
+    agentSpy.mockReturnValue(scriptOnlyAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    trackSpy.mockResolvedValue({
+      agentName: 'script-agent',
+      installType: 'script',
+      command: 'curl https://example.com/install | bash',
+    })
+
+    await installCommand('script-agent')
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      scriptOnlyAgent,
+      expect.objectContaining({
+        command: 'curl https://example.com/install | bash',
+        type: 'script',
+      }),
+    )
+    expect(installSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Quantex is now tracking the existing install'))
+  })
+
+  it('explains when an existing install remains untracked', async () => {
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+
+    await installCommand('test-agent')
+
+    expect(trackSpy).not.toHaveBeenCalled()
+    expect(installSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('not tracked by Quantex'))
   })
 
   it('calls installAgent and shows success', async () => {

--- a/test/commands/update.test.ts
+++ b/test/commands/update.test.ts
@@ -206,6 +206,50 @@ describe('updateCommand', () => {
     expect(output).toContain('quantex inspect self-updating-agent --json')
   })
 
+  it('includes tracked script installs in update --all via self-update', async () => {
+    const selfUpdatingAgent = {
+      ...testAgent,
+      name: 'self-updating-agent',
+      binaryName: 'self-updating-bin',
+      displayName: 'Self Updating Agent',
+      packages: undefined,
+      selfUpdate: {
+        command: ['self-updating-bin', 'update'],
+      },
+      platforms: {
+        linux: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+        macos: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+        windows: [{ type: 'script' as const, command: 'irm https://example.com/install | iex' }],
+      },
+    }
+
+    allAgentsSpy.mockReturnValue([selfUpdatingAgent])
+    binaryInPathSpy.mockResolvedValue(true)
+    installedVerSpy.mockResolvedValue('1.0.0')
+    latestVerSpy.mockResolvedValue(undefined)
+    installedStateSpy.mockResolvedValue({
+      agentName: 'self-updating-agent',
+      installType: 'script',
+      command: 'curl https://example.com/install | bash',
+    })
+    updateSpy.mockResolvedValue({ success: true })
+
+    await updateCommand(undefined, true)
+
+    expect(updateAgentsByTypeSpy).not.toHaveBeenCalled()
+    expect(updateSpy).toHaveBeenCalledWith(
+      selfUpdatingAgent,
+      expect.objectContaining({
+        command: 'curl https://example.com/install | bash',
+        installType: 'script',
+      }),
+    )
+
+    const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
+    expect(output).toContain('Updating Self Updating Agent via self-update... (1.0.0 -> latest)')
+    expect(output).toContain('Self Updating Agent updated successfully')
+  })
+
   it('still allows explicit single-agent updates for untracked PATH installs with self-update support', async () => {
     const selfUpdatingAgent = {
       ...testAgent,

--- a/test/package-manager/index.test.ts
+++ b/test/package-manager/index.test.ts
@@ -5,7 +5,13 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as config from '../../src/config'
 import * as binaryPm from '../../src/package-manager/binary'
 import * as bunPm from '../../src/package-manager/bun'
-import { installAgent, uninstallAgent, updateAgent, updateAgentsByType } from '../../src/package-manager/index'
+import {
+  installAgent,
+  trackInstalledAgent,
+  uninstallAgent,
+  updateAgent,
+  updateAgentsByType,
+} from '../../src/package-manager/index'
 import * as npmPm from '../../src/package-manager/npm'
 import * as state from '../../src/state'
 import * as detectUtils from '../../src/utils/detect'
@@ -147,6 +153,32 @@ describe('installAgent', () => {
     bunInstallSpy.mockResolvedValue(false)
     npmInstallSpy.mockResolvedValue(false)
     expect(await installAgent(testAgent)).toEqual({ success: false })
+  })
+})
+
+describe('trackInstalledAgent', () => {
+  it('persists an existing unmanaged install without running installers', async () => {
+    setInstalledAgentStateSpy.mockResolvedValue()
+
+    const installedState = await trackInstalledAgent(
+      {
+        ...testAgent,
+        packages: undefined,
+      },
+      { type: 'script', command: 'curl https://example.com/install | bash' },
+    )
+
+    expect(installedState).toEqual({
+      agentName: 'test-agent',
+      command: 'curl https://example.com/install | bash',
+      installType: 'script',
+      packageName: undefined,
+      packageTargetKind: undefined,
+    })
+    expect(setInstalledAgentStateSpy).toHaveBeenCalledWith(installedState)
+    expect(bunInstallSpy).not.toHaveBeenCalled()
+    expect(npmInstallSpy).not.toHaveBeenCalled()
+    expect(binarySpy).not.toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
## Summary
- allow `quantex install <agent>` and `quantex ensure <agent>` to adopt an existing untracked install when the current platform exposes exactly one unmanaged install method
- keep ambiguous PATH-only installs untracked, but replace the misleading `already installed` no-op with an explicit unmanaged warning
- add OpenSpec change `adopt-untracked-agent-installs` plus regression coverage proving tracked script installs now participate in `quantex update --all`

## Linked Artifacts
- OpenSpec change: `openspec/changes/adopt-untracked-agent-installs/`
- Spec delta: `openspec/changes/adopt-untracked-agent-installs/specs/agent-update/spec.md`

## Validation
- `bun run openspec:validate`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test`

## Release Intent
- No release action in this PR. This is a product behavior fix that should flow through the normal merge-to-release pipeline.

## Docs Updated
- OpenSpec artifacts updated in `openspec/changes/adopt-untracked-agent-installs/`.
- No product-facing README or runbook change was required because the existing remediation guidance stays correct; the command behavior now matches it.

## Scope Check
- Keeps Quantex on its lifecycle-CLI mission by reconciling tracked install state only.
- Does not expand Quantex into workflow orchestration or add new daemon / batch surfaces.

## Closure Check
- Local implementation: complete
- Repository delivery: complete
- PR delivery: complete
- Merge delivery: pending CI / merge
- OpenSpec archive closure: pending merge of accepted spec delta
- Release closure: not applicable in this PR
