### PR TITLE
docs: add quantex task start entry

### DIFF
--- a/.claude/skills/quantex-agent-runtime/SKILL.md
+++ b/.claude/skills/quantex-agent-runtime/SKILL.md
@@ -14,4 +14,6 @@ Then read and follow:
 - `AGENTS.md`
 - `openspec/README.md`
 
+For new task start or resume, use the "Task Start Entry" in the central runtime skill. Native slash or skill commands are only launchers; OpenSpec, worktrees, branches, and PRs remain the source of truth.
+
 Do not use copied OPSX workflow bodies from agent-specific directories. OpenSpec remains the source of truth for change contracts; this bootstrap only routes the session to the central runtime.

--- a/.codex/skills/quantex-agent-runtime/SKILL.md
+++ b/.codex/skills/quantex-agent-runtime/SKILL.md
@@ -14,4 +14,6 @@ Then read and follow:
 - `AGENTS.md`
 - `openspec/README.md`
 
+For new task start or resume, use the "Task Start Entry" in the central runtime skill. Native slash or skill commands are only launchers; OpenSpec, worktrees, branches, and PRs remain the source of truth.
+
 Do not use copied OPSX workflow bodies from agent-specific directories. OpenSpec remains the source of truth for change contracts; this bootstrap only routes the session to the central runtime.

--- a/.opencode/skills/quantex-agent-runtime/SKILL.md
+++ b/.opencode/skills/quantex-agent-runtime/SKILL.md
@@ -14,4 +14,6 @@ Then read and follow:
 - `AGENTS.md`
 - `openspec/README.md`
 
+For new task start or resume, use the "Task Start Entry" in the central runtime skill. Native slash or skill commands are only launchers; OpenSpec, worktrees, branches, and PRs remain the source of truth.
+
 Do not use copied OPSX workflow bodies from agent-specific directories. OpenSpec remains the source of truth for change contracts; this bootstrap only routes the session to the central runtime.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -176,6 +176,7 @@ For non-trivial behavior or durable-process changes, use Superpowers plus the ce
 - `skills/quantex-agent-runtime/SKILL.md`: Quantex-specific session startup, intake, validation, artifact routing, and closure
 - Superpowers skills: brainstorming, worktrees, planning, review, verification, and finishing branch behavior
 - OpenSpec CLI: proposal, design, spec, task, status, instructions, validation, and archive state transitions
+- [Quantex Task Start](./runbooks/quantex-task-start.md): copy-paste start prompt for fresh agent conversations when a native slash or skill launcher is unavailable
 
 On protected branches, archive closure is an explicit agent-driven follow-up. A fresh agent session should be able to resume from Superpowers + `skills/quantex-agent-runtime/SKILL.md`, inspect active OpenSpec changes, archive completed work, validate, and deliver the archive PR.
 

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -18,6 +18,7 @@ Current canonical runbooks:
 
 - [modal-sandbox-testing.md](./modal-sandbox-testing.md)
 - [quantex-troubleshooting.md](./quantex-troubleshooting.md)
+- [quantex-task-start.md](./quantex-task-start.md)
 - [releasing-quantex.md](./releasing-quantex.md)
 - [release-and-self-upgrade-debugging.md](./release-and-self-upgrade-debugging.md)
 - [worktree-task-execution.md](./worktree-task-execution.md)

