### PR TITLE
fix: propagate modal sandbox failures

### DIFF
--- a/docs/runbooks/modal-sandbox-testing.md
+++ b/docs/runbooks/modal-sandbox-testing.md
@@ -32,7 +32,7 @@ bun run test:container
 
 This command mounts the current checkout into a local Docker container based on the repository's default Bun image, copies the checkout to an internal temporary work directory, installs repository dependencies there, and then executes the lifecycle smoke script.
 
-The default lifecycle smoke agent is `pi`.
+The default local lifecycle smoke agents are `pi,qoder`.
 
 Default scenarios:
 
@@ -84,13 +84,13 @@ QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:containe
 
 Individual lifecycle commands time out after `QTX_ISOLATION_COMMAND_TIMEOUT_MS` milliseconds, defaulting to 300 seconds. Broader real-agent runs may need a higher timeout when upstream packages are slow.
 
-For local broad-agent coverage without the slower upstream install path, `qoder` is the preferred multi-install-method agent:
+For local broad-agent coverage without the slower upstream install path, `qoder` is the preferred multi-install-method agent and is included in the local default:
 
 ```bash
 QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:container
 ```
 
-The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AGENTS=pi,opencode` and a longer command timeout so remote validation covers both the lightweight managed-only default and an upstream package that can be slow from a local network.
+The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AGENTS=pi,opencode` and a longer command timeout so remote validation covers the lightweight baseline plus opencode under better network conditions.
 
 ## Triage order
 

--- a/openspec/changes/fix-modal-sandbox-failure-propagation/.openspec.yaml
+++ b/openspec/changes/fix-modal-sandbox-failure-propagation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/fix-modal-sandbox-failure-propagation/design.md
+++ b/openspec/changes/fix-modal-sandbox-failure-propagation/design.md
@@ -1,0 +1,22 @@
+# Design: Fix Modal sandbox failure propagation
+
+## Current behavior
+
+`scripts/test-sandbox.ts` spawns `modal shell` with inherited stdio and exits with the Modal process exit code. The observed GitHub Actions run showed that a Bun exception inside the remote command was printed to the log while the local Modal process still exited successfully.
+
+## Proposed behavior
+
+Wrap the remote shell command with an explicit exit-code marker:
+
+1. Run the existing remote command with `set +e` around the wrapped command.
+2. Capture `$?`.
+3. Print a stable marker containing that status.
+4. Exit the remote shell with the same status.
+
+`scripts/test-sandbox.ts` will capture Modal stdout/stderr, mirror them to the local process, parse the last marker, and fail when the marker is missing or non-zero. This makes the local script independent of whether the installed Modal CLI propagates the remote command status correctly.
+
+## Alternatives Considered
+
+- Use Modal CLI exit code only: rejected because the failure already demonstrated that it can be misleading for this command shape.
+- Move sandbox tests into merge-gating CI: rejected because the existing product decision keeps Modal validation in a separate workflow.
+- Remove `adopt-preinstalled` from expanded remote agent runs: rejected because preinstalled-agent adoption is one of the lifecycle edges the sandbox layer is intended to catch.

--- a/openspec/changes/fix-modal-sandbox-failure-propagation/proposal.md
+++ b/openspec/changes/fix-modal-sandbox-failure-propagation/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: Fix Modal sandbox failure propagation
+
+## Summary
+
+Fix the Modal-backed sandbox validation so failures inside the remote lifecycle smoke command make `bun run test:sandbox` and the dedicated GitHub Actions workflow fail reliably.
+
+## Motivation
+
+The dedicated sandbox workflow surfaced a remote `adopt-preinstalled` failure after the CI agent list changed from `qoder` to `opencode`, but the GitHub Actions job still completed successfully. That means the Modal CLI invocation did not propagate the remote command's failing exit status to the local runner, which breaks the workflow's value as a lifecycle validation gate.
+
+The same run also showed that the lifecycle smoke script lacks a package mapping for `opencode` in the preinstalled-agent adoption scenario.
+
+## Goals
+
+- Ensure `bun run test:sandbox` exits non-zero when the remote lifecycle smoke command fails.
+- Preserve useful Modal stdout/stderr in local and CI logs.
+- Add `opencode` support to the preinstalled-agent adoption smoke scenario.
+- Keep the Modal workflow separate from merge-gating `ci.yml`.
+
+## Non-Goals
+
+- Make Modal sandbox tests required for every PR.
+- Change the default local Docker smoke target list.
+- Broaden Quantex into a workflow orchestration system.

