### PR TITLE
test: add isolated agent lifecycle smoke

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -1,0 +1,56 @@
+name: Sandbox Tests
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+      - beta
+
+  schedule:
+    - cron: '0 6 * * 2'
+
+env:
+  CI: true
+  BUN_INSTALL_CACHE_DIR: .bun/install/cache
+  MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+  MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+  QTX_ISOLATION_AGENTS: pi,opencode
+  QTX_ISOLATION_COMMAND_TIMEOUT_MS: 600000
+
+permissions:
+  contents: read
+
+jobs:
+  sandbox-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            .bun/install/cache
+            node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock', 'package.json') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install Modal CLI
+        run: |
+          python -m pip install --upgrade pip
+          pip install modal
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --no-progress
+
+      - name: Run Modal sandbox lifecycle smoke
+        run: bun run test:sandbox

--- a/README.md
+++ b/README.md
@@ -253,8 +253,12 @@ bun run lint
 bun run format:check
 bun run typecheck
 bun run test
+bun run test:container
+bun run test:sandbox
 bun run build
 ```
+
+`bun run test:container` is the preferred local isolation pass for host-sensitive lifecycle checks when you want a clean Linux environment without installing Modal locally. It runs Quantex's real CLI lifecycle smoke flow for selected agents, including preinstalled-agent adoption and Quantex standalone-binary self checks, not the unit test suite. `bun run test:sandbox` runs the same smoke flow through Modal and is intended for validating the remote transport or the dedicated GitHub Actions workflow.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
 | Droid | `qtx droid` | Factory AI software engineering agent CLI |
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |
-| Kilo Code CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
+| Kilo CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -173,7 +173,7 @@ qtx upgrade --channel beta
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
 | Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |
-| Kilo Code CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
+| Kilo CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
 | OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
 | Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -16,6 +16,7 @@ Start from [_template.md](./_template.md).
 
 Current canonical runbooks:
 
+- [modal-sandbox-testing.md](./modal-sandbox-testing.md)
 - [quantex-troubleshooting.md](./quantex-troubleshooting.md)
 - [releasing-quantex.md](./releasing-quantex.md)
 - [release-and-self-upgrade-debugging.md](./release-and-self-upgrade-debugging.md)

--- a/docs/runbooks/modal-sandbox-testing.md
+++ b/docs/runbooks/modal-sandbox-testing.md
@@ -1,0 +1,139 @@
+# Runbook: Modal Sandbox Testing
+
+## Purpose
+
+Provide the repeatable flow for validating Quantex's real agent lifecycle behavior inside isolated Bun environments without turning the normal development loop into a remote-only workflow.
+
+## When to use
+
+- you changed install, ensure, exec, self-upgrade, or other lifecycle code that may interact with the local environment
+- you want a clean Linux HOME and PATH without using your host machine's global tool state
+- you want an extra validation layer after local `bun run test`, not a replacement for it
+
+## Inputs
+
+- `bun run test`
+- `bun run test:container`
+- `bun run test:sandbox`
+- Docker or Modal availability on the current machine
+
+## Prerequisites
+
+- For `bun run test:container`: Docker CLI available on `PATH`
+- For `bun run test:sandbox`: Modal CLI available on `PATH`
+- For `bun run test:sandbox`: an authenticated Modal profile, usually created with `modal setup`
+- network access for the isolated environment to install dependencies
+
+## Default local isolation command
+
+```bash
+bun run test:container
+```
+
+This command mounts the current checkout into a local Docker container based on the repository's default Bun image, copies the checkout to an internal temporary work directory, installs repository dependencies there, and then executes the lifecycle smoke script.
+
+The default lifecycle smoke agent is `pi`.
+
+Default scenarios:
+
+- `managed`: Quantex installs, inspects, resolves, ensures, updates, uninstalls, and re-inspects the agent.
+- `adopt-preinstalled`: the sandbox preinstalls the agent outside Quantex first, then verifies `quantex install <agent>` adopts and tracks that existing install.
+- `ambiguous-multi-method`: the sandbox places a fake multi-install-method agent binary in PATH and verifies Quantex does not guess an install source.
+- `self-binary`: the sandbox builds a Linux standalone Quantex binary, installs it into the isolated HOME, then verifies binary-entrypoint command discovery, agent inspection, and `upgrade --check` self-inspection.
+
+For each selected agent, the `managed` scenario executes the real Quantex CLI flow:
+
+- inspect before install
+- install
+- inspect after install
+- resolve
+- ensure idempotency
+- exec dry run
+- update
+- uninstall
+- inspect after uninstall
+
+## Modal-backed remote isolation
+
+When you want to verify the Modal path itself or exercise the same slice in the dedicated GitHub Actions transport, run:
+
+```bash
+bun run test:sandbox
+```
+
+The Modal command uses the same lifecycle smoke script and mounted-checkout shape as the Docker path, but requires a working local `modal` CLI plus credentials.
+
+## Custom agent list
+
+To override the default agent list, pass agent slugs after `--`:
+
+```bash
+bun run test:container -- pi qoder
+bun run test:sandbox -- pi qoder
+```
+
+The forwarded arguments replace the default agent list for that invocation. You can also set `QTX_ISOLATION_AGENTS=pi,qoder`.
+
+To limit scenarios, set `QTX_ISOLATION_SCENARIOS`:
+
+```bash
+QTX_ISOLATION_SCENARIOS=managed,adopt-preinstalled bun run test:container
+QTX_ISOLATION_SCENARIOS=self-binary bun run test:container
+QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:container
+```
+
+Individual lifecycle commands time out after `QTX_ISOLATION_COMMAND_TIMEOUT_MS` milliseconds, defaulting to 300 seconds. Broader real-agent runs may need a higher timeout when upstream packages are slow.
+
+For local broad-agent coverage without the slower upstream install path, `qoder` is the preferred multi-install-method agent:
+
+```bash
+QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:container
+```
+
+The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AGENTS=pi,opencode` and a longer command timeout so remote validation covers both the lightweight managed-only default and an upstream package that can be slow from a local network.
+
+## Triage order
+
+1. Run local validation first:
+
+   ```bash
+   bun run lint
+   bun run format:check
+   bun run typecheck
+   bun run test
+   ```
+
+2. Run `bun run test:container` when the change is sensitive to HOME, PATH, global tools, or filesystem isolation and you want a local fallback that does not require Modal.
+3. Run `bun run test:sandbox` when you also want to validate the Modal transport or reproduce the dedicated GitHub Actions workflow.
+4. If an isolated run fails, compare whether the failure is code-related or environment-related by rerunning the same agent list locally.
+5. If Modal setup is missing, install or repair the local Modal CLI before treating the failure as a product regression.
+
+## Recovery
+
+If `bun run test:container` reports that `docker` is missing, install or start a compatible Docker runtime before retrying.
+
+If `bun run test:sandbox` reports that `modal` is missing, install the CLI and authenticate:
+
+```bash
+pip install modal
+modal setup
+```
+
+If the sandbox cannot reach the network or registry, retry after confirming Modal workspace health and outbound access.
+
+If the isolated run is too broad or slow, narrow the agent list with explicit arguments instead of editing the repository default immediately.
+
+## Escalation
+
+Stop and ask for human input when:
+
+- the change appears to require platform-specific validation outside Linux
+- Modal account policy or credentials are unavailable to the current contributor
+- the isolation layer needs to become merge-gating CI instead of an opt-in maintainer tool
+- a new scenario needs to mutate real external account state instead of a disposable package install inside the sandbox
+
+## Related artifacts
+
+- [README.md](../../README.md)
+- [Code Quality Tooling Spec](../../openspec/specs/code-quality-tooling/spec.md)
+- [OpenSpec change add-modal-sandbox-test-layer](../../openspec/changes/add-modal-sandbox-test-layer/proposal.md)

