### PR TITLE
test(ci): fix windows script install assertions

### DIFF
--- a/test/commands/ensure.test.ts
+++ b/test/commands/ensure.test.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as agents from '../../src/agents'
 import { setCliContext } from '../../src/cli-context'
@@ -50,6 +51,11 @@ const scriptOnlyAgent = {
   },
 }
 
+const expectedScriptInstallCommand =
+  process.platform === 'win32'
+    ? scriptOnlyAgent.platforms.windows[0].command
+    : scriptOnlyAgent.platforms.macos[0].command
+
 describe('ensureCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
@@ -98,7 +104,7 @@ describe('ensureCommand', () => {
     trackSpy.mockResolvedValue({
       agentName: 'script-agent',
       installType: 'script',
-      command: 'curl https://example.com/install | bash',
+      command: expectedScriptInstallCommand,
     })
 
     await ensureCommand('script-agent')
@@ -106,7 +112,7 @@ describe('ensureCommand', () => {
     expect(trackSpy).toHaveBeenCalledWith(
       scriptOnlyAgent,
       expect.objectContaining({
-        command: 'curl https://example.com/install | bash',
+        command: expectedScriptInstallCommand,
         type: 'script',
       }),
     )

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as agents from '../../src/agents'
 import { setCliContext } from '../../src/cli-context'
@@ -51,6 +52,11 @@ const scriptOnlyAgent = {
   },
 }
 
+const expectedScriptInstallCommand =
+  process.platform === 'win32'
+    ? scriptOnlyAgent.platforms.windows[0].command
+    : scriptOnlyAgent.platforms.macos[0].command
+
 describe('installCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
@@ -99,7 +105,7 @@ describe('installCommand', () => {
     trackSpy.mockResolvedValue({
       agentName: 'script-agent',
       installType: 'script',
-      command: 'curl https://example.com/install | bash',
+      command: expectedScriptInstallCommand,
     })
 
     await installCommand('script-agent')
@@ -107,7 +113,7 @@ describe('installCommand', () => {
     expect(trackSpy).toHaveBeenCalledWith(
       scriptOnlyAgent,
       expect.objectContaining({
-        command: 'curl https://example.com/install | bash',
+        command: expectedScriptInstallCommand,
         type: 'script',
       }),
     )


### PR DESCRIPTION
## Summary
- make script-install tracking assertions platform-aware in install and ensure tests
- expect the Windows PowerShell command on win32 instead of hardcoding the Unix curl|bash form
- keep the regression coverage that verifies untracked script installs can be adopted safely

## Linked Artifacts
- Prior fix PR: #105
- Failing CI run: https://github.com/Drswith/quantex-cli/actions/runs/25063408306

## Validation
- bun run test -- test/commands/install.test.ts test/commands/ensure.test.ts
- bun run lint
- bun run format:check
- bun run typecheck
- bun run test

## Release Intent
- Patch release in the next normal cut; no immediate release required for this test-only cleanup.

## Docs Updated
- Not applicable; this change only corrects platform-specific test expectations.

## Scope Check
- Confined to test assertions for install/ensure script tracking on Windows vs Unix platforms.

## Closure Check
- Local validation complete
- Branch pushed and PR opened
- Waiting for CI and merge