### PR TITLE
ci: narrow sandbox workflow triggers

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -7,6 +7,26 @@ on:
     branches:
       - main
       - beta
+    paths:
+      - '.github/workflows/sandbox-tests.yml'
+      - 'bun.lock'
+      - 'package.json'
+      - 'scripts/lifecycle-smoke.ts'
+      - 'scripts/test-container.ts'
+      - 'scripts/test-sandbox.ts'
+      - 'src/agents/**'
+      - 'src/agent-update/**'
+      - 'src/commands/**'
+      - 'src/config/**'
+      - 'src/inspection/**'
+      - 'src/package-manager/**'
+      - 'src/self/**'
+      - 'src/state/**'
+      - 'src/testing/**'
+      - 'src/utils/**'
+      - 'test/agents.test.ts'
+      - 'test/testing/**'
+      - 'test/utils/install.test.ts'
 
   schedule:
     - cron: '0 6 * * 2'

--- a/docs/runbooks/modal-sandbox-testing.md
+++ b/docs/runbooks/modal-sandbox-testing.md
@@ -90,7 +90,7 @@ For local broad-agent coverage without the slower upstream install path, `qoder`
 QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:container
 ```
 
-The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AGENTS=pi,opencode` and a longer command timeout so remote validation covers the lightweight baseline plus opencode under better network conditions.
+The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AGENTS=pi,opencode` and a longer command timeout so remote validation covers the lightweight baseline plus opencode under better network conditions. Protected-branch pushes only trigger the workflow when lifecycle-sensitive files change; docs-only and OpenSpec archive-only merges do not start Modal automatically.
 
 ## Triage order
 

--- a/openspec/changes/narrow-sandbox-workflow-triggers/.openspec.yaml
+++ b/openspec/changes/narrow-sandbox-workflow-triggers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/narrow-sandbox-workflow-triggers/design.md
+++ b/openspec/changes/narrow-sandbox-workflow-triggers/design.md
@@ -1,0 +1,30 @@
+# Design: Narrow sandbox workflow push triggers
+
+## Approach
+
+Use GitHub Actions `paths` filtering on the existing `push` trigger for `main` and `beta`.
+
+The include list should cover files that can affect sandbox lifecycle behavior:
+
+- `.github/workflows/sandbox-tests.yml`
+- `package.json` and `bun.lock`
+- `scripts/lifecycle-smoke.ts`
+- `scripts/test-container.ts`
+- `scripts/test-sandbox.ts`
+- `src/agents/**`
+- `src/agent-update/**`
+- `src/commands/**`
+- `src/config/**`
+- `src/inspection/**`
+- `src/package-manager/**`
+- `src/self/**`
+- `src/state/**`
+- `src/testing/**`
+- `src/utils/**`
+- relevant tests for sandbox and lifecycle helpers
+
+Documentation and OpenSpec-only archive changes are intentionally excluded from automatic push-triggered sandbox runs. Maintainers can still run the workflow manually when a process-only change needs remote validation.
+
+## Tradeoffs
+
+Path filtering is simpler than calling the repository taxonomy from inside the workflow, and it prevents docs-only pushes from starting a Modal job before any repository code executes. The tradeoff is that the workflow carries a narrow path list. This is acceptable here because the sandbox workflow is an optional maintainer validation layer, not a merge-gating classification authority.

--- a/openspec/changes/narrow-sandbox-workflow-triggers/proposal.md
+++ b/openspec/changes/narrow-sandbox-workflow-triggers/proposal.md
@@ -1,0 +1,24 @@
+# Proposal: Narrow sandbox workflow push triggers
+
+## Summary
+
+Restrict the dedicated Modal sandbox workflow so protected-branch documentation-only or OpenSpec archive-only merges do not trigger expensive remote lifecycle smoke runs.
+
+## Motivation
+
+The sandbox workflow validates real agent lifecycle behavior through Modal. It is useful when lifecycle code, agent definitions, sandbox scripts, package metadata, or the workflow itself changes, but it is noisy and wasteful for docs-only or archive-only merges.
+
+The workflow should remain manually runnable and scheduled so maintainers can still validate the remote path on demand and catch upstream drift.
+
+## Goals
+
+- Keep `workflow_dispatch` and the weekly schedule.
+- Keep protected-branch `push` triggers for lifecycle-sensitive changes.
+- Avoid automatic sandbox runs for docs-only and OpenSpec archive-only merges.
+- Document the trigger boundary in the code quality tooling spec.
+
+## Non-Goals
+
+- Move sandbox validation into merge-gating `ci.yml`.
+- Make Modal sandbox validation required for every pull request.
+- Replace local Docker isolation validation.

--- a/openspec/changes/narrow-sandbox-workflow-triggers/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/narrow-sandbox-workflow-triggers/specs/code-quality-tooling/spec.md
@@ -1,0 +1,16 @@
+## MODIFIED Requirements
+
+### Requirement: Modal-backed isolation workflow remains separate from merge-gating CI
+
+The repository SHALL keep Modal-backed isolation validation in a dedicated GitHub Actions workflow instead of adding it to the merge-gating `ci.yml` workflow.
+
+#### Scenario: Documentation-only merge reaches a protected branch
+
+- **WHEN** a merge to `main` or `beta` changes only documentation or OpenSpec archive files
+- **THEN** the dedicated Modal sandbox workflow does not run automatically from the protected-branch push
+- **AND** maintainers can still start the sandbox workflow manually
+
+#### Scenario: Lifecycle-sensitive merge reaches a protected branch
+
+- **WHEN** a merge to `main` or `beta` changes agent definitions, lifecycle commands, install/update helpers, sandbox scripts, package metadata, or the sandbox workflow itself
+- **THEN** the dedicated Modal sandbox workflow runs automatically from the protected-branch push

--- a/openspec/changes/narrow-sandbox-workflow-triggers/tasks.md
+++ b/openspec/changes/narrow-sandbox-workflow-triggers/tasks.md
@@ -1,0 +1,6 @@
+## 1. Trigger Scope
+
+- [x] 1.1 Add an OpenSpec delta documenting path-scoped sandbox workflow push triggers.
+- [x] 1.2 Add `paths` filters to `.github/workflows/sandbox-tests.yml` for lifecycle-sensitive files.
+- [x] 1.3 Update runbook guidance to clarify docs-only merges do not automatically trigger sandbox CI.
+- [x] 1.4 Run validation and deliver through PR.


### PR DESCRIPTION
## Summary

Narrow the dedicated Sandbox Tests workflow push trigger so docs-only and OpenSpec archive-only merges do not automatically start Modal. Manual dispatch and the weekly schedule remain available.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `narrow-sandbox-workflow-triggers`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Additional validation:

- [x] `bun run openspec:validate`

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge.
- [x] Release is not applicable.

## Notes

The push trigger now watches lifecycle-sensitive files only. Docs-only and OpenSpec archive-only protected-branch pushes are intentionally excluded, while `workflow_dispatch` and the weekly schedule still run without path filtering.
