### PR TITLE
ci: unify workflow validation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,34 +32,16 @@ jobs:
       run_test_matrix: ${{ steps.classify.outputs.run_test_matrix }}
       scope: ${{ steps.classify.outputs.scope }}
     steps:
-      - name: Classify change scope
-        id: classify
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: List changed files
+        id: changed-files
         uses: actions/github-script@v7
         with:
           script: |
-            const productImpactingPrefixes = [
-              'src/',
-              'scripts/',
-              'skills/quantex-cli/',
-            ]
-            const productImpactingFiles = new Set([
-              'package.json',
-              'bun.lock',
-              'install.sh',
-              'install.ps1',
-              'tsdown.config.ts',
-            ])
-            const processOnlyFiles = new Set([
-              'release-please-config.json',
-              'release-please-config.beta.json',
-              '.release-please-manifest.json',
-            ])
-            const processOnlyPrefixes = [
-              '.github/',
-              'docs/',
-              'openspec/',
-            ]
-
             async function listChangedFiles() {
               if (context.eventName === 'pull_request') {
                 const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -91,35 +73,24 @@ jobs:
               return null
             }
 
-            function isProductImpacting(fileName) {
-              return productImpactingPrefixes.some(prefix => fileName.startsWith(prefix))
-                || productImpactingFiles.has(fileName)
-            }
-
-            function isProcessOnly(fileName) {
-              return processOnlyPrefixes.some(prefix => fileName.startsWith(prefix))
-                || processOnlyFiles.has(fileName)
-            }
-
             const changedFiles = await listChangedFiles()
 
             if (!changedFiles || changedFiles.length === 0) {
               core.info('No changed-file diff available for this event; defaulting to the full test matrix.')
               core.setOutput('changed_files', '[]')
-              core.setOutput('run_test_matrix', 'true')
-              core.setOutput('scope', 'unknown')
+              core.setOutput('changed_files_available', 'false')
               return
             }
 
-            const productImpacting = changedFiles.some(isProductImpacting)
-            const processOnly = changedFiles.every(isProcessOnly)
-            const runTestMatrix = !processOnly
-            const scope = processOnly ? 'process-only' : (productImpacting ? 'product-impacting' : 'mixed')
-
-            core.info(`Changed files (${scope}): ${changedFiles.join(', ')}`)
             core.setOutput('changed_files', JSON.stringify(changedFiles))
-            core.setOutput('run_test_matrix', String(runTestMatrix))
-            core.setOutput('scope', scope)
+            core.setOutput('changed_files_available', 'true')
+
+      - name: Classify change scope
+        id: classify
+        env:
+          CHANGED_FILES_AVAILABLE: ${{ steps.changed-files.outputs.changed_files_available }}
+          CHANGED_FILES_JSON: ${{ steps.changed-files.outputs.changed_files }}
+        run: bun run scripts/path-taxonomy.ts
 
   lint:
     runs-on: ubuntu-latest
@@ -155,22 +126,29 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Skip full matrix for process-only changes
-        if: ${{ needs.classify.outputs.run_test_matrix != 'true' }}
+      - name: Skip full matrix for process-only non-Linux changes
+        if: ${{ needs.classify.outputs.run_test_matrix != 'true' && runner.os != 'Linux' }}
         env:
           CHANGE_SCOPE: ${{ needs.classify.outputs.scope }}
         run: |
           echo "Process-only change detected (${CHANGE_SCOPE}); preserving required matrix check context without running full platform tests."
 
-      - if: ${{ needs.classify.outputs.run_test_matrix == 'true' }}
+      - name: Run minimal Linux build for process-only changes
+        if: ${{ needs.classify.outputs.run_test_matrix != 'true' && runner.os == 'Linux' }}
+        env:
+          CHANGE_SCOPE: ${{ needs.classify.outputs.scope }}
+        run: |
+          echo "Process-only change detected (${CHANGE_SCOPE}); running the minimal Ubuntu build guard while skipping the full test matrix."
+
+      - if: ${{ needs.classify.outputs.run_test_matrix == 'true' || runner.os == 'Linux' }}
         uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-        if: ${{ needs.classify.outputs.run_test_matrix == 'true' }}
+        if: ${{ needs.classify.outputs.run_test_matrix == 'true' || runner.os == 'Linux' }}
         with:
           bun-version: 1.3.11
 
       - uses: actions/cache@v4
-        if: ${{ needs.classify.outputs.run_test_matrix == 'true' }}
+        if: ${{ needs.classify.outputs.run_test_matrix == 'true' || runner.os == 'Linux' }}
         with:
           path: |
             .bun/install/cache
@@ -179,9 +157,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-
 
-      - if: ${{ needs.classify.outputs.run_test_matrix == 'true' }}
+      - if: ${{ needs.classify.outputs.run_test_matrix == 'true' || runner.os == 'Linux' }}
         run: bun install --frozen-lockfile --ignore-scripts --no-progress
-      - if: ${{ needs.classify.outputs.run_test_matrix == 'true' }}
+      - if: ${{ needs.classify.outputs.run_test_matrix == 'true' || runner.os == 'Linux' }}
         run: bun run build
       - if: ${{ needs.classify.outputs.run_test_matrix == 'true' && runner.os == 'Windows' && github.event_name != 'pull_request' }}
         run: bun run test -- --pool=threads

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -16,6 +16,31 @@ jobs:
   validate-body:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: List changed files
+        id: changed-files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            })
+
+            core.setOutput('changed_files', JSON.stringify(files.map(file => file.filename)))
+
+      - name: Classify pull request scope
+        id: classify
+        env:
+          CHANGED_FILES_JSON: ${{ steps.changed-files.outputs.changed_files }}
+        run: bun run scripts/path-taxonomy.ts
+
       - name: Validate PR body
         uses: actions/github-script@v7
         with:
