### PR TITLE
ci: require pr body preflight in agent runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 - 不要把 Quantex 主线扩展成 workflow orchestration platform。
 - 不要因为用户催促、测试通过或任务勾选完成，就跳过 commit / push / PR / archive closure 检查。
 - 不要重新在各 agent 目录复制完整 OPSX workflow；只保留薄 bootstrap，具体规则走 central runtime skill 和 OpenSpec。
+- 不要新增 `pr:create` 等 repo-local workflow 包装命令；优先使用 Superpowers/runtime 指令、OpenSpec、GitHub Actions、原生 CLI 和窄验证器。
 - 不要在 `AGENTS.md` 里复制大段目录树、类型定义、完整命令表或其他易漂移内容。
 - 不要新建 ad hoc root-level markdown；先把内容归类到 `openspec/` 或 `docs/`。
 
@@ -96,6 +97,8 @@ bun run release:artifacts
 - remote state
 - PR state
 - release state
+
+创建或编辑 PR body 前，必须先基于 `.github/pull_request_template.md` 写入 body 文件，运行 `bun run pr:body:check -- --body-file <body-file> --title "<title>"`，再用 `gh pr create --body-file <body-file>` 或 `gh pr edit --body-file <body-file>`；不要手写 inline `gh pr create --body "$(cat <<EOF ...)"`，也不要新增 repo-local PR 创建包装命令。
 
 闭环层级：
 

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -47,6 +47,16 @@ Use explicit closure language when handing work between agents, reviewers, and a
 
 Agents should not summarize a task as simply "done" when the current state is only local implementation or PR delivery. If the next step belongs to CI, reviewer approval, release automation, or agent-driven OpenSpec archive closure, name that owner explicitly.
 
+## Pull request body preflight
+
+PR descriptions are part of the delivery contract, not a best-effort summary. Before creating or editing a PR body, agents should:
+
+1. Prepare a body file based on `.github/pull_request_template.md`.
+2. Run `bun run pr:body:check -- --body-file <body-file> --title "<title>"`.
+3. Use `gh pr create --body-file <body-file>` or `gh pr edit --body-file <body-file>`.
+
+Do not hand-write inline `gh pr create --body "$(cat <<EOF ...)"` payloads. Also do not add a repo-local `pr:create` wrapper only to sequence these steps; keep PR creation on the native GitHub CLI and keep repository code focused on shared validation.
+
 ## Worktree-backed implementation
 
 For implementation that is expected to create commits or a PR, Quantex defaults to a dedicated git worktree rather than switching the user's active workspace in place.
@@ -112,8 +122,8 @@ The repository now includes:
 
 - issue forms in `.github/ISSUE_TEMPLATE/`
 - a PR template in `.github/pull_request_template.md`
-- discussion forms in `.github/DISCUSSION_TEMPLATE/`
 - a PR body validation workflow in `.github/workflows/pr-governance.yml`
+- discussion forms in `.github/DISCUSSION_TEMPLATE/`
 
 ## Manual GitHub setup still required
 

--- a/openspec/changes/harden-pr-body-preflight-runtime/.openspec.yaml
+++ b/openspec/changes/harden-pr-body-preflight-runtime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/harden-pr-body-preflight-runtime/design.md
+++ b/openspec/changes/harden-pr-body-preflight-runtime/design.md
@@ -1,0 +1,40 @@
+## Context
+
+PR Governance now uses `bun run pr:body:check` in GitHub Actions, but agent sessions can still hand-write a malformed `gh pr create --body ...` payload. That failure mode is caught remotely, which protects `main`, but it still creates avoidable red CI and another repair loop.
+
+The repository also has an explicit boundary: Quantex should not become a workflow orchestration platform, and the product repo should not accumulate custom lifecycle commands when native tools and Superpowers can carry the workflow.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move PR body validation into the agent delivery routine before PR creation or PR body edits.
+- Reuse `.github/pull_request_template.md` and `bun run pr:body:check` instead of duplicating PR body rules in prompts.
+- Keep `gh pr create` and `gh pr edit` as the action tools rather than introducing a repo-local PR creation wrapper.
+- Clarify the repository script boundary so future fixes prefer validators over workflow orchestrators.
+
+**Non-Goals:**
+
+- Do not add `bun run pr:create`, `workflow:*`, or another command that wraps GitHub PR creation.
+- Do not replace GitHub Actions PR Governance.
+- Do not remove build, package, release artifact, taxonomy, or policy validation scripts that remain executable guardrails.
+
+## Decisions
+
+1. Keep PR creation native and validate the body as an input file first.
+
+   Agents MUST prepare the PR body in a file, validate it with `bun run pr:body:check -- --body-file <file> --title "<title>"`, and only then call `gh pr create --body-file <file>` or `gh pr edit --body-file <file>`. This keeps the workflow visible while making the policy executable.
+
+2. Treat repository scripts as guardrails, not session orchestration.
+
+   Scripts may classify paths, validate policy, generate build metadata, or verify release artifacts. They MUST NOT become the primary way agents perform routine GitHub/OpenSpec lifecycle actions when official CLIs plus Superpowers runtime instructions are sufficient.
+
+3. Put the rule in the central runtime and thin fallback.
+
+   `skills/quantex-agent-runtime/SKILL.md` carries the detailed cross-agent delivery flow. `AGENTS.md` remains thin but includes the hard PR body preflight because it is an immediate execution constraint for any agent that cannot or does not activate Superpowers.
+
+## Risks / Trade-offs
+
+- Agents may still ignore instructions and call `gh pr create --body` directly. Mitigation: GitHub PR Governance remains the remote enforcement layer and fails the PR before merge.
+- A file-based body step is slightly more manual than a wrapper command. Mitigation: it avoids growing a hidden workflow CLI and keeps the body inspectable before creation.
+- Claude-specific hooks could block direct `gh pr create --body`, but they would not be portable across agents. Mitigation: keep hook ideas as optional environment hardening rather than repo contract.