--- a/docs/runbooks/quantex-task-start.md
+++ b/docs/runbooks/quantex-task-start.md
@@ -1,0 +1,81 @@
+# Runbook: Quantex Task Start
+
+## Purpose
+
+Provide one repeatable way to start or resume Quantex work from a fresh coding-agent conversation, regardless of whether the user starts in Codex, Claude Code, opencode, or another compatible agent.
+
+## When to use
+
+- you are starting a task that may create commits or a PR
+- you are resuming a task from a new conversation
+- you are unsure whether the current agent supports slash commands or skills
+- you want to avoid accidental edits on `main`
+
+## Canonical start prompt
+
+Paste this into a fresh agent conversation:
+
+```text
+Use quantex-agent-runtime.
+Activate Superpowers first if this environment supports it.
+Read AGENTS.md, skills/quantex-agent-runtime/SKILL.md, and openspec/README.md.
+Check git status, the current branch, git worktree list, and bun run openspec:list.
+If this will create commits or a PR, do not work on main; create or switch to a dedicated worktree branch named <agent>/<task-slug>.
+Classify the request through the OpenSpec intake gate before editing files.
+If OpenSpec is required, create or select the change and use openspec status/instructions to drive implementation.
+Continue through validation, commit, push, PR delivery, and archive-closure reporting as far as permissions allow.
+```
+
+If the agent has a native slash command or skill picker for `quantex-agent-runtime`, use that first. If it does not, paste the prompt above. The command or skill is only the launcher; project state still lives in git worktrees, branches, OpenSpec changes, PRs, and archive closure.
+
+## Worktree start
+
+For implementation work, start from an up-to-date `main` and create a dedicated worktree:
+
+```bash
+git switch main
+git pull --ff-only
+git worktree add -b <agent>/<task-slug> ../quantex-cli-<task-slug> main
+cd ../quantex-cli-<task-slug>
+git status --short --branch
+```
+
+Examples:
+
+```bash
+git worktree add -b codex/task-start-entry ../quantex-cli-task-start-entry main
+git worktree add -b claude/agent-catalog ../quantex-cli-agent-catalog main
+git worktree add -b opencode/sandbox-smoke ../quantex-cli-sandbox-smoke main
+```
+
+## Resume checklist
+
+When resuming from a fresh conversation, ask the agent to run:
+
+```bash
+git status --short --branch
+git worktree list
+bun run openspec:list
+```
+
+If the task already has an OpenSpec change, continue with:
+
+```bash
+bun run openspec:status -- --change <change-id>
+bun run openspec:instructions -- tasks --change <change-id>
+```
+
+## What not to do
+
+- Do not treat a slash command as project memory.
+- Do not implement on `main` when the task will create commits or a PR.
+- Do not duplicate full workflow instructions into agent-specific bootstrap files.
+- Do not add repo-local workflow wrapper commands when native `git`, `gh`, OpenSpec, and Superpowers instructions are enough.
+
+## Related artifacts
+
+- [AGENTS.md](../../AGENTS.md)
+- [GitHub Collaboration Flow](../github-collaboration.md)
+- [Worktree-Backed Implementation](./worktree-task-execution.md)
+- [OpenSpec README](../../openspec/README.md)
+- [Quantex Agent Runtime](../../skills/quantex-agent-runtime/SKILL.md)

--- a/openspec/changes/add-quantex-task-start-entry/.openspec.yaml
+++ b/openspec/changes/add-quantex-task-start-entry/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/add-quantex-task-start-entry/design.md
+++ b/openspec/changes/add-quantex-task-start-entry/design.md
@@ -1,0 +1,27 @@
+# Design: Quantex task start entry
+
+## Shape
+
+The task start entry is a documented prompt/runbook pattern, not a new product command. Agents that support skills or slash commands can use their native entry to invoke `quantex-agent-runtime`; agents without that support can paste the canonical prompt.
+
+The runtime still owns the session behavior:
+
+1. Activate Superpowers when available.
+2. Read the central runtime and `AGENTS.md`.
+3. Inspect git and OpenSpec state.
+4. Classify the request through the intake gate.
+5. Use a dedicated worktree/branch for implementation work by default.
+
+## Rationale
+
+This keeps Quantex aligned with the existing non-goal: do not turn the project into a workflow orchestration platform. The entry removes ambiguity for humans and agents while leaving actual state in repo-native artifacts: OpenSpec changes, worktrees, branches, PRs, and archive closure.
+
+## Compatibility
+
+The entry is intentionally text-first:
+
+- Codex can trigger the runtime skill by name.
+- Claude Code and opencode can use their agent-specific bootstrap skills when available.
+- Any agent can paste the fallback prompt and still reach the same repo-native workflow.
+
+No assumptions are made about a universal slash command syntax across agents.

--- a/openspec/changes/add-quantex-task-start-entry/proposal.md
+++ b/openspec/changes/add-quantex-task-start-entry/proposal.md
@@ -1,0 +1,14 @@
+# Proposal: Add Quantex task start entry
+
+## Why
+
+Quantex already has the pieces for cross-agent work: Superpowers, a central runtime skill, OpenSpec, worktree guidance, and thin agent bootstraps. The missing piece is a clear, repeatable "start a new task" entry that a user can paste into a fresh Codex, Claude Code, or opencode session without knowing each agent's slash-command details.
+
+Without that entry, users can reasonably expect `/something` to exist and become confused when the project has workflow rules but no obvious task-start affordance.
+
+## What Changes
+
+- Define a canonical Quantex task start prompt that works across agents.
+- Update the central runtime skill so task start/resume behavior is explicit.
+- Add a runbook explaining how to start a task from a fresh conversation, with or without slash-command support.
+- Keep the implementation lightweight: no Quantex product command, no repo-local orchestration wrapper, and no duplicated full workflow bodies per agent.