@@ -73,34 +98,15 @@ jobs:
             }
 
       - name: Validate release trigger scope
+        if: ${{ steps.classify.outputs.scope == 'process-only' }}
+        env:
+          CHANGED_FILES_JSON: ${{ steps.classify.outputs.changed_files }}
         uses: actions/github-script@v7
         with:
           script: |
-            const pullRequest = context.payload.pull_request
-            const title = pullRequest.title || ''
-            const body = pullRequest.body || ''
-
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequest.number,
-              per_page: 100,
-            })
-
-            const changedFiles = files.map(file => file.filename)
-            const releaseProcessOnly = changedFiles.length > 0
-              && changedFiles.every(fileName => {
-                return fileName.startsWith('.github/')
-                  || fileName.startsWith('docs/')
-                  || fileName.startsWith('openspec/')
-                  || fileName === 'release-please-config.json'
-                  || fileName === 'release-please-config.beta.json'
-                  || fileName === '.release-please-manifest.json'
-              })
-
-            if (!releaseProcessOnly)
-              return
-
+            const title = context.payload.pull_request.title || ''
+            const body = context.payload.pull_request.body || ''
+            const changedFiles = JSON.parse(process.env.CHANGED_FILES_JSON || '[]')
             const releaseWorthyTitle = /^(feat|fix|perf)(\(.+\))?!?:/.test(title)
               || /^[a-z]+(\(.+\))?!:/.test(title)
             const releaseWorthyBody = /\nBREAKING CHANGE:/.test(`\n${body}`)
@@ -114,6 +120,9 @@ jobs:
             }
 
       - name: Validate product release intent
+        if: ${{ steps.classify.outputs.product_impacting == 'true' }}
+        env:
+          PRODUCT_IMPACTING_FILES_JSON: ${{ steps.classify.outputs.product_impacting_files }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -125,27 +134,7 @@ jobs:
             if (headBranch.startsWith('release-please--branches--'))
               return
 
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pullRequest.number,
-              per_page: 100,
-            })
-
-            const changedFiles = files.map(file => file.filename)
-            const productImpactingFiles = changedFiles.filter(fileName => {
-              return fileName.startsWith('src/')
-                || fileName.startsWith('skills/quantex-cli/')
-                || fileName.startsWith('scripts/')
-                || fileName === 'package.json'
-                || fileName === 'bun.lock'
-                || fileName === 'install.sh'
-                || fileName === 'install.ps1'
-                || fileName === 'tsdown.config.ts'
-            })
-
-            if (productImpactingFiles.length === 0)
-              return
+            const productImpactingFiles = JSON.parse(process.env.PRODUCT_IMPACTING_FILES_JSON || '[]')
 
             const releaseWorthyTitle = /^(feat|fix|perf)(\(.+\))?!?:/.test(title)
               || /^[a-z]+(\(.+\))?!:/.test(title)

