### PR TITLE
fix: verify self-update version changes

### DIFF
--- a/openspec/changes/verify-self-update-version-change/.openspec.yaml
+++ b/openspec/changes/verify-self-update-version-change/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/verify-self-update-version-change/design.md
+++ b/openspec/changes/verify-self-update-version-change/design.md
@@ -1,0 +1,33 @@
+## Context
+
+Cursor CLI exposes a version probe through `agent --version`, but Quantex does not have an authoritative "latest version" source for it. That means Quantex cannot know ahead of time whether Cursor is outdated, yet it can still verify whether a self-update changed the installed version after the command runs.
+
+Today, `performUpdate` trusts `updateAgent(...).success` for self-update and prints `updated successfully!` unconditionally. For Cursor-like agents, that makes successful command execution indistinguishable from a genuine version change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Verify self-update outcomes with pre/post installed-version probes when available.
+- Preserve existing managed-update behavior.
+- Keep the human output concise while making its semantics accurate.
+
+**Non-Goals:**
+
+- Do not invent a latest-version feed for Cursor or other script-installed agents.
+- Do not block self-update for agents that lack a working version probe.
+- Do not redesign batch update planning in this change.
+
+## Decisions
+
+- Add a post-update verification path only for `self-update` strategy inside the command layer. The package-manager layer can keep reporting command execution success; the command layer is where user-facing status is decided.
+- Re-probe the installed version after a successful self-update command when a version probe is available.
+- If the pre-update and post-update versions are both known and unchanged, emit `up-to-date` instead of `updated`.
+- If the post-update version changed, emit `updated` and prefer the verified post-update version in result data.
+- If Quantex cannot probe either side, keep the existing success behavior to avoid turning unknowns into false failures.
+
+## Risks / Trade-offs
+
+- [Extra version probe process] → Self-update runs one more lightweight version command; acceptable for accuracy.
+- [Unknown-version ambiguity remains] → Agents without a reliable version probe can still only report command success; this change narrows the ambiguity where Quantex has enough information to do better.
+- [Structured result shift] → Some callers that previously saw `updated` may now see `up-to-date`; this is an intended contract fix and should be covered in spec + tests.

--- a/openspec/changes/verify-self-update-version-change/proposal.md
+++ b/openspec/changes/verify-self-update-version-change/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Quantex currently reports `updated successfully` for self-updating agents such as Cursor CLI when the upstream update command exits successfully, even if the installed version does not change. That overstates what Quantex has actually verified and makes it impossible to distinguish "the update command ran" from "the agent really upgraded" when no upstream latest-version API is available.
+
+## What Changes
+
+- Change self-update result handling so Quantex compares the installed version before and after a self-update attempt whenever the agent exposes a version probe.
+- Report self-update results as `up to date` when the update command succeeds but the installed version does not change.
+- Keep the existing `updated successfully` outcome only when Quantex can verify that the installed version changed, or when no version probe is available at all.
+- Add regression coverage for tracked script installs and explicit single-agent self-update flows.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: self-update outcomes must reflect verified version change instead of command success alone when Quantex can probe the installed version before and after the update.
+
+## Impact
+
+- Affected code: `src/commands/update.ts`, version utilities, and update command tests.
+- Affected contracts: human and structured update results for self-updating agents such as Cursor CLI.
+- Dependencies: no new runtime dependency.

--- a/openspec/changes/verify-self-update-version-change/specs/agent-update/spec.md
+++ b/openspec/changes/verify-self-update-version-change/specs/agent-update/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Single-agent update MUST choose an appropriate strategy
+
+The agent update system SHALL choose the best available update strategy for a single agent based on install source and agent capabilities.
+
+#### Scenario: Updating a managed agent
+
+- GIVEN an agent was installed through a managed package source
+- WHEN the user runs `quantex update <agent>`
+- THEN Quantex selects the matching managed update path
+
+#### Scenario: Updating an agent that cannot be managed automatically
+
+- GIVEN an installed agent is not updateable through a managed path
+- WHEN the user runs `quantex update <agent>`
+- THEN Quantex provides a manual or explanatory hint instead of pretending the agent was upgraded
+
+#### Scenario: Self-update only reports an upgrade when the installed version changes
+
+- GIVEN an installed agent is updated through a self-update command
+- AND Quantex can probe the installed version before and after the command
+- WHEN the self-update command exits successfully
+- THEN Quantex compares the probed versions
+- AND reports the agent as updated only if the installed version changed
+
+#### Scenario: Self-update reports no change when the version stays the same
+
+- GIVEN an installed agent is updated through a self-update command
+- AND Quantex can probe the installed version before and after the command
+- WHEN the self-update command exits successfully
+- BUT the installed version remains the same
+- THEN Quantex reports the agent as up to date instead of updated

--- a/openspec/changes/verify-self-update-version-change/tasks.md
+++ b/openspec/changes/verify-self-update-version-change/tasks.md
@@ -1,0 +1,14 @@
+## 1. Self-Update Verification
+
+- [x] 1.1 Add post-update version verification for self-update results when the agent exposes a version probe.
+- [x] 1.2 Adjust update result rendering/data so unchanged versions resolve to `up to date` instead of `updated successfully`.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add tests for a self-update that changes version and for one that returns success without changing version.
+- [x] 2.2 Keep existing managed-update and failure-path coverage passing.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run openspec:validate`.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run test`.

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -16,6 +16,7 @@ import { pc } from '../utils/color'
 import { canAutoUpdateAgent, canUpdateInstallType } from '../utils/install'
 import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
+import { getInstalledVersion } from '../utils/version'
 
 type UpdateStatus = 'failed' | 'locked' | 'manual-required' | 'planned' | 'up-to-date' | 'updated'
 