--- a/openspec/changes/add-modal-sandbox-test-layer/.openspec.yaml
+++ b/openspec/changes/add-modal-sandbox-test-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/add-modal-sandbox-test-layer/design.md
+++ b/openspec/changes/add-modal-sandbox-test-layer/design.md
@@ -1,0 +1,73 @@
+## Context
+
+Quantex is a CLI project, so most of its logic belongs in fast local tests. The gap is not unit coverage; the gap is a lightweight way to re-run a narrow slice of host-sensitive validation inside an isolated environment without asking contributors to manually prepare a VM or risk mutating their workstation state.
+
+The repository already avoids orchestration-heavy project wrappers and prefers native tooling. That means the sandbox layer should stay thin, optional, and easy to reason about.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide one repository-native command for running a curated validation slice inside a Modal sandbox.
+- Provide one repository-native local fallback command for running the same slice inside Docker when Modal is unavailable on the contributor machine.
+- Keep the implementation small enough that Quantex does not grow workflow-platform behavior.
+- Reuse official Modal primitives for mounting a local checkout and running commands in a remote container.
+- Reuse a normal Bun container image for local isolation without introducing a repository-specific Dockerfile.
+- Preserve `bun run test` as the default validation path for normal development.
+
+**Non-Goals:**
+
+- Replacing the local Vitest suite with remote execution.
+- Turning every CI run into a Modal-backed workflow.
+- Making the Modal sandbox workflow a merge-gating requirement in the first iteration.
+- Adding project-specific PR, queue, or workflow orchestration commands around Modal.
+- Building a general-purpose remote execution service inside Quantex itself.
+
+## Decisions
+
+- Use the Modal CLI's `modal shell` path as the transport instead of adding a repository-managed Python Modal app.
+  Rationale: this keeps the integration thin, avoids adding a Python dependency graph to the repository, and uses official `--add-local` and `--image` support to mount the checkout into an isolated container.
+
+- Add a local Docker transport that uses the same Bun image and mounted checkout shape as the Modal path.
+  Rationale: contributors should be able to exercise the isolated test slice locally without needing Modal credentials or a local Modal CLI install.
+
+- Mount the current repository into the sandbox and execute tests from that mount.
+  Rationale: the official Modal docs support adding a local directory into the sandbox image/runtime, which gives us a fast path for validating the current checkout without a packaging step.
+
+- Default to a real lifecycle smoke script instead of running the unit test suite in a container.
+  Rationale: the isolation layer is intended to validate Quantex against a clean HOME, PATH, package-manager state, and real agent installs. The script exercises install, inspect, resolve, ensure, update, and uninstall for the selected agents.
+
+- Include adoption and self-binary scenarios in the default smoke set.
+  Rationale: Quantex must handle agents that were installed before Quantex started tracking them, and it must be able to inspect its own standalone binary install source and self-upgrade surface from an actual compiled entrypoint.
+
+- Include an ambiguous multi-method scenario for agents such as Qoder.
+  Rationale: agents with bun, npm, script, and brew install paths must not be silently adopted from a generic PATH hit unless Quantex can identify the actual install source.
+
+- Use the pinned Bun version from `package.json` as the default sandbox image tag.
+  Rationale: running inside `oven/bun:<version>` keeps the remote runtime aligned with the repository's local package-manager contract while avoiding ad hoc install logic inside the sandbox.
+
+- Fail fast with actionable guidance when the Modal CLI is unavailable locally.
+  Rationale: sandbox validation is optional, so the harness should clearly explain the missing prerequisite instead of failing with an opaque spawn error.
+
+- Keep Modal-backed isolation in a dedicated GitHub Actions workflow instead of merging it into `ci.yml`.
+  Rationale: the existing `ci.yml` workflow is the merge-gating path and intentionally avoids extra credentialed remote dependencies. A dedicated workflow keeps Modal tokens, scheduling, and failure modes isolated from the baseline CI contract.
+
+## Risks / Trade-offs
+
+- [Remote dependency drift] Modal login state, network availability, or registry access can fail independently of the code under test. → Mitigation: keep the command opt-in and document it as an additional validation layer rather than a mandatory local gate.
+- [Container runtime drift] Docker and Modal may expose slightly different defaults even when they share the same base image. → Mitigation: keep the default agent list narrow and treat Docker as a local isolation fallback, not as proof that the Modal workflow itself is healthy.
+- [False sense of isolation] A Linux sandbox does not cover macOS- or Windows-specific behavior. → Mitigation: scope the first version to host-sensitive generic flows and keep existing platform-specific CI and local tests in place.
+- [Slow feedback] Real lifecycle smoke installs and removes agent packages. → Mitigation: run one low-risk default agent and allow explicit agent lists when contributors need broader validation.
+- [Self-upgrade network variability] `upgrade --check` for standalone binaries depends on GitHub release metadata. → Mitigation: the smoke accepts check-unavailable results but still asserts that the binary entrypoint reports `installSource: binary` and `canAutoUpdate: true`.
+
+## Migration Plan
+
+- Add the OpenSpec delta describing the optional Docker and Modal isolation commands and the dedicated workflow.
+- Implement a shared command builder plus `test:container` and `test:sandbox` wrapper scripts.
+- Add a dedicated GitHub Actions workflow for Modal-backed isolation runs.
+- Document prerequisites and intended use in the README maintainer section and a dedicated runbook.
+- Validate with lint, format, typecheck, tests, and OpenSpec validation. The Modal-backed command itself is best-effort unless the local machine is authenticated with Modal.
+
+## Open Questions
+
+- None for the first slice. Broader coverage, PR-triggered remote runs, or non-Linux sandbox targets can be evaluated in later changes if the optional layer proves useful.

--- a/openspec/changes/add-modal-sandbox-test-layer/proposal.md
+++ b/openspec/changes/add-modal-sandbox-test-layer/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+The repository's local Vitest suite already protects most CLI logic, but a small set of lifecycle-oriented checks still benefit from running in a clean environment that does not share the contributor's real home directory, PATH, or globally installed tools. We need an opt-in isolation layer now so Quantex can validate host-sensitive flows without turning the default developer loop into a remote-only workflow or requiring every contributor workstation to have Modal installed.
+
+## What Changes
+
+- Add an optional `bun run test:sandbox` maintainer command that runs real Quantex agent lifecycle smoke checks inside a Modal sandbox.
+- Add an optional `bun run test:container` maintainer command that runs the same lifecycle smoke checks inside a local Docker container when contributors do not have Modal installed locally.
+- Keep `bun run test` as the canonical local suite and document that the Docker and Modal layers are extra isolation passes rather than replacements.
+- Add a repository-managed harness that mounts the current checkout into an isolated Bun container, copies it into an internal temporary work directory, installs dependencies inside that environment, and executes real Quantex lifecycle commands for the selected agents.
+- Cover preinstalled-agent adoption and Quantex standalone-binary self lifecycle checks in the default isolated smoke set.
+- Add a dedicated GitHub Actions workflow for Modal-backed sandbox tests instead of expanding the merge-gating `ci.yml` workflow.
+- Document prerequisites, scope, and troubleshooting for the isolation test layer in maintainer-facing docs.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: Add the optional Docker- and Modal-backed isolation validation contracts and their contributor guidance.
+
+## Impact
+
+- Affected code: `package.json`, `.github/workflows/`, `scripts/`, `src/testing/`, and `test/`.
+- Affected docs: `README.md` maintainer guidance and `docs/runbooks/`.
+- Affected contract: `openspec/specs/code-quality-tooling/spec.md`.

--- a/openspec/changes/add-modal-sandbox-test-layer/specs/agent-update/spec.md
+++ b/openspec/changes/add-modal-sandbox-test-layer/specs/agent-update/spec.md
@@ -1,0 +1,47 @@
+## MODIFIED Requirements
+
+### Requirement: Batch update MUST plan from recorded install sources
+
+Batch agent updates SHALL prioritize recorded actual install sources over candidate install methods declared for the agent.
+
+#### Scenario: Updating all installed agents
+
+- GIVEN multiple agents have recorded install state
+- WHEN the user runs `quantex update --all`
+- THEN Quantex groups update work by install type
+- AND it groups work by the recorded actual install source where available
+- AND it does not rely only on the agent definition's possible install methods
+
+#### Scenario: Skipping untracked PATH detections during batch update
+
+- GIVEN an agent binary is detected in `PATH`
+- AND Quantex has no recorded install state for that agent
+- WHEN the user runs `quantex update --all`
+- THEN Quantex does not execute managed update or self-update operations for that agent
+- AND the batch result explains that the agent was detected in `PATH` but is not tracked as a Quantex-managed install
+
+#### Scenario: Adopting a safely identifiable existing install
+
+- GIVEN an agent binary is detected in `PATH`
+- AND Quantex has no recorded install state for that agent
+- AND the current platform exposes exactly one supported unmanaged install method for that agent
+- WHEN the user runs `quantex install <agent>` or `quantex ensure <agent>`
+- THEN Quantex records that install method as the agent's install state without re-running an installer
+
+#### Scenario: Adopting a safely identifiable existing managed install
+
+- GIVEN an agent binary is detected in `PATH`
+- AND Quantex has no recorded install state for that agent
+- AND the detected binary path identifies a supported managed install source such as Bun global bin
+- WHEN the user runs `quantex install <agent>` or `quantex ensure <agent>`
+- THEN Quantex records that managed install method as the agent's install state without re-running an installer
+- AND later lifecycle commands use that recorded managed install source
+
+#### Scenario: Refusing to guess an ambiguous existing install source
+
+- GIVEN an agent binary is detected in `PATH`
+- AND Quantex has no recorded install state for that agent
+- AND the current platform exposes multiple plausible install methods without an identifying binary path
+- WHEN the user runs `quantex install <agent>` or `quantex ensure <agent>`
+- THEN Quantex does not invent or overwrite install state for that agent
+- AND the command explains that the install remains untracked