--- a/openspec/changes/unify-ci-validation-gates/.openspec.yaml
+++ b/openspec/changes/unify-ci-validation-gates/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/unify-ci-validation-gates/design.md
+++ b/openspec/changes/unify-ci-validation-gates/design.md
@@ -1,0 +1,72 @@
+## Context
+
+Quantex already documents a broader validation contract in `AGENTS.md` than the repository enforces before code reaches CI. Today, local hooks stop at staged-file formatting and lint fixes, while merge-gating CI and PR governance each embed their own path classifier logic. That creates three failure modes:
+
+1. Critical repository checks first fail in CI instead of at push time.
+2. Scope classification can drift between CI and governance because the same taxonomy lives in multiple YAML files.
+3. Process-only changes currently preserve required matrix contexts without exercising any build step, which weakens the signal behind the green checks.
+
+This is a cross-cutting workflow change because it touches local hooks, repository scripts, merge-gating CI, and PR governance together.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move high-value repository checks left to `pre-push` without making `pre-commit` run the full repository validation surface.
+- Establish one repository-native path taxonomy that CI and PR governance can both consume.
+- Preserve the current scoped-CI optimization for process-only changes while adding a small execution guardrail.
+- Keep the implementation Bun/TypeScript-native and easy to call from GitHub Actions.
+
+**Non-Goals:**
+
+- Redesign the release-please two-phase release workflow.
+- Eliminate archive PR automation or change release/archive concurrency topology.
+- Expand formatting coverage to Markdown or introduce new third-party linters/formatters.
+- Run the full cross-platform test matrix for process-only changes.
+
+## Decisions
+
+### Decision: introduce a shared TypeScript path-taxonomy script
+
+We will add a repository script that exposes the canonical product-impacting/process-only rules and can classify an arbitrary file list. GitHub Actions and local scripts will call this file instead of duplicating prefix/file-set logic inline.
+
+Why this over “keep the YAML copies but document them better”:
+
+- Documentation already exists and has not prevented drift.
+- TypeScript can be unit-tested and reused locally.
+- A repo-native script makes future taxonomy changes a single-diff operation.
+
+### Decision: add `pre-push` instead of widening `pre-commit`
+
+We will keep `pre-commit` focused on staged-file formatting/lint fixes and add a new `pre-push` hook for `format:check`, `typecheck`, `openspec:validate`, and `memory:check`.
+
+Why this over moving everything into `pre-commit`:
+
+- `pre-commit` should stay fast and file-scoped so routine commits remain lightweight.
+- `typecheck` and OpenSpec/project-memory validation are repository-wide checks, which fit the push boundary better.
+- This catches the highest-value CI failures earlier without turning every commit into a full validation run.
+
+### Decision: keep process-only matrix skipping, but require a minimal Ubuntu build
+
+Process-only changes will continue to skip the expensive three-platform test execution, but CI will no longer report a pure no-op matrix success. Instead, the process-only path will run `bun run build` on Ubuntu as a lightweight execution guard.
+
+Why this over restoring the full matrix for process-only changes:
+
+- The goal is to preserve most of the scoped-CI cost savings.
+- A minimal build provides real execution signal for workflow/docs/OpenSpec changes that could still break repository wiring.
+
+### Decision: PR governance consumes classifier output, not its own path rules
+
+PR governance will call the shared classifier to determine whether a PR is process-only or product-impacting for release-intent enforcement.
+
+Why this over embedding the script output into generated YAML variables ahead of time:
+
+- Direct invocation keeps the workflow simpler.
+- It avoids a second transformation layer that could itself drift.
+
+## Risks / Trade-offs
+
+- [Pre-push becomes slower] → Keep the hook limited to four repository-wide checks and leave tests/builds in CI.
+- [Script output shape becomes another contract] → Keep the JSON surface intentionally small and add focused tests around classification behavior.
+- [Process-only build still misses platform-specific regressions] → Accept this as a scoped P0 trade-off; the full matrix remains required for product-impacting changes.
+- [Workflow shell glue becomes brittle] → Use Bun/TypeScript for classification and keep the YAML side thin.