--- a/openspec/changes/fix-modal-sandbox-failure-propagation/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/fix-modal-sandbox-failure-propagation/specs/code-quality-tooling/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Optional isolation validation commands
+
+The repository SHALL expose `bun run test:sandbox` and `bun run test:container` as optional maintainer-facing validation commands for running real Quantex agent lifecycle smoke checks inside isolated Bun environments. These commands MUST complement rather than replace the canonical local `bun run test` workflow.
+
+#### Scenario: Modal remote command fails
+
+- **WHEN** the remote lifecycle smoke command invoked by `bun run test:sandbox` exits non-zero
+- **THEN** `bun run test:sandbox` exits non-zero even if the Modal CLI process itself reports success
+- **AND** the local command output preserves enough remote stdout and stderr to diagnose the failed lifecycle stage
+
+#### Scenario: Expanded smoke list includes opencode preinstall adoption
+
+- **WHEN** the isolated lifecycle smoke script runs `adopt-preinstalled` for `opencode`
+- **THEN** it preinstalls the `opencode-ai` package before asking Quantex to adopt the existing install
+
+#### Scenario: Maintainer compares local and CI sandbox defaults
+
+- **WHEN** a maintainer runs the local Docker isolation command without overriding agents
+- **THEN** the lifecycle smoke script uses `pi,qoder` as the local default agent list
+- **AND** the dedicated GitHub Actions sandbox workflow overrides the agent list to `pi,opencode`

--- a/openspec/changes/fix-modal-sandbox-failure-propagation/tasks.md
+++ b/openspec/changes/fix-modal-sandbox-failure-propagation/tasks.md
@@ -1,0 +1,7 @@
+## 1. Sandbox Failure Propagation
+
+- [x] 1.1 Add an OpenSpec delta requiring Modal sandbox failure propagation independent of raw Modal CLI exit status.
+- [x] 1.2 Add `opencode` package mapping for the preinstalled-agent adoption smoke scenario.
+- [x] 1.3 Wrap Modal remote command output with a stable exit-code marker and make `test:sandbox` fail when the marker is missing or non-zero.
+- [x] 1.4 Add unit coverage for Modal failure-marker parsing/invocation behavior.
+- [x] 1.5 Run validation and deliver through PR.

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -14,7 +14,7 @@ interface JsonResult {
   warnings?: Array<{ code?: string; message?: string }>
 }
 
-const DEFAULT_SMOKE_AGENTS = ['pi']
+const DEFAULT_SMOKE_AGENTS = ['pi', 'qoder']
 const DEFAULT_SMOKE_SCENARIOS = ['managed', 'adopt-preinstalled', 'ambiguous-multi-method', 'self-binary']
 const DEFAULT_COMMAND_TIMEOUT_MS = Number(process.env.QTX_ISOLATION_COMMAND_TIMEOUT_MS ?? 300_000)
 const agents = resolveSmokeAgents()