--- a/openspec/changes/harden-pr-body-preflight-runtime/proposal.md
+++ b/openspec/changes/harden-pr-body-preflight-runtime/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+PR body governance now catches malformed pull request descriptions in CI, but agents can still create a PR with an invalid hand-written body and only discover the problem after PR Governance turns red. The fix should left-shift the existing validator into the agent delivery flow without adding another repo-local workflow CLI or wrapping native `gh` behavior.
+
+This is a durable workflow and project-memory change because it changes how supported agent sessions deliver PRs.
+
+## What Changes
+
+- Require agents to prepare PR bodies as files based on `.github/pull_request_template.md` before creating or editing pull requests.
+- Require agents to run the existing local `bun run pr:body:check` command before `gh pr create` or `gh pr edit` when a PR body is provided.
+- Clarify that Quantex keeps repository scripts as validators, classifiers, build helpers, and release artifact checks, not as general workflow orchestration commands.
+- Explicitly discourage adding repo-local wrappers such as `pr:create` when a native tool plus a shared validator is sufficient.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `project-memory`: defines the Superpowers-backed delivery runtime boundary between agent instructions, native tools, and repo-local validation scripts.
+- `release-governance`: requires PR body governance to be run before PR creation or PR body edits, not only inside GitHub Actions.
+
+## Impact
+
+- Affected artifacts: `AGENTS.md`, `skills/quantex-agent-runtime/SKILL.md`, `openspec/specs/project-memory/spec.md`, and `openspec/specs/release-governance/spec.md`.
+- Affected systems: agent PR delivery closure, PR Governance preflight, and repository script boundary.
+- Non-goal: do not introduce a `pr:create`, `workflow:*`, or similar repo-local command that wraps GitHub pull request creation.

--- a/openspec/changes/harden-pr-body-preflight-runtime/specs/project-memory/spec.md
+++ b/openspec/changes/harden-pr-body-preflight-runtime/specs/project-memory/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Repository workflow scripts MUST remain guardrails instead of orchestration commands
+
+Repository scripts that support the agent workflow SHALL remain focused on validation, classification, generation of build or release artifacts, and other executable guardrails. The project MUST NOT add repo-local workflow wrapper commands when Superpowers runtime instructions plus official CLIs such as `gh`, `git`, and `openspec` can perform the action with the same reviewability.
+
+#### Scenario: A workflow gap is discovered
+
+- **GIVEN** a recurring agent delivery failure is discovered
+- **WHEN** a maintainer chooses how to fix it
+- **THEN** the maintainer MUST prefer central runtime instructions, OpenSpec contracts, GitHub-native workflow enforcement, or a narrow validator over a new repo-local orchestration command
+
+#### Scenario: Native tool plus validator is sufficient
+
+- **GIVEN** an agent needs to create or edit a pull request
+- **WHEN** the repository already exposes a local validator for the PR body
+- **THEN** the project MUST keep the action on the native GitHub CLI
+- **AND** it MUST NOT add a project-specific PR creation command solely to sequence that native action

--- a/openspec/changes/harden-pr-body-preflight-runtime/specs/release-governance/spec.md
+++ b/openspec/changes/harden-pr-body-preflight-runtime/specs/release-governance/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: PR body governance MUST be run before PR delivery actions
+
+Agents and contributors SHALL run the local PR body governance command before creating a pull request or editing a pull request body when they provide a body manually. The repository SHALL prefer native GitHub CLI PR commands with a validated body file over repo-local commands that wrap PR creation.
+
+#### Scenario: Agent creates a pull request
+
+- **GIVEN** an agent has prepared a branch for PR delivery
+- **WHEN** the agent writes the pull request body
+- **THEN** it MUST write the body to a file based on `.github/pull_request_template.md`
+- **AND** it MUST run `bun run pr:body:check -- --body-file <body-file> --title "<title>"` before `gh pr create --body-file <body-file>`
+
+#### Scenario: Agent edits a pull request body
+
+- **GIVEN** an agent needs to update an existing pull request body
+- **WHEN** the agent prepares the replacement body manually
+- **THEN** it MUST run `bun run pr:body:check -- --body-file <body-file> --title "<title>"` before `gh pr edit --body-file <body-file>`
+
+#### Scenario: PR body preflight is skipped
+
+- **GIVEN** a pull request body is malformed or missing required governance sections
+- **WHEN** local preflight is skipped
+- **THEN** GitHub Actions PR Governance MUST still evaluate the same PR body policy and fail the pull request before merge