--- a/openspec/changes/unify-ci-validation-gates/proposal.md
+++ b/openspec/changes/unify-ci-validation-gates/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Recent CI failures show that Quantex's workflow rules are documented more strongly than they are enforced locally. Critical validation such as `format:check`, `typecheck`, `openspec:validate`, and `memory:check` still first fail in CI, while change-scope classification is duplicated across workflows and can drift.
+
+This change is classified as a durable workflow update under the OpenSpec intake gate. We need a smaller, executable P0 that moves key checks earlier, reduces classification drift, and preserves the existing scoped-CI model without expanding into a broader release workflow redesign.
+
+## What Changes
+
+- Add a repository-native change-scope classifier script that defines the canonical product-impacting and process-only path taxonomy.
+- Reuse that canonical taxonomy from merge-gating CI and PR governance instead of maintaining multiple inline copies.
+- Add a `pre-push` hook that runs `bun run format:check`, `bun run typecheck`, `bun run openspec:validate`, and `bun run memory:check`.
+- Keep the existing process-only CI optimization, but add a minimal Ubuntu build guard so process-only PRs no longer report a completely execution-free test context.
+- Preserve the current release and archive automation topology; this change does not redesign release orchestration or archive PR generation.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: local hooks and merge-gating CI validation requirements expand to include pre-push enforcement, a canonical path taxonomy, and a minimal process-only build guard.
+- `release-governance`: PR governance change-scope checks derive their path classification from the same canonical repository taxonomy used by CI.
+
+## Impact
+
+- Affected code: `.github/workflows/ci.yml`, `.github/workflows/pr-governance.yml`, `package.json`, `scripts/**`, and related tests if needed.
+- Affected systems: local git hook enforcement, merge-gating CI classification, and PR governance scope validation.
+- Dependencies: no new third-party lint or format tools; the implementation should stay within Bun/TypeScript and the current GitHub Actions surface.

--- a/openspec/changes/unify-ci-validation-gates/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/unify-ci-validation-gates/specs/code-quality-tooling/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Workflow scope classification MUST use a canonical repository taxonomy
+
+Repository workflows that distinguish product-impacting changes from process-only changes MUST derive that classification from a single canonical repository taxonomy instead of maintaining independent inline path lists.
+
+#### Scenario: CI classifies a pull request
+
+- **WHEN** merge-gating CI evaluates the changed files for a pull request or protected-branch push
+- **THEN** it MUST classify the change with the canonical repository taxonomy
+- **AND** it MUST NOT rely on a workflow-local copy of the same product-impacting or process-only path rules
+
+#### Scenario: PR governance validates release intent
+
+- **WHEN** PR governance evaluates whether a pull request is process-only or product-impacting
+- **THEN** it MUST use the same canonical repository taxonomy consumed by merge-gating CI
+- **AND** the repository MUST be able to update that taxonomy through one source-of-truth change
+
+### Requirement: Pre-push validation MUST enforce repository-wide workflow gates
+
+The repository SHALL enforce a `pre-push` hook through `simple-git-hooks` that runs the repository-wide checks most likely to fail merge-gating CI for durable workflow changes.
+
+#### Scenario: Contributor pushes a branch
+
+- **WHEN** a contributor pushes commits from a clone with repository hooks installed
+- **THEN** the `pre-push` hook MUST run `bun run format:check`
+- **AND** it MUST run `bun run typecheck`
+- **AND** it MUST run `bun run openspec:validate`
+- **AND** it MUST run `bun run memory:check`
+- **AND** the push MUST be aborted if any of those commands exits non-zero
+
+## MODIFIED Requirements
+
+### Requirement: Merge-gating CI scopes cross-platform execution by change impact
+
+The merge-gating CI workflow SHALL classify pull requests and protected-branch pushes as either product-impacting or process-only with the canonical repository taxonomy before deciding whether to run expensive cross-platform test jobs. Process-only changes MAY skip the protected-branch test matrix, but the workflow MUST still execute the required lint and format validation, MUST still publish the same required test job contexts expected by GitHub rulesets, and MUST still run a minimal build guard on Ubuntu.
+
+#### Scenario: Process-only pull request targets main
+
+- **WHEN** a pull request targeting `main` changes only workflow, documentation, OpenSpec, or release-process metadata
+- **THEN** merge-gating CI executes the always-on validation jobs for the repository
+- **AND** it runs `bun run build` on Ubuntu as a minimal execution guard
+- **AND** the `test (ubuntu-latest)`, `test (macos-latest)`, and `test (windows-latest)` contexts are reported without running the full cross-platform test workload
+
+#### Scenario: Product-impacting pull request targets beta
+
+- **WHEN** a pull request targeting `beta` changes product-impacting files such as `src/**`, install surfaces, package metadata, or runtime scripts
+- **THEN** merge-gating CI runs the required test jobs for Ubuntu, macOS, and Windows
+- **AND** any failing platform context blocks merge through the existing ruleset