@@ -317,6 +317,7 @@ function resolveSmokeScenarios(): string[] {
 function getAgentPackageName(agent: string): string {
   if (agent === 'pi') return '@mariozechner/pi-coding-agent'
   if (agent === 'qoder') return '@qoder-ai/qodercli'
+  if (agent === 'opencode') return 'opencode-ai'
 
   throw new Error(
     `Lifecycle smoke does not know how to preinstall "${agent}". Add its package mapping before including it in adopt-preinstalled.`,

--- a/scripts/test-container.ts
+++ b/scripts/test-container.ts
@@ -4,13 +4,14 @@ import { buildContainerSandboxInvocation, getMissingDockerCliMessage } from '../
 const invocation = buildContainerSandboxInvocation({
   smokeArgs: process.argv.slice(2),
 })
+const defaultLifecycleAgents = 'pi,qoder'
 
 await ensureDockerCliAvailable()
 
 console.log(`Running container isolation validation with image ${invocation.image}`)
 console.log(`Mounted repository path: ${invocation.mountPath}`)
 console.log(
-  `Lifecycle smoke agents: ${invocation.smokeArgs.length > 0 ? invocation.smokeArgs.join(', ') : process.env.QTX_ISOLATION_AGENTS || 'pi'}`,
+  `Lifecycle smoke agents: ${invocation.smokeArgs.length > 0 ? invocation.smokeArgs.join(', ') : process.env.QTX_ISOLATION_AGENTS || defaultLifecycleAgents}`,
 )
 
 const containerProc = Bun.spawn(invocation.command, {

--- a/scripts/test-sandbox.ts
+++ b/scripts/test-sandbox.ts
@@ -1,24 +1,48 @@
 import process from 'node:process'
-import { buildModalSandboxInvocation, getMissingModalCliMessage } from '../src/testing/modal-sandbox'
+import {
+  buildModalSandboxInvocation,
+  getMissingModalCliMessage,
+  parseModalRemoteExitCode,
+} from '../src/testing/modal-sandbox'
 
 const invocation = buildModalSandboxInvocation({
   smokeArgs: process.argv.slice(2),
 })
+const defaultLifecycleAgents = 'pi,qoder'
 
 await ensureModalCliAvailable()
 
 console.log(`Running Modal sandbox validation with image ${invocation.image}`)
 console.log(`Mounted repository path: ${invocation.mountPath}`)
 console.log(
-  `Lifecycle smoke agents: ${invocation.smokeArgs.length > 0 ? invocation.smokeArgs.join(', ') : process.env.QTX_ISOLATION_AGENTS || 'pi'}`,
+  `Lifecycle smoke agents: ${invocation.smokeArgs.length > 0 ? invocation.smokeArgs.join(', ') : process.env.QTX_ISOLATION_AGENTS || defaultLifecycleAgents}`,
 )
 
-const sandboxProc = Bun.spawn(invocation.command, {
-  stdio: ['inherit', 'inherit', 'inherit'] as const,
-})
+const sandboxExitCode = await runModalSandboxCommand(invocation.command)
+process.exit(sandboxExitCode)
 
-const sandboxExitCode = await sandboxProc.exited
-process.exit(sandboxExitCode === 0 ? 0 : (sandboxExitCode ?? 1))
+async function runModalSandboxCommand(command: string[]): Promise<number> {
+  const sandboxProc = Bun.spawn(command, {
+    stdio: ['inherit', 'pipe', 'pipe'] as const,
+  })
+
+  const [stdout, stderr, modalExitCode] = await Promise.all([
+    readStreamText(sandboxProc.stdout),
+    readStreamText(sandboxProc.stderr),
+    sandboxProc.exited,
+  ])
+
+  if (stdout) process.stdout.write(stdout)
+  if (stderr) process.stderr.write(stderr)
+
+  const remoteExitCode = parseModalRemoteExitCode(`${stdout}\n${stderr}`)
+  if (remoteExitCode !== undefined) return remoteExitCode
+
+  if (modalExitCode !== 0) return modalExitCode ?? 1
+
+  process.stderr.write('Modal sandbox validation did not emit a remote exit-code marker.\n')
+  return 1
+}
 
 async function ensureModalCliAvailable(): Promise<void> {
   let proc: ReturnType<typeof Bun.spawn>
@@ -39,7 +63,9 @@ async function ensureModalCliAvailable(): Promise<void> {
   }
 }
 
-async function readStreamText(stream: ReturnType<typeof Bun.spawn>['stderr']): Promise<string> {
+async function readStreamText(
+  stream: ReturnType<typeof Bun.spawn>['stderr'] | ReturnType<typeof Bun.spawn>['stdout'],
+): Promise<string> {
   if (!stream || typeof stream === 'number') return ''
   return new Response(stream).text()
 }

--- a/src/testing/modal-sandbox.ts
+++ b/src/testing/modal-sandbox.ts
@@ -7,6 +7,7 @@ import {
 
 export const DEFAULT_MODAL_SANDBOX_IMAGE = DEFAULT_ISOLATION_IMAGE
 export const DEFAULT_MODAL_SANDBOX_SMOKE_ARGS = DEFAULT_ISOLATION_SMOKE_ARGS
+export const MODAL_REMOTE_EXIT_CODE_MARKER = '__QTX_MODAL_REMOTE_EXIT_CODE__'
 
 export interface ModalSandboxInvocation {
   command: string[]
@@ -24,6 +25,7 @@ export function buildModalSandboxInvocation(
   } = {},
 ): ModalSandboxInvocation {
   const plan = buildIsolationExecutionPlan(options)
+  const remoteCommand = buildModalRemoteCommand(plan.remoteCommand)
 
   return {
     command: [
@@ -34,13 +36,32 @@ export function buildModalSandboxInvocation(
       '--add-local',
       plan.repoRoot,
       '--cmd',
-      `/bin/bash -lc ${quoteForShell(plan.remoteCommand)}`,
+      `/bin/bash -lc ${quoteForShell(remoteCommand)}`,
     ],
     image: plan.image,
     mountPath: plan.mountPath,
-    remoteCommand: plan.remoteCommand,
+    remoteCommand,
     smokeArgs: plan.smokeArgs,
   }
+}
+
+export function buildModalRemoteCommand(remoteCommand: string): string {
+  return [
+    'set +e',
+    remoteCommand,
+    'status=$?',
+    `printf '\\n${MODAL_REMOTE_EXIT_CODE_MARKER}=%s\\n' "$status"`,
+    'exit "$status"',
+  ].join('\n')
+}
+
+export function parseModalRemoteExitCode(output: string): number | undefined {
+  const markerPattern = new RegExp(`${MODAL_REMOTE_EXIT_CODE_MARKER}=(\\d+)`, 'g')
+  let exitCode: number | undefined
+
+  for (const match of output.matchAll(markerPattern)) exitCode = Number(match[1])
+
+  return exitCode
 }
 
 export function getMissingModalCliMessage(): string {

--- a/test/testing/modal-sandbox.test.ts
+++ b/test/testing/modal-sandbox.test.ts
@@ -10,6 +10,8 @@ import {
   DEFAULT_MODAL_SANDBOX_IMAGE,
   DEFAULT_MODAL_SANDBOX_SMOKE_ARGS,
   getMissingModalCliMessage,
+  MODAL_REMOTE_EXIT_CODE_MARKER,
+  parseModalRemoteExitCode,
 } from '../../src/testing/modal-sandbox'
 
 describe('buildModalSandboxInvocation', () => {
@@ -29,11 +31,12 @@ describe('buildModalSandboxInvocation', () => {
       '--add-local',
       '/tmp/quantex-cli',
       '--cmd',
-      expect.stringContaining("/bin/bash -lc 'set -euo pipefail"),
+      expect.stringContaining('/bin/bash -lc'),
     ])
     expect(invocation.remoteCommand).toContain("cp -R '/mnt/quantex-cli' /tmp/quantex-work")
     expect(invocation.remoteCommand).toContain('bun install --frozen-lockfile --ignore-scripts --no-progress')
     expect(invocation.remoteCommand).toContain('bun run scripts/lifecycle-smoke.ts')
+    expect(invocation.remoteCommand).toContain(MODAL_REMOTE_EXIT_CODE_MARKER)
   })
 
   it('forwards explicit smoke agent arguments into the remote command', () => {
@@ -44,6 +47,18 @@ describe('buildModalSandboxInvocation', () => {
 
     expect(invocation.smokeArgs).toEqual(['pi', 'opencode'])
     expect(invocation.remoteCommand).toContain("bun run scripts/lifecycle-smoke.ts 'pi' 'opencode'")
+  })
+})
+
+describe('parseModalRemoteExitCode', () => {
+  it('returns the last remote exit-code marker', () => {
+    expect(
+      parseModalRemoteExitCode(`first\n${MODAL_REMOTE_EXIT_CODE_MARKER}=1\nretry\n${MODAL_REMOTE_EXIT_CODE_MARKER}=0`),
+    ).toBe(0)
+  })
+
+  it('returns undefined when the remote marker is missing', () => {
+    expect(parseModalRemoteExitCode('remote command output without marker')).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

Fix Modal sandbox validation so remote lifecycle smoke failures make `bun run test:sandbox` and the dedicated GitHub Actions workflow fail reliably. Also align the sandbox agent split: local Docker defaults to `pi,qoder`, while Actions overrides to `pi,opencode`.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `fix-modal-sandbox-failure-propagation`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Additional validation:

- [x] `bun run openspec:validate`
- [x] `bun run test -- test/testing/modal-sandbox.test.ts`
- [x] `QTX_ISOLATION_SCENARIOS=adopt-preinstalled QTX_ISOLATION_AGENTS=opencode bun run test:container`
- [x] `bun run test:container`

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge.
- [x] Release is not applicable.

## Notes

The prior sandbox workflow showed a remote Bun exception but still reported success because `modal shell` did not expose the remote command failure through its process exit code. This patch adds a stable remote exit-code marker and makes the local wrapper fail when the marker is missing or non-zero.