--- a/openspec/changes/add-modal-sandbox-test-layer/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/add-modal-sandbox-test-layer/specs/code-quality-tooling/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Optional isolation validation commands
+
+The repository SHALL expose `bun run test:sandbox` and `bun run test:container` as optional maintainer-facing validation commands for running real Quantex agent lifecycle smoke checks inside isolated Bun environments. These commands MUST complement rather than replace the canonical local `bun run test` workflow.
+
+#### Scenario: Contributor runs local container isolation with default targets
+
+- **WHEN** a contributor runs `bun run test:container`
+- **THEN** the repository invokes Docker against a Bun container that mounts the current checkout
+- **AND** the container command copies the checkout into an internal temporary work directory
+- **AND** it installs repository dependencies inside the isolated environment before running the default lifecycle smoke flow
+- **AND** the default lifecycle smoke flow executes real Quantex CLI install, inspect, resolve, ensure, update, and uninstall commands for the selected agent list
+- **AND** the default lifecycle smoke flow verifies that Quantex can adopt an agent that was installed before Quantex started tracking it
+- **AND** the default lifecycle smoke flow verifies that ambiguous multi-install-method PATH detections remain untracked
+- **AND** the default lifecycle smoke flow verifies Quantex's standalone binary entrypoint and self-upgrade inspection surface
+- **AND** the command exits non-zero if the isolated validation fails
+
+#### Scenario: Contributor runs sandbox validation with default targets
+
+- **WHEN** a contributor runs `bun run test:sandbox`
+- **THEN** the repository invokes the Modal CLI against a sandbox container that mounts the current checkout
+- **AND** the sandbox command copies the checkout into an internal temporary work directory
+- **AND** it installs repository dependencies inside the isolated environment before running the default lifecycle smoke flow
+- **AND** the default lifecycle smoke flow executes real Quantex CLI install, inspect, resolve, ensure, update, and uninstall commands for the selected agent list
+- **AND** the default lifecycle smoke flow verifies that Quantex can adopt an agent that was installed before Quantex started tracking it
+- **AND** the default lifecycle smoke flow verifies that ambiguous multi-install-method PATH detections remain untracked
+- **AND** the default lifecycle smoke flow verifies Quantex's standalone binary entrypoint and self-upgrade inspection surface
+- **AND** the command exits non-zero if the remote validation fails
+
+#### Scenario: Contributor needs a different agent smoke list
+
+- **WHEN** a contributor passes explicit agent slugs after `bun run test:sandbox --` or `bun run test:container --`
+- **THEN** the repository forwards those agent slugs to the isolated lifecycle smoke script
+- **AND** the default agent list is skipped for that invocation
+
+#### Scenario: Contributor needs a narrower scenario set
+
+- **WHEN** a contributor sets `QTX_ISOLATION_SCENARIOS`
+- **THEN** the isolated lifecycle smoke script runs only the named scenarios
+- **AND** omitted scenarios do not run for that invocation
+
+#### Scenario: External lifecycle command stalls
+
+- **WHEN** an isolated lifecycle command exceeds the configured command timeout
+- **THEN** the smoke script terminates that command
+- **AND** the isolation validation fails instead of hanging indefinitely
+
+#### Scenario: Contributor follows normal local validation
+
+- **WHEN** a contributor reads the repository's maintainer-facing validation guidance
+- **THEN** the guidance still presents `bun run test` as the default local suite
+- **AND** it describes `bun run test:container` and `bun run test:sandbox` as opt-in isolation layers for host-sensitive checks rather than mandatory replacements
+
+#### Scenario: Docker prerequisite is missing
+
+- **WHEN** a contributor runs `bun run test:container` without a working `docker` CLI on `PATH`
+- **THEN** the command exits non-zero
+- **AND** stderr explains that Docker must be installed before container isolation can run
+
+#### Scenario: Modal CLI prerequisite is missing
+
+- **WHEN** a contributor runs `bun run test:sandbox` without a working `modal` CLI on `PATH`
+- **THEN** the command exits non-zero
+- **AND** stderr explains that Modal must be installed and authenticated before sandbox validation can run
+
+### Requirement: Modal-backed isolation workflow remains separate from merge-gating CI
+
+The repository SHALL keep Modal-backed isolation validation in a dedicated GitHub Actions workflow instead of adding it to the merge-gating `ci.yml` workflow.
+
+#### Scenario: Maintainer inspects GitHub Actions workflows
+
+- **WHEN** a maintainer inspects the repository workflows for isolation validation
+- **THEN** a dedicated workflow exists for Modal-backed sandbox tests
+- **AND** the merge-gating `ci.yml` workflow does not require Modal credentials to complete its normal validation path
+- **AND** the dedicated Modal workflow runs an expanded real-agent smoke set that includes a multi-install-method agent