--- a/openspec/changes/harden-pr-body-preflight-runtime/tasks.md
+++ b/openspec/changes/harden-pr-body-preflight-runtime/tasks.md
@@ -1,0 +1,14 @@
+## 1. Contract
+
+- [x] 1.1 Add OpenSpec proposal, design, and spec deltas for PR body preflight and script-boundary behavior.
+- [x] 1.2 Update the central Quantex runtime skill with file-based PR body preflight before PR create/edit.
+- [x] 1.3 Update the thin AGENTS fallback with the same hard PR body preflight constraint.
+- [x] 1.4 Update GitHub collaboration docs with the native CLI plus validator delivery pattern.
+
+## 2. Validation
+
+- [x] 2.1 Run `bun run openspec:validate`.
+- [x] 2.2 Run `bun run lint`.
+- [x] 2.3 Run `bun run format:check`.
+- [x] 2.4 Run `bun run typecheck`.
+- [x] 2.5 Run `bun run memory:check`.

--- a/skills/quantex-agent-runtime/SKILL.md
+++ b/skills/quantex-agent-runtime/SKILL.md
@@ -75,6 +75,14 @@ Also run:
 
 ## Delivery Closure
 
+Before creating or editing a pull request body:
+
+1. Prepare the body as a file based on `.github/pull_request_template.md`.
+2. Run `bun run pr:body:check -- --body-file <body-file> --title "<title>"`.
+3. Use the validated file with `gh pr create --body-file <body-file>` or `gh pr edit --body-file <body-file>`.
+
+Do not hand-write inline `gh pr create --body "$(cat <<EOF ...)"` payloads, and do not add a repo-local PR creation wrapper when the native `gh` command plus the validator is enough.
+
 Before final handoff, report:
 
 - validation state
@@ -105,10 +113,16 @@ After an OpenSpec-backed implementation PR merges:
 2. Sync accepted spec deltas into `openspec/specs/` when they are not already present.
 3. Run `bun run openspec:archive-closure -- <change-id> --body-file .tmp/archive-pr-body.md`.
 4. Use the generated body file when creating or editing the archive PR.
-5. Run `bun run pr:body:check -- --body-file .tmp/archive-pr-body.md --title "<archive-pr-title>"` if the PR body is edited manually.
+5. Run `bun run pr:body:check -- --body-file .tmp/archive-pr-body.md --title "<archive-pr-title>"` before creating or editing the archive PR.
 6. Commit, push, and open the archive PR when protected branches prevent direct archive closure.
 
 Do not rely on repository automation to create archive PRs.
+
+## Script Boundary
+
+Repository scripts are executable guardrails: validation, path classification, build metadata, package checks, release artifact generation, and release smoke verification. Prefer Superpowers runtime instructions, OpenSpec artifacts, GitHub Actions, and native CLIs for workflow actions.
+
+Do not add project-specific workflow orchestration commands, such as `pr:create`, when a native CLI action plus a shared validator is sufficient.
 
 ## Artifact Routing
 


### PR DESCRIPTION
## Summary

- Require agents to prepare PR bodies as files and run `bun run pr:body:check` before `gh pr create` or `gh pr edit`.
- Keep PR delivery on native `gh --body-file` instead of adding a repo-local `pr:create` workflow wrapper.
- Document the script boundary so repository scripts stay focused on validators, classifiers, build helpers, and release checks.

## Linked Artifacts

- OpenSpec: `openspec/changes/harden-pr-body-preflight-runtime/`
- Docs: `docs/github-collaboration.md`

## Validation

- [x] `bun run openspec:validate`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run memory:check`
- [x] Pre-commit hook passed
- [x] Pre-push hook passed

## Release Intent

- Release: not applicable - process/documentation workflow change only

## Docs Updated

- [x] `AGENTS.md`
- [x] `skills/quantex-agent-runtime/SKILL.md`
- [x] `docs/github-collaboration.md`
- [x] `openspec/changes/harden-pr-body-preflight-runtime/`

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant OpenSpec change and collaboration docs.
- [x] I did not add a repo-local PR creation wrapper or expand Quantex into workflow orchestration.

## Closure Check

- [x] Working tree was clean after commit except for this temporary PR body file.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is active by design until merge, then requires archive closure.
- [x] Release is not applicable.

## Notes

This PR intentionally dogfoods the new delivery rule: this body was prepared as a file, validated locally with `bun run pr:body:check`, and will be passed to `gh pr create --body-file`.