@@ -413,6 +414,32 @@ async function performUpdate(
   }
 
   if (result.success) {
+    if (strategy === 'self-update') {
+      const verifiedVersion = await getInstalledVersion(agent.binaryName, agent.versionProbe)
+
+      if (installedVersion && verifiedVersion) {
+        if (verifiedVersion === installedVersion) {
+          return {
+            displayName: agent.displayName,
+            installedVersion: verifiedVersion,
+            latestVersion: verifiedVersion,
+            name: agent.name,
+            status: 'up-to-date',
+            strategy,
+          }
+        }
+
+        return {
+          displayName: agent.displayName,
+          installedVersion,
+          latestVersion: verifiedVersion,
+          name: agent.name,
+          status: 'updated',
+          strategy,
+        }
+      }
+    }
+
     return {
       displayName: agent.displayName,
       installedVersion,

--- a/test/commands/update.test.ts
+++ b/test/commands/update.test.ts
@@ -225,7 +225,7 @@ describe('updateCommand', () => {
 
     allAgentsSpy.mockReturnValue([selfUpdatingAgent])
     binaryInPathSpy.mockResolvedValue(true)
-    installedVerSpy.mockResolvedValue('1.0.0')
+    installedVerSpy.mockResolvedValueOnce('1.0.0').mockResolvedValueOnce('2.0.0')
     latestVerSpy.mockResolvedValue(undefined)
     installedStateSpy.mockResolvedValue({
       agentName: 'self-updating-agent',
@@ -246,8 +246,43 @@ describe('updateCommand', () => {
     )
 
     const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
-    expect(output).toContain('Updating Self Updating Agent via self-update... (1.0.0 -> latest)')
+    expect(output).toContain('Updating Self Updating Agent via self-update... (1.0.0 -> 2.0.0)')
     expect(output).toContain('Self Updating Agent updated successfully')
+  })
+
+  it('reports self-update as up to date when the version does not change', async () => {
+    const selfUpdatingAgent = {
+      ...testAgent,
+      name: 'self-updating-agent',
+      binaryName: 'self-updating-bin',
+      displayName: 'Self Updating Agent',
+      packages: undefined,
+      selfUpdate: {
+        command: ['self-updating-bin', 'update'],
+      },
+      platforms: {
+        linux: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+        macos: [{ type: 'script' as const, command: 'curl https://example.com/install | bash' }],
+        windows: [{ type: 'script' as const, command: 'irm https://example.com/install | iex' }],
+      },
+    }
+
+    agentSpy.mockReturnValue(selfUpdatingAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    installedVerSpy.mockResolvedValueOnce('1.0.0').mockResolvedValueOnce('1.0.0')
+    latestVerSpy.mockResolvedValue(undefined)
+    installedStateSpy.mockResolvedValue({
+      agentName: 'self-updating-agent',
+      installType: 'script',
+      command: 'curl https://example.com/install | bash',
+    })
+    updateSpy.mockResolvedValue({ success: true })
+
+    await updateCommand('self-updating-agent', false)
+
+    const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
+    expect(output).toContain('Self Updating Agent is up to date (1.0.0)')
+    expect(output).not.toContain('Self Updating Agent updated successfully')
   })
 
   it('still allows explicit single-agent updates for untracked PATH installs with self-update support', async () => {
@@ -269,7 +304,7 @@ describe('updateCommand', () => {
 
     agentSpy.mockReturnValue(selfUpdatingAgent)
     binaryInPathSpy.mockResolvedValue(true)
-    installedVerSpy.mockResolvedValue('1.0.0')
+    installedVerSpy.mockResolvedValueOnce('1.0.0').mockResolvedValueOnce('2.0.0')
     latestVerSpy.mockResolvedValue(undefined)
     installedStateSpy.mockResolvedValue(undefined)
     updateSpy.mockResolvedValue({ success: true })
@@ -278,7 +313,7 @@ describe('updateCommand', () => {
 
     expect(updateSpy).toHaveBeenCalledWith(selfUpdatingAgent, undefined)
     const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
-    expect(output).toContain('Updating Self Updating Agent via self-update... (1.0.0 -> latest)')
+    expect(output).toContain('Updating Self Updating Agent via self-update... (1.0.0 -> 2.0.0)')
     expect(output).toContain('Self Updating Agent updated successfully')
   })
 


### PR DESCRIPTION
## Summary
- verify self-update outcomes with a post-update version probe when the agent exposes a version command
- report Cursor-like self-updates as `up to date` when the command succeeds but the installed version does not change
- keep `updated successfully` only for verified version changes, and add OpenSpec/test coverage for the corrected contract

## Linked Artifacts
- OpenSpec change: `openspec/changes/verify-self-update-version-change/`
- Spec delta: `openspec/changes/verify-self-update-version-change/specs/agent-update/spec.md`

## Validation
- `bun run openspec:validate`
- `bun run lint`
- `bun run format:check`
- `bun run typecheck`
- `bun run test`

## Release Intent
- No manual release step in this PR. The fix should flow through the normal merge-to-release pipeline.

## Docs Updated
- OpenSpec artifacts updated in `openspec/changes/verify-self-update-version-change/`.
- No README change was needed because this tightens update result semantics rather than changing user-facing command discovery.

## Scope Check
- Keeps Quantex focused on lifecycle truthfulness by verifying self-update outcomes where a version probe exists.
- Does not add orchestration behavior or broaden Quantex beyond install/update lifecycle concerns.

## Closure Check
- Local implementation: complete
- Repository delivery: complete
- PR delivery: complete
- Merge delivery: pending CI / merge
- OpenSpec archive closure: pending merge of accepted spec delta
- Release closure: pending next automated release