--- a/openspec/changes/add-modal-sandbox-test-layer/tasks.md
+++ b/openspec/changes/add-modal-sandbox-test-layer/tasks.md
@@ -1,0 +1,18 @@
+## 1. Contract
+
+- [x] 1.1 Document the optional Docker and Modal isolation layer in the OpenSpec proposal, design, and code-quality-tooling delta spec.
+- [x] 1.2 Record contributor guidance for when the isolation layer should complement local `bun run test`.
+
+## 2. Implementation
+
+- [x] 2.1 Add repository-native `bun run test:container` and `bun run test:sandbox` harnesses that run real lifecycle smoke checks inside isolated Bun environments.
+- [x] 2.2 Add implementation tests for the isolation invocation builders and update maintainer-facing docs/runbooks.
+- [x] 2.3 Add a dedicated GitHub Actions workflow for Modal-backed sandbox tests without expanding the merge-gating `ci.yml` workflow.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/fix-agent-catalog-naming/.openspec.yaml
+++ b/openspec/changes/fix-agent-catalog-naming/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/fix-agent-catalog-naming/design.md
+++ b/openspec/changes/fix-agent-catalog-naming/design.md
@@ -1,0 +1,38 @@
+## Context
+
+Quantex models agent discovery through static catalog entries. This change only adjusts naming metadata that users and machine consumers see during lookup or inspection; it does not alter install methods, binaries, or update commands.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the catalog aligned with the intended upstream-facing names for Kilo, Qoder, and Qwen.
+- Preserve the existing `qoder` canonical slug while allowing lookup by the published binary name `qodercli`.
+- Stop advertising the legacy `qwen-code` alias through Quantex lookup surfaces.
+
+**Non-Goals:**
+
+- Changing install methods, package metadata, binaries, or self-update behavior.
+- Renaming canonical agent slugs.
+- Expanding the catalog with new agents.
+
+## Decisions
+
+- Use `Kilo CLI` as the Kilo display name so Quantex matches the shorter product-facing name already used in the implementation change.
+- Add `qodercli` as a lookup alias instead of renaming the canonical slug from `qoder`, because the existing Quantex command surface remains `qtx qoder` while the upstream executable is `qodercli`.
+- Remove `qwen-code` from `lookupAliases` so Quantex only resolves Qwen through the canonical `qwen` identifier.
+
+## Risks / Trade-offs
+
+- [Lookup compatibility] Removing `qwen-code` can break callers that still resolve Qwen through the legacy alias. → Mitigation: record the alias removal in the catalog spec and update tests so the change is explicit and intentional.
+- [Doc drift] README tables and tests can lag behind catalog metadata. → Mitigation: update product-facing tables and registry assertions in the same change.
+
+## Migration Plan
+
+- Update the agent definitions and associated assertions.
+- Sync the README supported-agent tables with the new names.
+- Validate with lint, format, typecheck, tests, and OpenSpec validation.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/fix-agent-catalog-naming/proposal.md
+++ b/openspec/changes/fix-agent-catalog-naming/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The supported agent catalog still exposes a few stale or inconsistent public names and lookup aliases for Kilo, Qoder, and Qwen. Because these identifiers are user-visible and machine-consumable lifecycle metadata, Quantex needs to align them with the current upstream naming we want to support.
+
+## What Changes
+
+- Rename the Kilo display name from `Kilo Code CLI` to `Kilo CLI`.
+- Add `qodercli` as a supported lookup alias for the canonical `qoder` agent entry.
+- Remove the legacy `qwen-code` lookup alias so Qwen resolves only through the canonical `qwen` slug.
+- Update tests and product-facing README tables to match the corrected catalog names.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-catalog`: Update the supported naming and lookup-alias contract for Kilo, Qoder, and Qwen catalog entries.
+
+## Impact
+
+- Affected code: `src/agents/definitions/`, agent lookup tests, and root README tables.
+- Affected contract: `openspec/specs/agent-catalog/spec.md`.

--- a/openspec/changes/fix-agent-catalog-naming/specs/agent-catalog/spec.md
+++ b/openspec/changes/fix-agent-catalog-naming/specs/agent-catalog/spec.md
@@ -1,29 +1,4 @@
-# agent-catalog Specification
-
-## Purpose
-TBD - created by archiving change remove-agent-description-metadata. Update Purpose after archive.
-## Requirements
-### Requirement: Supported agent catalog entries MUST stay lifecycle-focused
-
-Quantex SHALL keep supported agent catalog metadata scoped to values that directly support installation, inspection, resolution, execution, update planning, and stable machine-readable contracts.
-
-#### Scenario: Registering a supported agent entry
-
-- **WHEN** Quantex defines or updates a supported agent entry
-- **THEN** the entry includes only metadata that is relevant to lifecycle operations or stable identification
-- **AND** that metadata may include canonical name, display name, lookup aliases, homepage, package metadata, install methods, binary name, version probe data, and self-update commands
-- **AND** Quantex does not require free-form descriptive marketing copy as part of the catalog contract
-
-### Requirement: Lifecycle inspection surfaces MUST avoid localized descriptive metadata
-
-Quantex lifecycle inspection surfaces SHALL expose stable agent identifiers and lifecycle metadata without requiring localized prose fields.
-
-#### Scenario: Rendering or returning agent metadata
-
-- **GIVEN** the user runs `quantex info <agent>` or `quantex inspect <agent>`
-- **WHEN** Quantex returns human-readable or structured agent metadata
-- **THEN** the result includes the identifiers and lifecycle fields needed to install, inspect, or update the agent
-- **AND** the result does not depend on a free-form `description` field to remain valid
+## MODIFIED Requirements
 
 ### Requirement: Qoder CLI MUST be a supported lifecycle agent
 

--- a/openspec/changes/fix-agent-catalog-naming/tasks.md
+++ b/openspec/changes/fix-agent-catalog-naming/tasks.md
@@ -1,0 +1,17 @@
+## 1. Catalog Contract
+
+- [x] 1.1 Document the Kilo, Qoder, and Qwen naming updates in the OpenSpec proposal and agent-catalog delta spec.
+- [x] 1.2 Record the minimal implementation design and verification plan for the naming correction.
+
+## 2. Implementation
+
+- [x] 2.1 Update the affected agent definitions to use the corrected display names and lookup aliases.
+- [x] 2.2 Update tests and product-facing README tables to match the corrected catalog naming.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "release:artifacts": "bun run scripts/write-release-checksums.ts && bun run scripts/generate-release-manifest.ts && bun run scripts/verify-release-artifacts.ts",
     "release:smoke": "bun run scripts/verify-release-smoke.ts",
     "test": "vitest run",
+    "test:container": "bun run scripts/test-container.ts",
+    "test:sandbox": "bun run scripts/test-sandbox.ts",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -1,0 +1,339 @@
+import process from 'node:process'
+
+interface CommandOutput {
+  exitCode: number
+  stderr: string
+  stdout: string
+}
+
+interface JsonResult {
+  action?: string
+  data?: any
+  error?: { code?: string; message?: string } | null
+  ok?: boolean
+  warnings?: Array<{ code?: string; message?: string }>
+}
+
+const DEFAULT_SMOKE_AGENTS = ['pi']
+const DEFAULT_SMOKE_SCENARIOS = ['managed', 'adopt-preinstalled', 'ambiguous-multi-method', 'self-binary']
+const DEFAULT_COMMAND_TIMEOUT_MS = Number(process.env.QTX_ISOLATION_COMMAND_TIMEOUT_MS ?? 300_000)
+const agents = resolveSmokeAgents()
+const scenarios = resolveSmokeScenarios()
+const cli = ['bun', 'run', 'src/cli.ts', '--json', '--non-interactive', '--yes', '--color', 'never']
+
+console.log(`Lifecycle smoke agents: ${agents.join(', ')}`)
+console.log(`Lifecycle smoke scenarios: ${scenarios.join(', ')}`)
+
+await runJson('config set defaultPackageManager bun', [...cli, 'config', 'set', 'defaultPackageManager', 'bun'])
+
+const installedAgents: string[] = []
+
+try {
+  if (scenarios.includes('managed')) {
+    for (const agent of agents) {
+      installedAgents.push(agent)
+      await smokeManagedAgentLifecycle(agent)
+      installedAgents.pop()
+    }
+  }
+
+  if (scenarios.includes('adopt-preinstalled')) {
+    for (const agent of agents) await smokeAdoptPreinstalledAgent(agent)
+  }
+
+  if (scenarios.includes('ambiguous-multi-method')) await smokeAmbiguousMultiMethodAgent()
+
+  if (scenarios.includes('self-binary')) await smokeSelfBinaryLifecycle()
+} finally {
+  for (const agent of installedAgents.toReversed())
+    await runJson(`cleanup uninstall ${agent}`, [...cli, 'uninstall', agent], {
+      allowExitCodes: [0, 1],
+      allowFailure: true,
+    })
+}
+
+console.log('Lifecycle smoke completed successfully.')
+
+async function smokeManagedAgentLifecycle(agent: string): Promise<void> {
+  console.log(`\n[${agent}] inspect before install`)
+  const beforeInstall = await runJson(`inspect ${agent} before install`, [...cli, 'inspect', agent])
+  assertResult(
+    beforeInstall,
+    result => result.data?.inspection?.installed === false,
+    `${agent} should start uninstalled`,
+  )
+
+  console.log(`[${agent}] install`)
+  const install = await runJson(`install ${agent}`, [...cli, 'install', agent])
+  assertResult(install, result => result.data?.installed === true, `${agent} install should report installed=true`)
+
+  console.log(`[${agent}] inspect after install`)
+  const afterInstall = await runJson(`inspect ${agent} after install`, [...cli, 'inspect', agent, '--refresh'])
+  assertResult(afterInstall, result => result.data?.inspection?.installed === true, `${agent} should be installed`)
+  assertResult(afterInstall, result => result.data?.inspection?.lifecycle === 'managed', `${agent} should be managed`)
+
+  console.log(`[${agent}] resolve`)
+  const resolve = await runJson(`resolve ${agent}`, [...cli, 'resolve', agent])
+  assertResult(resolve, result => result.data?.resolution?.installed === true, `${agent} should resolve after install`)
+  assertResult(resolve, result => Boolean(result.data?.resolution?.binaryPath), `${agent} should expose a binary path`)
+
+  console.log(`[${agent}] ensure idempotency`)
+  const ensure = await runJson(`ensure ${agent}`, [...cli, 'ensure', agent])
+  assertResult(ensure, result => result.data?.installed === true, `${agent} ensure should report installed=true`)
+  assertResult(ensure, result => result.data?.changed === false, `${agent} ensure should be idempotent`)
+
+  console.log(`[${agent}] exec dry run`)
+  await runText(`exec ${agent} dry run`, [...cli, '--dry-run', 'exec', agent, '--', '--version'])
+
+  console.log(`[${agent}] update`)
+  const update = await runJson(`update ${agent}`, [...cli, 'update', agent])
+  assertResult(
+    update,
+    result => Array.isArray(result.data?.results) && result.data.results.length > 0,
+    `${agent} update should return at least one result`,
+  )
+
+  console.log(`[${agent}] uninstall`)
+  const uninstall = await runJson(`uninstall ${agent}`, [...cli, 'uninstall', agent])
+  assertResult(uninstall, result => result.data?.changed === true, `${agent} uninstall should report changed=true`)
+
+  console.log(`[${agent}] inspect after uninstall`)
+  const afterUninstall = await runJson(`inspect ${agent} after uninstall`, [...cli, 'inspect', agent, '--refresh'])
+  assertResult(
+    afterUninstall,
+    result => result.data?.inspection?.installed === false,
+    `${agent} should be uninstalled after lifecycle smoke`,
+  )
+}
+
+async function smokeAdoptPreinstalledAgent(agent: string): Promise<void> {
+  console.log(`\n[${agent}] preinstall outside Quantex`)
+  await runText(`preinstall ${agent}`, ['bun', 'add', '-g', getAgentPackageName(agent)])
+
+  console.log(`[${agent}] install should adopt existing agent`)
+  const install = await runJson(`install ${agent} adopts existing`, [...cli, 'install', agent])
+  assertResult(install, result => result.data?.installed === true, `${agent} adoption should report installed=true`)
+  assertResult(install, result => result.data?.changed === true, `${agent} adoption should persist tracked state`)
+  assertResult(
+    install,
+    result => result.warnings?.some(warning => warning.code === 'TRACKED_EXISTING_INSTALL') === true,
+    `${agent} adoption should warn that Quantex tracked an existing install`,
+  )
+
+  console.log(`[${agent}] inspect adopted state`)
+  const inspection = await runJson(`inspect adopted ${agent}`, [...cli, 'inspect', agent, '--refresh'])
+  assertResult(inspection, result => result.data?.inspection?.installed === true, `${agent} should remain installed`)
+  assertResult(inspection, result => result.data?.inspection?.lifecycle === 'managed', `${agent} should be managed`)
+
+  console.log(`[${agent}] uninstall adopted agent`)
+  const uninstall = await runJson(`uninstall adopted ${agent}`, [...cli, 'uninstall', agent])
+  assertResult(uninstall, result => result.data?.changed === true, `${agent} adopted uninstall should change state`)
+}
+
+async function smokeSelfBinaryLifecycle(): Promise<void> {
+  const binaryTarget = getCurrentLinuxBinaryTarget()
+  const binaryAsset = `dist/bin/quantex-${binaryTarget}`
+
+  console.log('\n[self] build Linux standalone binary')
+  await runText('build linux self binary', ['bun', 'run', 'build:bin', binaryTarget])
+
+  console.log('[self] install standalone binary into isolated HOME')
+  await runText('install local self binary', [
+    'sh',
+    '-c',
+    [
+      'set -euo pipefail',
+      'mkdir -p "$HOME/.local/bin" "$HOME/.quantex"',
+      `cp ${binaryAsset} "$HOME/.local/bin/quantex"`,
+      'chmod +x "$HOME/.local/bin/quantex"',
+      'ln -sf "$HOME/.local/bin/quantex" "$HOME/.local/bin/qtx"',
+      'printf \'{"installedAgents":{},"self":{"installSource":"binary"}}\\n\' > "$HOME/.quantex/state.json"',
+    ].join(' && '),
+  ])
+
+  const binaryCli = '$HOME/.local/bin/qtx --json --non-interactive --yes --color never'
+
+  console.log('[self] binary commands catalog')
+  const commands = await runJson('binary qtx commands', shellCommand(`${binaryCli} commands`))
+  assertResult(commands, result => result.action === 'commands', 'binary qtx should emit the commands action')
+
+  console.log('[self] binary inspect pi')
+  const inspection = await runJson('binary qtx inspect pi', shellCommand(`${binaryCli} inspect pi`))
+  assertResult(inspection, result => result.data?.agent?.name === 'pi', 'binary qtx should inspect agent catalog')
+
+  console.log('[self] binary upgrade check')
+  const upgrade = await runJson('binary qtx upgrade --check', shellCommand(`${binaryCli} upgrade --check`), {
+    allowExitCodes: [0, 1, 6],
+    allowFailure: true,
+  })
+  assertResult(upgrade, result => result.action === 'upgrade', 'binary qtx should emit the upgrade action')
+  assertResult(upgrade, result => result.data?.installSource === 'binary', 'binary qtx should inspect itself as binary')
+  assertResult(upgrade, result => result.data?.canAutoUpdate === true, 'binary qtx should support self auto-update')
+}
+
+async function smokeAmbiguousMultiMethodAgent(): Promise<void> {
+  const agent = 'qoder'
+  const binaryName = 'qodercli'
+  const fakeBinDir = '/tmp/quantex-ambiguous-bin'
+
+  console.log(`\n[${agent}] ambiguous multi-method PATH install should remain untracked`)
+  await runText(`create ambiguous ${agent} binary`, [
+    'sh',
+    '-c',
+    [
+      'set -euo pipefail',
+      `mkdir -p ${fakeBinDir}`,
+      `printf '#!/usr/bin/env sh\\necho qodercli 1.2.3\\n' > ${fakeBinDir}/${binaryName}`,
+      `chmod +x ${fakeBinDir}/${binaryName}`,
+    ].join(' && '),
+  ])
+
+  const ambiguousCli = withPathPrefix(fakeBinDir, [...cli, 'install', agent])
+  const install = await runJson(`install ambiguous ${agent}`, ambiguousCli)
+  assertResult(install, result => result.data?.installed === true, `${agent} should be visible in PATH`)
+  assertResult(install, result => result.data?.changed === false, `${agent} ambiguous install should not change state`)
+  assertResult(
+    install,
+    result => result.warnings?.some(warning => warning.code === 'UNTRACKED_EXISTING_INSTALL') === true,
+    `${agent} ambiguous install should remain untracked`,
+  )
+
+  const inspection = await runJson(`inspect ambiguous ${agent}`, withPathPrefix(fakeBinDir, [...cli, 'inspect', agent]))
+  assertResult(
+    inspection,
+    result => result.data?.inspection?.lifecycle === 'unmanaged',
+    `${agent} ambiguous install should inspect as unmanaged`,
+  )
+}
+
+async function runJson(
+  label: string,
+  command: string[],
+  options: { allowExitCodes?: number[]; allowFailure?: boolean } = {},
+): Promise<JsonResult> {
+  const output = await runCommand(label, command)
+  const allowedExitCodes = options.allowExitCodes ?? [0]
+  if (!allowedExitCodes.includes(output.exitCode) && !options.allowFailure) throw commandError(label, command, output)
+
+  const parsed = parseJsonResult(label, command, output)
+  if (!options.allowFailure && parsed.ok !== true) {
+    throw new Error(`${label} returned ok=false: ${parsed.error?.code ?? 'UNKNOWN'} ${parsed.error?.message ?? ''}`)
+  }
+
+  return parsed
+}
+
+async function runText(label: string, command: string[]): Promise<CommandOutput> {
+  const output = await runCommand(label, command)
+  if (output.exitCode !== 0) throw commandError(label, command, output)
+  return output
+}
+
+async function runCommand(label: string, command: string[]): Promise<CommandOutput> {
+  const proc = Bun.spawn(command, {
+    env: {
+      ...process.env,
+      NO_COLOR: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'] as const,
+  })
+
+  const timeout = setTimeout(() => {
+    proc.kill('SIGTERM')
+  }, DEFAULT_COMMAND_TIMEOUT_MS)
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  clearTimeout(timeout)
+
+  if (stderr.trim()) process.stderr.write(`[${label} stderr]\n${stderr}`)
+
+  return {
+    exitCode,
+    stderr,
+    stdout,
+  }
+}
+
+function parseJsonResult(label: string, command: string[], output: CommandOutput): JsonResult {
+  try {
+    return JSON.parse(output.stdout) as JsonResult
+  } catch (error) {
+    throw new Error(
+      [
+        `Failed to parse JSON output for ${label}.`,
+        `Command: ${command.join(' ')}`,
+        `Exit code: ${output.exitCode}`,
+        `Stdout: ${output.stdout.trim() || '(empty)'}`,
+        `Stderr: ${output.stderr.trim() || '(empty)'}`,
+        `Parse error: ${error instanceof Error ? error.message : String(error)}`,
+      ].join('\n'),
+      { cause: error },
+    )
+  }
+}
+
+function assertResult(result: JsonResult, predicate: (result: JsonResult) => boolean, message: string): void {
+  if (!predicate(result)) throw new Error(message)
+}
+
+function commandError(label: string, command: string[], output: CommandOutput): Error {
+  return new Error(
+    [
+      `${label} failed.`,
+      `Command: ${command.join(' ')}`,
+      `Exit code: ${output.exitCode}`,
+      `Stdout: ${output.stdout.trim() || '(empty)'}`,
+      `Stderr: ${output.stderr.trim() || '(empty)'}`,
+    ].join('\n'),
+  )
+}
+
+function resolveSmokeAgents(): string[] {
+  const cliAgents = process.argv.slice(2).filter(Boolean)
+  if (cliAgents.length > 0) return cliAgents
+
+  const envAgents = process.env.QTX_ISOLATION_AGENTS?.split(',')
+    .map(agent => agent.trim())
+    .filter(Boolean)
+  if (envAgents && envAgents.length > 0) return envAgents
+
+  return DEFAULT_SMOKE_AGENTS
+}
+
+function resolveSmokeScenarios(): string[] {
+  const envScenarios = process.env.QTX_ISOLATION_SCENARIOS?.split(',')
+    .map(scenario => scenario.trim())
+    .filter(Boolean)
+
+  if (envScenarios && envScenarios.length > 0) return envScenarios
+
+  return DEFAULT_SMOKE_SCENARIOS
+}
+
+function getAgentPackageName(agent: string): string {
+  if (agent === 'pi') return '@mariozechner/pi-coding-agent'
+  if (agent === 'qoder') return '@qoder-ai/qodercli'
+
+  throw new Error(
+    `Lifecycle smoke does not know how to preinstall "${agent}". Add its package mapping before including it in adopt-preinstalled.`,
+  )
+}
+
+function shellCommand(command: string): string[] {
+  return ['sh', '-c', command]
+}
+
+function withPathPrefix(prefix: string, command: string[]): string[] {
+  return ['env', `PATH=${prefix}:${process.env.PATH ?? ''}`, ...command]
+}
+
+function getCurrentLinuxBinaryTarget(): 'linux-arm64' | 'linux-x64' {
+  if (process.arch === 'arm64') return 'linux-arm64'
+  if (process.arch === 'x64') return 'linux-x64'
+
+  throw new Error(`Unsupported Linux binary smoke architecture: ${process.arch}`)
+}

--- a/scripts/test-container.ts
+++ b/scripts/test-container.ts
@@ -1,0 +1,45 @@
+import process from 'node:process'
+import { buildContainerSandboxInvocation, getMissingDockerCliMessage } from '../src/testing/container-sandbox'
+
+const invocation = buildContainerSandboxInvocation({
+  smokeArgs: process.argv.slice(2),
+})
+
+await ensureDockerCliAvailable()
+
+console.log(`Running container isolation validation with image ${invocation.image}`)
+console.log(`Mounted repository path: ${invocation.mountPath}`)
+console.log(
+  `Lifecycle smoke agents: ${invocation.smokeArgs.length > 0 ? invocation.smokeArgs.join(', ') : process.env.QTX_ISOLATION_AGENTS || 'pi'}`,
+)
+
+const containerProc = Bun.spawn(invocation.command, {
+  stdio: ['inherit', 'inherit', 'inherit'] as const,
+})
+
+const containerExitCode = await containerProc.exited
+process.exit(containerExitCode === 0 ? 0 : (containerExitCode ?? 1))
+
+async function ensureDockerCliAvailable(): Promise<void> {
+  let proc: ReturnType<typeof Bun.spawn>
+
+  try {
+    proc = Bun.spawn(['docker', 'info'], {
+      stdio: ['ignore', 'ignore', 'pipe'] as const,
+    })
+  } catch {
+    throw new Error(getMissingDockerCliMessage())
+  }
+
+  const [dockerExitCode, stderr] = await Promise.all([proc.exited, readStreamText(proc.stderr)])
+
+  if (dockerExitCode !== 0) {
+    const details = stderr.trim()
+    throw new Error(details ? `${getMissingDockerCliMessage()}\n\n${details}` : getMissingDockerCliMessage())
+  }
+}
+
+async function readStreamText(stream: ReturnType<typeof Bun.spawn>['stderr']): Promise<string> {
+  if (!stream || typeof stream === 'number') return ''
+  return new Response(stream).text()
+}

--- a/scripts/test-sandbox.ts
+++ b/scripts/test-sandbox.ts
@@ -1,0 +1,45 @@
+import process from 'node:process'
+import { buildModalSandboxInvocation, getMissingModalCliMessage } from '../src/testing/modal-sandbox'
+
+const invocation = buildModalSandboxInvocation({
+  smokeArgs: process.argv.slice(2),
+})
+
+await ensureModalCliAvailable()
+
+console.log(`Running Modal sandbox validation with image ${invocation.image}`)
+console.log(`Mounted repository path: ${invocation.mountPath}`)
+console.log(
+  `Lifecycle smoke agents: ${invocation.smokeArgs.length > 0 ? invocation.smokeArgs.join(', ') : process.env.QTX_ISOLATION_AGENTS || 'pi'}`,
+)
+
+const sandboxProc = Bun.spawn(invocation.command, {
+  stdio: ['inherit', 'inherit', 'inherit'] as const,
+})
+
+const sandboxExitCode = await sandboxProc.exited
+process.exit(sandboxExitCode === 0 ? 0 : (sandboxExitCode ?? 1))
+
+async function ensureModalCliAvailable(): Promise<void> {
+  let proc: ReturnType<typeof Bun.spawn>
+
+  try {
+    proc = Bun.spawn(['modal', '--version'], {
+      stdio: ['ignore', 'ignore', 'pipe'] as const,
+    })
+  } catch {
+    throw new Error(getMissingModalCliMessage())
+  }
+
+  const [modalExitCode, stderr] = await Promise.all([proc.exited, readStreamText(proc.stderr)])
+
+  if (modalExitCode !== 0) {
+    const details = stderr.trim()
+    throw new Error(details ? `${getMissingModalCliMessage()}\n\n${details}` : getMissingModalCliMessage())
+  }
+}
+
+async function readStreamText(stream: ReturnType<typeof Bun.spawn>['stderr']): Promise<string> {
+  if (!stream || typeof stream === 'number') return ''
+  return new Response(stream).text()
+}

--- a/src/agents/definitions/kilo.ts
+++ b/src/agents/definitions/kilo.ts
@@ -3,8 +3,7 @@ import { bunInstall, npmInstall } from '../methods'
 
 export const kilo: AgentDefinition = {
   name: 'kilo',
-  lookupAliases: ['kilocode'],
-  displayName: 'Kilo Code CLI',
+  displayName: 'Kilo CLI',
   homepage: 'https://kilo.ai/docs/cli',
   packages: {
     npm: '@kilocode/cli',

--- a/src/agents/definitions/qoder.ts
+++ b/src/agents/definitions/qoder.ts
@@ -3,6 +3,7 @@ import { brewInstall, bunInstall, npmInstall, scriptInstall } from '../methods'
 
 export const qoder: AgentDefinition = {
   name: 'qoder',
+  lookupAliases: ['qodercli'],
   displayName: 'Qoder CLI',
   homepage: 'https://docs.qoder.com/cli/quick-start',
   packages: {

--- a/src/agents/definitions/qwen.ts
+++ b/src/agents/definitions/qwen.ts
@@ -3,7 +3,6 @@ import { brewInstall, bunInstall, npmInstall, scriptInstall } from '../methods'
 
 export const qwen: AgentDefinition = {
   name: 'qwen',
-  lookupAliases: ['qwen-code'],
   displayName: 'Qwen Code',
   homepage: 'https://qwenlm.github.io/qwen-code-docs/',
   packages: {

--- a/src/commands/ensure.ts
+++ b/src/commands/ensure.ts
@@ -72,7 +72,10 @@ export async function ensureCommand(agentName: string): Promise<CommandResult<En
       )
     }
 
-    const adoptableMethod = getAdoptableExistingInstallMethod(inspection.methods)
+    const adoptableMethod = getAdoptableExistingInstallMethod(
+      inspection.methods,
+      inspection.resolvedBinaryPath ?? inspection.binaryPath,
+    )
     if (adoptableMethod) {
       if (isDryRunEnabled()) {
         return emitCommandResult(

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -72,7 +72,10 @@ export async function installCommand(agentName: string): Promise<CommandResult<I
       )
     }
 
-    const adoptableMethod = getAdoptableExistingInstallMethod(inspection.methods)
+    const adoptableMethod = getAdoptableExistingInstallMethod(
+      inspection.methods,
+      inspection.resolvedBinaryPath ?? inspection.binaryPath,
+    )
     if (adoptableMethod) {
       if (isDryRunEnabled()) {
         return emitCommandResult(

--- a/src/inspection/agents.ts
+++ b/src/inspection/agents.ts
@@ -9,7 +9,7 @@ import {
   getInstallLifecycle,
   getLatestVersionPackage,
 } from '../utils/install'
-import { getBinaryPath, getInstalledVersion, getLatestVersion } from '../utils/version'
+import { getBinaryPath, getInstalledVersion, getLatestVersion, getResolvedBinaryPath } from '../utils/version'
 
 export interface AgentInspection {
   agent: AgentDefinition
@@ -19,6 +19,7 @@ export interface AgentInspection {
   installedVersion?: string
   latestVersion?: string
   binaryPath?: string
+  resolvedBinaryPath?: string
   sourceLabel: string
   updateLabel: string
   lifecycle: 'managed' | 'unmanaged'
@@ -36,6 +37,7 @@ export async function inspectAgent(agent: AgentDefinition): Promise<AgentInspect
     inPath ? getBinaryPath(agent.binaryName) : Promise.resolve(undefined),
     getLatestVersionForAgent(agent, installedState, methods),
   ])
+  const resolvedBinaryPath = await getResolvedBinaryPath(binaryPath)
 
   return {
     agent,
@@ -45,6 +47,7 @@ export async function inspectAgent(agent: AgentDefinition): Promise<AgentInspect
     installedVersion,
     latestVersion,
     binaryPath,
+    resolvedBinaryPath,
     sourceLabel: formatInstalledSource(installedState),
     updateLabel: formatUpdateManagement(agent, installedState),
     lifecycle: installedState ? getInstallLifecycle(installedState.installType) : 'unmanaged',

--- a/src/testing/container-sandbox.ts
+++ b/src/testing/container-sandbox.ts
@@ -1,0 +1,55 @@
+import { buildIsolationExecutionPlan, DEFAULT_ISOLATION_IMAGE, DEFAULT_ISOLATION_SMOKE_ARGS } from './isolation-shared'
+
+export const DEFAULT_CONTAINER_SANDBOX_IMAGE = DEFAULT_ISOLATION_IMAGE
+export const DEFAULT_CONTAINER_SANDBOX_SMOKE_ARGS = DEFAULT_ISOLATION_SMOKE_ARGS
+
+export interface ContainerSandboxInvocation {
+  command: string[]
+  image: string
+  mountPath: string
+  remoteCommand: string
+  smokeArgs: string[]
+}
+
+export function buildContainerSandboxInvocation(
+  options: {
+    image?: string
+    repoRoot?: string
+    smokeArgs?: string[]
+  } = {},
+): ContainerSandboxInvocation {
+  const plan = buildIsolationExecutionPlan(options)
+
+  return {
+    command: [
+      'docker',
+      'run',
+      '--rm',
+      '--volume',
+      `${plan.repoRoot}:${plan.mountPath}`,
+      '--workdir',
+      plan.mountPath,
+      '--env',
+      'HOME=/tmp/quantex-home',
+      '--env',
+      'QTX_ISOLATION_AGENTS',
+      '--env',
+      'QTX_ISOLATION_SCENARIOS',
+      plan.image,
+      '/bin/bash',
+      '-lc',
+      plan.remoteCommand,
+    ],
+    image: plan.image,
+    mountPath: plan.mountPath,
+    remoteCommand: plan.remoteCommand,
+    smokeArgs: plan.smokeArgs,
+  }
+}
+
+export function getMissingDockerCliMessage(): string {
+  return [
+    'Container isolation requires a working Docker CLI and running Docker daemon.',
+    'Install and start Docker Desktop or another compatible Docker runtime before retrying `bun run test:container`.',
+  ].join('\n')
+}

--- a/src/testing/isolation-shared.ts
+++ b/src/testing/isolation-shared.ts
@@ -1,0 +1,63 @@
+import { basename } from 'node:path'
+import process from 'node:process'
+
+export const DEFAULT_ISOLATION_IMAGE =
+  process.env.QTX_ISOLATION_IMAGE ||
+  process.env.QTX_MODAL_IMAGE ||
+  process.env.MODAL_SANDBOX_IMAGE ||
+  'docker.io/oven/bun:1.3.11'
+
+export const DEFAULT_ISOLATION_SMOKE_ARGS: string[] = []
+
+export interface IsolationExecutionPlan {
+  image: string
+  mountPath: string
+  remoteCommand: string
+  repoRoot: string
+  smokeArgs: string[]
+}
+
+export function buildIsolationExecutionPlan(
+  options: {
+    image?: string
+    repoRoot?: string
+    smokeArgs?: string[]
+  } = {},
+): IsolationExecutionPlan {
+  const repoRoot = options.repoRoot || process.cwd()
+  const image = options.image || DEFAULT_ISOLATION_IMAGE
+  const smokeArgs =
+    options.smokeArgs && options.smokeArgs.length > 0 ? [...options.smokeArgs] : [...DEFAULT_ISOLATION_SMOKE_ARGS]
+  const mountPath = `/mnt/${basename(repoRoot)}`
+
+  return {
+    image,
+    mountPath,
+    remoteCommand: buildRemoteCommand(mountPath, smokeArgs),
+    repoRoot,
+    smokeArgs,
+  }
+}
+
+export function quoteForShell(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
+}
+
+function buildRemoteCommand(mountPath: string, smokeArgs: string[]): string {
+  const quotedArgs = smokeArgs.map(quoteForShell).join(' ')
+
+  return [
+    'set -euo pipefail',
+    'export HOME=/tmp/quantex-home',
+    'export BUN_INSTALL="$HOME/.bun"',
+    'export PATH="$BUN_INSTALL/bin:$PATH"',
+    `export QTX_ISOLATION_AGENTS=${quoteForShell(process.env.QTX_ISOLATION_AGENTS ?? '')}`,
+    `export QTX_ISOLATION_SCENARIOS=${quoteForShell(process.env.QTX_ISOLATION_SCENARIOS ?? '')}`,
+    'mkdir -p "$HOME"',
+    'rm -rf /tmp/quantex-work',
+    `cp -R ${quoteForShell(mountPath)} /tmp/quantex-work`,
+    'cd /tmp/quantex-work',
+    'bun install --frozen-lockfile --ignore-scripts --no-progress',
+    `bun run scripts/lifecycle-smoke.ts${quotedArgs ? ` ${quotedArgs}` : ''}`,
+  ].join(' && ')
+}

--- a/src/testing/modal-sandbox.ts
+++ b/src/testing/modal-sandbox.ts
@@ -1,0 +1,51 @@
+import {
+  buildIsolationExecutionPlan,
+  DEFAULT_ISOLATION_IMAGE,
+  DEFAULT_ISOLATION_SMOKE_ARGS,
+  quoteForShell,
+} from './isolation-shared'
+
+export const DEFAULT_MODAL_SANDBOX_IMAGE = DEFAULT_ISOLATION_IMAGE
+export const DEFAULT_MODAL_SANDBOX_SMOKE_ARGS = DEFAULT_ISOLATION_SMOKE_ARGS
+
+export interface ModalSandboxInvocation {
+  command: string[]
+  image: string
+  mountPath: string
+  remoteCommand: string
+  smokeArgs: string[]
+}
+
+export function buildModalSandboxInvocation(
+  options: {
+    image?: string
+    repoRoot?: string
+    smokeArgs?: string[]
+  } = {},
+): ModalSandboxInvocation {
+  const plan = buildIsolationExecutionPlan(options)
+
+  return {
+    command: [
+      'modal',
+      'shell',
+      '--image',
+      plan.image,
+      '--add-local',
+      plan.repoRoot,
+      '--cmd',
+      `/bin/bash -lc ${quoteForShell(plan.remoteCommand)}`,
+    ],
+    image: plan.image,
+    mountPath: plan.mountPath,
+    remoteCommand: plan.remoteCommand,
+    smokeArgs: plan.smokeArgs,
+  }
+}
+
+export function getMissingModalCliMessage(): string {
+  return [
+    'Modal sandbox validation requires the `modal` CLI on PATH and an authenticated Modal profile.',
+    'Install it with `pip install modal` or your preferred Python tool, then run `modal setup` before retrying.',
+  ].join('\n')
+}

--- a/src/utils/install.ts
+++ b/src/utils/install.ts
@@ -130,11 +130,30 @@ export function getLatestVersionPackage(
   return agent.packages.npm
 }
 
-export function getAdoptableExistingInstallMethod(methods: InstallMethod[]): InstallMethod | undefined {
+export function getAdoptableExistingInstallMethod(
+  methods: InstallMethod[],
+  binaryPath?: string,
+): InstallMethod | undefined {
+  const inferredManagedType = inferManagedInstallTypeFromBinaryPath(binaryPath)
+  if (inferredManagedType) {
+    const inferredMethod = methods.find(method => method.type === inferredManagedType)
+    if (inferredMethod) return inferredMethod
+  }
+
   if (methods.length !== 1) return undefined
 
   const [method] = methods
   if (method.type !== 'script' && method.type !== 'binary') return undefined
 
   return method
+}
+
+function inferManagedInstallTypeFromBinaryPath(binaryPath?: string): 'bun' | 'npm' | undefined {
+  if (!binaryPath) return undefined
+
+  const normalized = binaryPath.replaceAll('\\', '/')
+  if (normalized.includes('/.bun/bin/') || normalized.includes('/.bun/install/global/')) return 'bun'
+  if (normalized.includes('/node_modules/.bin/') || normalized.includes('/node_modules/')) return 'npm'
+
+  return undefined
 }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,4 +1,5 @@
 import type { AgentVersionProbe } from '../agents'
+import { realpath } from 'node:fs/promises'
 import process from 'node:process'
 import { fetchJsonWithCache } from './network'
 import { buildRegistryPackageVersionUrl, OFFICIAL_NPM_REGISTRY, normalizeRegistryUrl } from './registry'
@@ -58,5 +59,15 @@ export async function getBinaryPath(binaryName: string): Promise<string | undefi
     return text.trim().split('\n')[0]
   } catch {
     return undefined
+  }
+}
+
+export async function getResolvedBinaryPath(binaryPath?: string): Promise<string | undefined> {
+  if (!binaryPath) return undefined
+
+  try {
+    return await realpath(binaryPath)
+  } catch {
+    return binaryPath
   }
 }

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -246,8 +246,8 @@ describe('kilo', () => {
   it('has valid structure', () => {
     validateAgent(kilo)
     expect(kilo.name).toBe('kilo')
-    expect(kilo.lookupAliases).toEqual(['kilocode'])
-    expect(kilo.displayName).toBe('Kilo Code CLI')
+    expect(kilo.lookupAliases).toBeUndefined()
+    expect(kilo.displayName).toBe('Kilo CLI')
     expect(kilo.packages?.npm).toBe('@kilocode/cli')
     expect(kilo.binaryName).toBe('kilo')
     expect(kilo.homepage).toBe('https://kilo.ai/docs/cli')
@@ -285,6 +285,10 @@ describe('pi', () => {
 describe('qoder', () => {
   it('is registered for lookup by canonical name', () => {
     expect(getAgentByNameOrAlias('qoder')).toBe(qoder)
+  })
+
+  it('is registered for lookup by executable alias', () => {
+    expect(getAgentByNameOrAlias('qodercli')).toBe(qoder)
   })
 
   it('has valid structure', () => {
@@ -328,15 +332,15 @@ describe('qoder', () => {
 })
 
 describe('qwen', () => {
-  it('is registered for lookup by alias', () => {
+  it('is registered for lookup by canonical name', () => {
     expect(getAgentByNameOrAlias('qwen')).toBe(qwen)
-    expect(getAgentByNameOrAlias('qwen-code')).toBe(qwen)
+    expect(getAgentByNameOrAlias('qwen-code')).toBeUndefined()
   })
 
   it('has valid structure', () => {
     validateAgent(qwen)
     expect(qwen.name).toBe('qwen')
-    expect(qwen.lookupAliases).toEqual(['qwen-code'])
+    expect(qwen.lookupAliases).toBeUndefined()
     expect(qwen.displayName).toBe('Qwen Code')
     expect(qwen.packages?.npm).toBe('@qwen-code/qwen-code')
     expect(qwen.binaryName).toBe('qwen')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,9 +38,9 @@ describe('agent registry', () => {
     expect(agent?.name).toBe('cursor')
   })
 
-  it('resolves Kilo by published alias', () => {
-    const agent = getAgentByLookupName('kilocode')
-    expect(agent?.name).toBe('kilo')
+  it('resolves Qoder by executable alias', () => {
+    const agent = getAgentByLookupName('qodercli')
+    expect(agent?.name).toBe('qoder')
   })
 })
 
@@ -73,7 +73,7 @@ describe('agent definitions', () => {
   it('kilo has correct structure', () => {
     const agent = getAgentByNameOrAlias('kilo')
     expect(agent).toBeDefined()
-    expect(agent!.displayName).toBe('Kilo Code CLI')
+    expect(agent!.displayName).toBe('Kilo CLI')
     expect(agent!.packages?.npm).toBe('@kilocode/cli')
     expect(agent!.binaryName).toBe('kilo')
   })

--- a/test/testing/modal-sandbox.test.ts
+++ b/test/testing/modal-sandbox.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildContainerSandboxInvocation,
+  DEFAULT_CONTAINER_SANDBOX_IMAGE,
+  DEFAULT_CONTAINER_SANDBOX_SMOKE_ARGS,
+  getMissingDockerCliMessage,
+} from '../../src/testing/container-sandbox'
+import {
+  buildModalSandboxInvocation,
+  DEFAULT_MODAL_SANDBOX_IMAGE,
+  DEFAULT_MODAL_SANDBOX_SMOKE_ARGS,
+  getMissingModalCliMessage,
+} from '../../src/testing/modal-sandbox'
+
+describe('buildModalSandboxInvocation', () => {
+  it('builds the default modal shell invocation', () => {
+    const invocation = buildModalSandboxInvocation({
+      repoRoot: '/tmp/quantex-cli',
+    })
+
+    expect(invocation.image).toBe(DEFAULT_MODAL_SANDBOX_IMAGE)
+    expect(invocation.mountPath).toBe('/mnt/quantex-cli')
+    expect(invocation.smokeArgs).toEqual(DEFAULT_MODAL_SANDBOX_SMOKE_ARGS)
+    expect(invocation.command).toEqual([
+      'modal',
+      'shell',
+      '--image',
+      DEFAULT_MODAL_SANDBOX_IMAGE,
+      '--add-local',
+      '/tmp/quantex-cli',
+      '--cmd',
+      expect.stringContaining("/bin/bash -lc 'set -euo pipefail"),
+    ])
+    expect(invocation.remoteCommand).toContain("cp -R '/mnt/quantex-cli' /tmp/quantex-work")
+    expect(invocation.remoteCommand).toContain('bun install --frozen-lockfile --ignore-scripts --no-progress')
+    expect(invocation.remoteCommand).toContain('bun run scripts/lifecycle-smoke.ts')
+  })
+
+  it('forwards explicit smoke agent arguments into the remote command', () => {
+    const invocation = buildModalSandboxInvocation({
+      repoRoot: '/tmp/quantex-cli',
+      smokeArgs: ['pi', 'opencode'],
+    })
+
+    expect(invocation.smokeArgs).toEqual(['pi', 'opencode'])
+    expect(invocation.remoteCommand).toContain("bun run scripts/lifecycle-smoke.ts 'pi' 'opencode'")
+  })
+})
+
+describe('getMissingModalCliMessage', () => {
+  it('explains how to install and authenticate modal', () => {
+    expect(getMissingModalCliMessage()).toContain('modal setup')
+    expect(getMissingModalCliMessage()).toContain('pip install modal')
+  })
+})
+
+describe('buildContainerSandboxInvocation', () => {
+  it('builds the default docker invocation', () => {
+    const invocation = buildContainerSandboxInvocation({
+      repoRoot: '/tmp/quantex-cli',
+    })
+
+    expect(invocation.image).toBe(DEFAULT_CONTAINER_SANDBOX_IMAGE)
+    expect(invocation.mountPath).toBe('/mnt/quantex-cli')
+    expect(invocation.smokeArgs).toEqual(DEFAULT_CONTAINER_SANDBOX_SMOKE_ARGS)
+    expect(invocation.command).toEqual([
+      'docker',
+      'run',
+      '--rm',
+      '--volume',
+      '/tmp/quantex-cli:/mnt/quantex-cli',
+      '--workdir',
+      '/mnt/quantex-cli',
+      '--env',
+      'HOME=/tmp/quantex-home',
+      '--env',
+      'QTX_ISOLATION_AGENTS',
+      '--env',
+      'QTX_ISOLATION_SCENARIOS',
+      DEFAULT_CONTAINER_SANDBOX_IMAGE,
+      '/bin/bash',
+      '-lc',
+      expect.stringContaining('set -euo pipefail'),
+    ])
+  })
+})
+
+describe('getMissingDockerCliMessage', () => {
+  it('explains how to install docker', () => {
+    expect(getMissingDockerCliMessage()).toContain('Docker')
+    expect(getMissingDockerCliMessage()).toContain('test:container')
+  })
+})

--- a/test/utils/install.test.ts
+++ b/test/utils/install.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { getAdoptableExistingInstallMethod } from '../../src/utils/install'
+
+describe('getAdoptableExistingInstallMethod', () => {
+  it('adopts a Bun-managed existing install when the binary path identifies Bun global bin', () => {
+    const method = getAdoptableExistingInstallMethod(
+      [{ type: 'bun' }, { type: 'npm' }],
+      '/tmp/quantex-home/.bun/bin/pi',
+    )
+
+    expect(method).toEqual({ type: 'bun' })
+  })
+
+  it('does not guess between multiple managed methods without an identifying binary path', () => {
+    const method = getAdoptableExistingInstallMethod([{ type: 'bun' }, { type: 'npm' }])
+
+    expect(method).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Add an isolated agent lifecycle smoke layer for Quantex using local Docker and Modal-backed sandbox execution. The smoke flow validates real CLI lifecycle behavior rather than re-running unit tests in a container.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `add-modal-sandbox-test-layer`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Additional validation:

- [x] `bun run test:container`

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge.
- [x] Release is not applicable.

## Notes

The local Docker path is the preferred host-isolated fallback. The Modal path is wired as an independent GitHub Actions workflow and uses repository secrets for Modal authentication.