--- a/openspec/changes/unify-ci-validation-gates/specs/release-governance/spec.md
+++ b/openspec/changes/unify-ci-validation-gates/specs/release-governance/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Process-only PRs MUST use the shared scope taxonomy for release-metadata enforcement
+
+PR governance SHALL determine whether a pull request is process-only by using the same canonical repository taxonomy as merge-gating CI before enforcing release-metadata restrictions.
+
+#### Scenario: Process-only PR changes workflow or OpenSpec files
+
+- **WHEN** a pull request changes only files classified as process-only by the canonical repository taxonomy
+- **THEN** PR governance MUST treat the pull request as process-only for release-metadata enforcement
+- **AND** it MUST reject release-worthy conventional metadata such as `feat:`, `fix:`, or `perf:` for that scope
+
+## MODIFIED Requirements
+
+### Requirement: Product-Impacting PRs Must Not Silently Skip Release
+
+PR Governance SHALL reject product-impacting pull requests whose title is not release-worthy unless the PR explicitly declares that release is not applicable with a non-placeholder reason. The product-impacting determination MUST use the same canonical repository taxonomy as merge-gating CI.
+
+#### Scenario: Product-impacting PR has release-worthy title
+
+- **WHEN** a pull request changes files classified as product-impacting by the canonical repository taxonomy
+- **AND** its title uses release-worthy conventional metadata such as `feat:`, `fix:`, `perf:`, `type!:` or a breaking-change footer
+- **THEN** PR Governance allows the release intent check to pass
+
+#### Scenario: Product-impacting PR has explicit no-release reason
+
+- **WHEN** a pull request changes files classified as product-impacting by the canonical repository taxonomy
+- **AND** its title is not release-worthy
+- **AND** its release-intent section says release is not applicable with a meaningful reason
+- **THEN** PR Governance allows the release intent check to pass
+
+#### Scenario: Product-impacting PR has non-release title and no reason
+
+- **WHEN** a pull request changes files classified as product-impacting by the canonical repository taxonomy
+- **AND** its title is not release-worthy
+- **AND** its release-intent section is missing, empty, or only says a placeholder such as `n/a`
+- **THEN** PR Governance fails with guidance to use release-worthy metadata or provide a reason