--- a/openspec/changes/add-quantex-task-start-entry/specs/project-memory/spec.md
+++ b/openspec/changes/add-quantex-task-start-entry/specs/project-memory/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Quantex task start entry SHALL be canonical and text-first
+
+The project SHALL document a canonical task start entry that lets a user start or resume Quantex work from a fresh coding-agent conversation without relying on a specific agent's slash-command syntax. The entry MUST route the agent through Superpowers when available, the central Quantex runtime skill, OpenSpec intake, and worktree-backed implementation rules.
+
+#### Scenario: User starts a task in a fresh agent conversation
+
+- **WHEN** a user starts a new Quantex task from a fresh Codex, Claude Code, opencode, or comparable coding-agent conversation
+- **THEN** the project provides a copy-paste task start prompt that tells the agent to use the central Quantex runtime
+- **AND** the prompt tells the agent to inspect git state and active OpenSpec changes before editing
+- **AND** the prompt tells the agent not to implement on `main` when work will create commits or a PR
+- **AND** the prompt tells the agent to create or select an OpenSpec change when the intake gate requires one
+
+#### Scenario: Agent supports slash commands or skills
+
+- **WHEN** the current agent supports a slash command, skill invocation, or equivalent native workflow entry
+- **THEN** the user MAY invoke the native entry for `quantex-agent-runtime`
+- **AND** the native entry MUST remain a thin route to the central runtime instead of duplicating the full workflow body
+
+#### Scenario: Agent does not support a task start command
+
+- **WHEN** the current agent has no usable slash-command or skill invocation surface
+- **THEN** the user can paste the canonical task start prompt directly into the conversation
+- **AND** the agent still follows the same OpenSpec and worktree-backed workflow

--- a/openspec/changes/add-quantex-task-start-entry/tasks.md
+++ b/openspec/changes/add-quantex-task-start-entry/tasks.md
@@ -1,0 +1,7 @@
+## 1. Task Start Entry
+
+- [x] 1.1 Add the OpenSpec contract for the canonical task start entry.
+- [x] 1.2 Update the central runtime skill with task start/resume instructions.
+- [x] 1.3 Add a runbook with the copy-paste start prompt and worktree behavior.
+- [x] 1.4 Keep agent-specific bootstraps thin while pointing to the canonical start entry.
+- [x] 1.5 Run validation.

--- a/skills/quantex-agent-runtime/SKILL.md
+++ b/skills/quantex-agent-runtime/SKILL.md
@@ -24,6 +24,23 @@ Use this skill at the start of every Quantex repository session, and again befor
 4. Run `bun run openspec:list` to identify active changes.
 5. Classify the user request before editing files.
 
+## Task Start Entry
+
+Use this canonical entry when a user starts or resumes Quantex work from a fresh agent conversation:
+
+```text
+Use quantex-agent-runtime.
+Activate Superpowers first if this environment supports it.
+Read AGENTS.md, skills/quantex-agent-runtime/SKILL.md, and openspec/README.md.
+Check git status, the current branch, git worktree list, and bun run openspec:list.
+If this will create commits or a PR, do not work on main; create or switch to a dedicated worktree branch named <agent>/<task-slug>.
+Classify the request through the OpenSpec intake gate before editing files.
+If OpenSpec is required, create or select the change and use openspec status/instructions to drive implementation.
+Continue through validation, commit, push, PR delivery, and archive-closure reporting as far as permissions allow.
+```
+
+If the current agent has a slash command, skill command, or equivalent native entry for `quantex-agent-runtime`, use that native entry first. If it does not, paste the text entry above. The slash command is only a launcher; OpenSpec, git worktrees, branches, PRs, and archive closure remain the source of truth.
+
 ## Intake
 
 Create or select an OpenSpec change before implementation when the work affects:


### PR DESCRIPTION
## Summary

Add a canonical Quantex task start entry for fresh coding-agent conversations. The entry is text-first, routes through `quantex-agent-runtime`, OpenSpec intake, and worktree-backed implementation, and avoids adding a product CLI or repo-local workflow wrapper.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `add-quantex-task-start-entry`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Additional validation:

- [x] `bun run openspec:validate`

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge.
- [x] Release is not applicable.

## Notes

This intentionally defines a canonical prompt/runbook entry rather than adding a `/quantex:start` product command or repo-local orchestration wrapper.
