### PR TITLE
feat: add Qwen Code agent support

### DIFF
--- a/openspec/changes/2026-04-29-add-qwen-code-support/proposal.md
+++ b/openspec/changes/2026-04-29-add-qwen-code-support/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Qwen Code (by QwenLM/Alibaba) is an open-source AI coding agent CLI that users want to manage through Quantex's lifecycle commands. It is actively maintained (npm v0.15.4, 9k+ Homebrew installs in 30 days) and has official install scripts, npm distribution, and Homebrew support. Adding it to the catalog lets users install, inspect, ensure, update, uninstall, resolve, and shortcut-launch Qwen Code with the same stable Quantex contract as existing agents.
+
+## What Changes
+
+- Add Qwen Code as a supported agent catalog entry.
+- Expose Qwen Code through existing lookup, list, info, inspect, resolve, ensure, install, update, uninstall, and shortcut execution surfaces.
+- Include Qwen Code's lifecycle metadata: canonical name, display name, lookup alias, homepage, npm package, binary name, and supported install methods (script, bun, npm, brew).
+- Add tests covering the new catalog entry and registry export.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-catalog`: the supported agent catalog includes Qwen Code as a lifecycle-managed agent.
+
+## Impact
+
+- Affected code: `src/agents/definitions/`, `src/agents/index.ts`, and agent registry tests.
+- Affected contracts: supported agent catalog output and any CLI command that enumerates or resolves supported agents.
+- Dependencies: no new runtime dependency.

--- a/openspec/changes/2026-04-29-add-qwen-code-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/2026-04-29-add-qwen-code-support/specs/agent-catalog/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Qwen Code MUST be a supported lifecycle agent
+
+Quantex SHALL include Qwen Code in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, and stable identification.
+
+#### Scenario: Looking up Qwen Code
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `qwen` or the alias `qwen-code`
+- **THEN** Quantex returns a supported agent entry for Qwen Code
+- **AND** the entry identifies `qwen` as the executable binary
+- **AND** the entry identifies `@qwen-code/qwen-code` as its npm package metadata
+
+#### Scenario: Installing Qwen Code through supported methods
+
+- **WHEN** Quantex renders or executes install options for Qwen Code
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official Homebrew formula and curl installer options
+- **AND** Windows includes the official batch installer option

--- a/openspec/changes/2026-04-29-add-qwen-code-support/tasks.md
+++ b/openspec/changes/2026-04-29-add-qwen-code-support/tasks.md
@@ -1,0 +1,14 @@
+## 1. Catalog
+
+- [x] 1.1 Add a Qwen Code agent definition with lifecycle metadata and install methods.
+- [x] 1.2 Register and export Qwen Code through the agent registry.
+
+## 2. Tests
+
+- [x] 2.1 Add registry tests for Qwen Code metadata, install methods, and lookup aliases.
+- [x] 2.2 Run agent-focused tests.
+
+## 3. Validation
+
+- [x] 3.1 Run OpenSpec validation.
+- [x] 3.2 Run lint and typecheck.

--- a/src/agents/definitions/qwen.ts
+++ b/src/agents/definitions/qwen.ts
@@ -1,0 +1,38 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, bunInstall, npmInstall, scriptInstall } from '../methods'
+
+export const qwen: AgentDefinition = {
+  name: 'qwen',
+  lookupAliases: ['qwen-code'],
+  displayName: 'Qwen Code',
+  homepage: 'https://qwenlm.github.io/qwen-code-docs/',
+  packages: {
+    npm: '@qwen-code/qwen-code',
+  },
+  binaryName: 'qwen',
+  platforms: {
+    windows: [
+      scriptInstall(
+        'curl -fsSL -o %TEMP%\\install-qwen.bat https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen.bat && %TEMP%\\install-qwen.bat',
+      ),
+      bunInstall(),
+      npmInstall(),
+    ],
+    macos: [
+      scriptInstall(
+        'curl -fsSL https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen.sh | bash',
+      ),
+      bunInstall(),
+      npmInstall(),
+      brewInstall('qwen-code'),
+    ],
+    linux: [
+      scriptInstall(
+        'curl -fsSL https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen.sh | bash',
+      ),
+      bunInstall(),
+      npmInstall(),
+      brewInstall('qwen-code'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -9,8 +9,9 @@ import { kilo } from './definitions/kilo'
 import { opencode } from './definitions/opencode'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
+import { qwen } from './definitions/qwen'
 
-const agents: AgentDefinition[] = [claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi, qoder]
+const agents: AgentDefinition[] = [claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi, qoder, qwen]
 
 export function getAllAgents(): AgentDefinition[] {
   return agents
@@ -24,7 +25,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
   return getAgentByLookupName(name)
 }
 
-export { claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi, qoder }
+export { claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi, qoder, qwen }
 export type {
   AgentDefinition,
   AgentPackageMetadata,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -11,12 +11,13 @@ import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
 import { pi } from '../src/agents/definitions/pi'
 import { qoder } from '../src/agents/definitions/qoder'
+import { qwen } from '../src/agents/definitions/qwen'
 import { formatInstallMethodCommand } from '../src/utils/install'
 
 describe('agent registry', () => {
   it('returns array with at least 10 agents', () => {
     const agents = getAllAgents()
-    expect(agents.length).toBeGreaterThanOrEqual(10)
+    expect(agents.length).toBeGreaterThanOrEqual(11)
   })
 
   it('finds agent by name', () => {
@@ -323,6 +324,47 @@ describe('qoder', () => {
   it('uses qodercli as the executable binary while keeping qoder as the slug', () => {
     expect(qoder.name).toBe('qoder')
     expect(qoder.binaryName).toBe('qodercli')
+  })
+})
+
+describe('qwen', () => {
+  it('is registered for lookup by alias', () => {
+    expect(getAgentByNameOrAlias('qwen')).toBe(qwen)
+    expect(getAgentByNameOrAlias('qwen-code')).toBe(qwen)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(qwen)
+    expect(qwen.name).toBe('qwen')
+    expect(qwen.lookupAliases).toEqual(['qwen-code'])
+    expect(qwen.displayName).toBe('Qwen Code')
+    expect(qwen.packages?.npm).toBe('@qwen-code/qwen-code')
+    expect(qwen.binaryName).toBe('qwen')
+    expect(qwen.homepage).toBe('https://qwenlm.github.io/qwen-code-docs/')
+  })
+
+  it('script install returns correct strings per platform', () => {
+    expect(
+      qwen.platforms.macos!.find(
+        m => m.type === 'script' && m.command.includes('qwen-code-assets.oss-cn-hangzhou.aliyuncs.com'),
+      ),
+    ).toBeDefined()
+    expect(
+      qwen.platforms.linux!.find(
+        m => m.type === 'script' && m.command.includes('qwen-code-assets.oss-cn-hangzhou.aliyuncs.com'),
+      ),
+    ).toBeDefined()
+    expect(
+      qwen.platforms.windows!.find(
+        m => m.type === 'script' && m.command.includes('qwen-code-assets.oss-cn-hangzhou.aliyuncs.com'),
+      ),
+    ).toBeDefined()
+  })
+
+  it('brew install returns correct strings per platform', () => {
+    expect(qwen.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'qwen-code')).toBeDefined()
+    expect(qwen.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'qwen-code')).toBeDefined()
+    expect(qwen.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

- Add Qwen Code (`@qwen-code/qwen-code`) to the supported agent catalog with full lifecycle metadata
- Install methods: official script installer (all platforms), bun/npm (all platforms), Homebrew `qwen-code` (macOS/Linux)
- Lookup alias: `qwen-code` in addition to canonical name `qwen`
- OpenSpec change: `2026-04-29-add-qwen-code-support`

## Linked Artifacts

- OpenSpec change: `openspec/changes/2026-04-29-add-qwen-code-support/`
- Spec: `openspec/specs/agent-catalog/spec.md`

## Validation

- `bun run lint` passes
- `bun run format:check` passes
- `bun run typecheck` passes
- `bun run test` — 331 tests pass
- `bun run openspec:validate` — 11/11 pass
- Pre-commit hooks pass
- Pre-push hooks pass (format, typecheck, openspec, memory)

## Release Intent

Release: yes — feat: adds a new supported agent to the catalog.

## Docs Updated

- OpenSpec proposal, tasks, and spec delta created under `openspec/changes/2026-04-29-add-qwen-code-support/`
- No README changes needed (agent catalog is enumerated from code, not hardcoded in docs)

## Scope Check

- Only adds a new agent definition; no changes to existing agent behavior, CLI surface, or contracts
- `src/agents/definitions/qwen.ts` (new), `src/agents/index.ts` (registration), `test/agents.test.ts` (tests)

## Closure Check

- [x] Local implementation complete
- [x] OpenSpec change created and validated
- [x] Committed and pushed
- [x] PR delivered
- [ ] Merge pending review
- [ ] Archive closure pending merge (sync spec delta, `openspec archive`)