--- a/openspec/changes/unify-ci-validation-gates/tasks.md
+++ b/openspec/changes/unify-ci-validation-gates/tasks.md
@@ -1,0 +1,20 @@
+## 1. Shared Classification Contract
+
+- [x] 1.1 Add a repository-native path taxonomy/classification script for process-only vs product-impacting changes.
+- [x] 1.2 Add focused tests or assertions for the shared classifier behavior.
+
+## 2. Local Validation Left Shift
+
+- [x] 2.1 Add a `pre-push` hook that runs `format:check`, `typecheck`, `openspec:validate`, and `memory:check`.
+- [x] 2.2 Keep `pre-commit` scoped to staged formatting/lint fixes and document the split in repository-native workflow guidance if needed.
+
+## 3. Workflow Integration
+
+- [x] 3.1 Update merge-gating CI to consume the shared classifier and run a minimal Ubuntu build for process-only changes.
+- [x] 3.2 Update PR governance to consume the shared classifier for process-only and product-impacting release-intent checks.
+
+## 4. Validation And Closure
+
+- [x] 4.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run openspec:validate`, and `bun run memory:check`.
+- [x] 4.2 Run `bun run test` if the classifier or workflow-support code gains behavior that is covered by automated tests.
+- [x] 4.3 Report OpenSpec, validation, git, commit, push, PR, release, and archive-closure state for this implementation pass.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "vitest": "^4.1.3"
   },
   "simple-git-hooks": {
-    "pre-commit": "bun install --frozen-lockfile && npx lint-staged"
+    "pre-commit": "bun install --frozen-lockfile && npx lint-staged",
+    "pre-push": "bun run format:check && bun run typecheck && bun run openspec:validate && bun run memory:check"
   },
   "lint-staged": {
     "*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}": [

--- a/scripts/path-taxonomy.ts
+++ b/scripts/path-taxonomy.ts
@@ -1,0 +1,104 @@
+import { appendFile } from 'node:fs/promises'
+import process from 'node:process'
+
+export type ChangeScope = 'mixed' | 'process-only' | 'product-impacting' | 'unknown'
+
+export interface ChangeScopeClassification {
+  changedFiles: string[]
+  processOnly: boolean
+  productImpacting: boolean
+  productImpactingFiles: string[]
+  runTestMatrix: boolean
+  scope: ChangeScope
+}
+
+export const productImpactingPrefixes = ['src/', 'scripts/', 'skills/quantex-cli/'] as const
+
+export const productImpactingFiles = new Set([
+  'package.json',
+  'bun.lock',
+  'install.sh',
+  'install.ps1',
+  'tsdown.config.ts',
+])
+
+export const processOnlyFiles = new Set([
+  'release-please-config.json',
+  'release-please-config.beta.json',
+  '.release-please-manifest.json',
+])
+
+export const processOnlyPrefixes = ['.github/', 'docs/', 'openspec/'] as const
+
+export function isProductImpactingPath(fileName: string): boolean {
+  return productImpactingPrefixes.some(prefix => fileName.startsWith(prefix)) || productImpactingFiles.has(fileName)
+}
+
+export function isProcessOnlyPath(fileName: string): boolean {
+  return processOnlyPrefixes.some(prefix => fileName.startsWith(prefix)) || processOnlyFiles.has(fileName)
+}
+
+export function classifyChangedFiles(changedFiles: string[] | null | undefined): ChangeScopeClassification {
+  if (!changedFiles || changedFiles.length === 0) {
+    return {
+      changedFiles: changedFiles ?? [],
+      processOnly: false,
+      productImpacting: false,
+      productImpactingFiles: [],
+      runTestMatrix: true,
+      scope: 'unknown',
+    }
+  }
+
+  const productImpactingMatches = changedFiles.filter(isProductImpactingPath)
+  const productImpacting = productImpactingMatches.length > 0
+  const processOnly = changedFiles.every(isProcessOnlyPath)
+  const runTestMatrix = !processOnly
+  const scope = processOnly ? 'process-only' : productImpacting ? 'product-impacting' : 'mixed'
+
+  return {
+    changedFiles,
+    processOnly,
+    productImpacting,
+    productImpactingFiles: productImpactingMatches,
+    runTestMatrix,
+    scope,
+  }
+}
+
+if (import.meta.main) {
+  const changedFiles = readChangedFilesFromEnv()
+  const diffAvailable = process.env.CHANGED_FILES_AVAILABLE !== 'false'
+  const classification = diffAvailable ? classifyChangedFiles(changedFiles) : classifyChangedFiles(undefined)
+
+  await writeGithubOutputs(classification)
+  console.log(JSON.stringify(classification))
+}
+
+function readChangedFilesFromEnv(): string[] | undefined {
+  const rawValue = process.env.CHANGED_FILES_JSON
+  if (!rawValue) return undefined
+
+  const parsedValue = JSON.parse(rawValue)
+  if (!Array.isArray(parsedValue) || parsedValue.some(value => typeof value !== 'string')) {
+    throw new Error('CHANGED_FILES_JSON must be a JSON array of file paths.')
+  }
+
+  return parsedValue
+}
+
+async function writeGithubOutputs(classification: ChangeScopeClassification): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (!outputPath) return
+
+  const outputLines = [
+    `changed_files=${JSON.stringify(classification.changedFiles)}`,
+    `process_only=${String(classification.processOnly)}`,
+    `product_impacting=${String(classification.productImpacting)}`,
+    `product_impacting_files=${JSON.stringify(classification.productImpactingFiles)}`,
+    `run_test_matrix=${String(classification.runTestMatrix)}`,
+    `scope=${classification.scope}`,
+  ]
+
+  await appendFile(outputPath, `${outputLines.join('\n')}\n`)
+}

--- a/test/path-taxonomy.test.ts
+++ b/test/path-taxonomy.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { classifyChangedFiles, isProcessOnlyPath, isProductImpactingPath } from '../scripts/path-taxonomy'
+
+describe('path taxonomy', () => {
+  it('classifies process-only changes from docs and workflow paths', () => {
+    expect(classifyChangedFiles(['.github/workflows/ci.yml', 'openspec/specs/code-quality-tooling/spec.md'])).toEqual({
+      changedFiles: ['.github/workflows/ci.yml', 'openspec/specs/code-quality-tooling/spec.md'],
+      processOnly: true,
+      productImpacting: false,
+      productImpactingFiles: [],
+      runTestMatrix: false,
+      scope: 'process-only',
+    })
+  })
+
+  it('classifies product-impacting changes when any product file is present', () => {
+    expect(classifyChangedFiles(['docs/github-collaboration.md', 'src/cli.ts'])).toEqual({
+      changedFiles: ['docs/github-collaboration.md', 'src/cli.ts'],
+      processOnly: false,
+      productImpacting: true,
+      productImpactingFiles: ['src/cli.ts'],
+      runTestMatrix: true,
+      scope: 'product-impacting',
+    })
+  })
+
+  it('classifies uncategorized files as mixed', () => {
+    expect(classifyChangedFiles(['.vscode/settings.json'])).toEqual({
+      changedFiles: ['.vscode/settings.json'],
+      processOnly: false,
+      productImpacting: false,
+      productImpactingFiles: [],
+      runTestMatrix: true,
+      scope: 'mixed',
+    })
+  })
+
+  it('defaults to unknown scope when no changed-file diff is available', () => {
+    expect(classifyChangedFiles(undefined)).toEqual({
+      changedFiles: [],
+      processOnly: false,
+      productImpacting: false,
+      productImpactingFiles: [],
+      runTestMatrix: true,
+      scope: 'unknown',
+    })
+  })
+
+  it('exposes stable product-impacting and process-only predicates', () => {
+    expect(isProductImpactingPath('scripts/path-taxonomy.ts')).toBe(true)
+    expect(isProductImpactingPath('docs/README.md')).toBe(false)
+    expect(isProcessOnlyPath('.github/workflows/ci.yml')).toBe(true)
+    expect(isProcessOnlyPath('src/index.ts')).toBe(false)
+  })
+})

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -13,8 +13,8 @@ describe('pr governance release intent', () => {
   it('guards product-impacting files from silently skipping release automation', () => {
     expect(prGovernanceWorkflow).toContain('Validate product release intent')
     expect(prGovernanceWorkflow).toContain("headBranch.startsWith('release-please--branches--')")
-    expect(prGovernanceWorkflow).toContain("fileName.startsWith('src/')")
-    expect(prGovernanceWorkflow).toContain("fileName.startsWith('skills/quantex-cli/')")
+    expect(prGovernanceWorkflow).toContain('PRODUCT_IMPACTING_FILES_JSON')
+    expect(prGovernanceWorkflow).toContain('bun run scripts/path-taxonomy.ts')
     expect(prGovernanceWorkflow).toContain('Release: not applicable - <reason>')
   })
 

--- a/test/workflow-classification.test.ts
+++ b/test/workflow-classification.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8')
+const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml', 'utf8')
+
+describe('workflow classification integration', () => {
+  it('routes CI scope classification through the shared taxonomy script', () => {
+    expect(ciWorkflow).toContain('bun run scripts/path-taxonomy.ts')
+    expect(ciWorkflow).toContain('CHANGED_FILES_JSON')
+    expect(ciWorkflow).not.toContain('const productImpactingPrefixes = [')
+  })
+
+  it('routes PR governance scope classification through the shared taxonomy script', () => {
+    expect(prGovernanceWorkflow).toContain('bun run scripts/path-taxonomy.ts')
+    expect(prGovernanceWorkflow).toContain('steps.classify.outputs.scope')
+    expect(prGovernanceWorkflow).not.toContain("fileName.startsWith('src/')")
+  })
+})


### PR DESCRIPTION
## Summary

Unify workflow scope classification behind a shared repository script, add a `pre-push` validation gate, and make process-only CI run a minimal Ubuntu build instead of a pure no-op matrix green.

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: `openspec/changes/unify-ci-validation-gates/`
- Discussion: CI workflow deep-diagnosis thread on 2026-04-29

## Validation

- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run openspec:validate`
- [x] `bun run memory:check`
- [x] `bun run test`
- [x] `pre-push` verification via real `git push`
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - workflow and repository validation hardening only

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Local validation passed.
- [x] Changes were committed.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] Release is not applicable for this change.
- [x] OpenSpec archive closure remains pending until after merge.
