### PR TITLE
feat(agents): add Crush agent support

### DIFF
--- a/openspec/changes/add-crush-agent/design.md
+++ b/openspec/changes/add-crush-agent/design.md
@@ -1,0 +1,24 @@
+## Context
+
+Crush (by Charmbracelet) is a Go-based terminal AI coding agent with broad multi-platform install support. Quantex's agent catalog needs a new definition entry following the established pattern in `src/agents/definitions/`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add Crush as a supported agent with all known install methods
+- Follow the existing agent definition pattern exactly
+
+**Non-Goals:**
+- No changes to Quantex core, CLI surface, or catalog schema
+- No changes to install resolution or update planning logic
+
+## Decisions
+
+- **Homebrew tap over core formula**: Use `charmbracelet/tap/crush` (the official Charm tap) as the Homebrew install method, matching the README recommendation.
+- **No script install method**: Crush does not advertise a curl-to-shell install script in its README. The available methods are Homebrew, npm, winget, scoop, apt/yum repos, Go install, and binary download. We register Homebrew, npm/bun, and winget as the primary managed methods.
+- **Self-update**: Crush supports `crush update` for self-updating.
+- **Version probe**: `crush --version` is the standard version check.
+
+## Risks / Trade-offs
+
+- [Homebrew tap path format] → The `brewInstall` helper takes a `packageName` string. For taps, the convention is to pass the full tap reference (e.g., `charmbracelet/tap/crush`). This is consistent with how other agents use brew.

--- a/openspec/changes/add-crush-agent/proposal.md
+++ b/openspec/changes/add-crush-agent/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Charmbracelet's Crush is a prominent terminal-based AI coding agent with broad multi-platform support (Homebrew, npm, winget, scoop, apt, yum, Go install, binary downloads). It is not yet in the Quantex agent catalog, so users cannot install, inspect, update, or launch Crush through Quantex.
+
+## What Changes
+
+- Add Crush as a supported agent entry in the Quantex catalog
+- Register canonical name `crush`, display name `Crush`, binary name `crush`
+- Register npm package `@charmland/crush`
+- Register install methods: Homebrew (macOS/Linux), npm/bun (all platforms), winget (Windows)
+- Register self-update command `crush update`
+- Register version probe command `crush --version`
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `agent-catalog`: Add Crush as a supported lifecycle agent with install, inspect, update, and execution metadata
+
+## Impact
+
+- `src/agents/definitions/crush.ts` (new file)
+- `src/agents/index.ts` (import and register)
+- `openspec/specs/agent-catalog/spec.md` (add Crush requirement)

--- a/openspec/changes/add-crush-agent/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-crush-agent/specs/agent-catalog/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Crush MUST be a supported lifecycle agent
+
+Quantex SHALL include Crush (by Charmbracelet) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Crush
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `crush`
+- **THEN** Quantex returns a supported agent entry for Crush
+- **AND** the entry identifies `crush` as the executable binary
+- **AND** the entry identifies `@charmland/crush` as its npm package metadata
+- **AND** the entry identifies `https://github.com/charmbracelet/crush` as the homepage
+
+#### Scenario: Installing Crush through supported methods
+
+- **WHEN** Quantex renders or executes install options for Crush
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the Homebrew tap install method (`charmbracelet/tap/crush`)
+- **AND** Windows includes the winget install method (`charmbracelet.crush`)
+
+#### Scenario: Probing Crush version
+
+- **WHEN** Quantex probes the installed version of Crush
+- **THEN** it runs `crush --version` and parses the output
+
+#### Scenario: Planning Crush updates
+
+- **WHEN** Quantex plans an update for a Crush installation that supports self-update
+- **THEN** the catalog exposes `crush update` as the agent self-update command

--- a/openspec/changes/add-crush-agent/tasks.md
+++ b/openspec/changes/add-crush-agent/tasks.md
@@ -1,0 +1,5 @@
+## Tasks
+
+- [ ] Create `src/agents/definitions/crush.ts` with Crush agent definition
+- [ ] Register Crush in `src/agents/index.ts` (import + array entry + re-export)
+- [ ] Update `openspec/specs/agent-catalog/spec.md` with Crush requirement

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -87,6 +87,35 @@ Quantex SHALL include Kimi Code CLI in the supported agent catalog with lifecycl
 - **WHEN** Quantex plans an update for a Kimi Code CLI installation that supports self-update
 - **THEN** the catalog exposes `uv tool upgrade kimi-cli --no-cache` as the agent self-update command
 
+### Requirement: Crush MUST be a supported lifecycle agent
+
+Quantex SHALL include Crush (by Charmbracelet) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Crush
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `crush`
+- **THEN** Quantex returns a supported agent entry for Crush
+- **AND** the entry identifies `crush` as the executable binary
+- **AND** the entry identifies `@charmland/crush` as its npm package metadata
+- **AND** the entry identifies `https://github.com/charmbracelet/crush` as the homepage
+
+#### Scenario: Installing Crush through supported methods
+
+- **WHEN** Quantex renders or executes install options for Crush
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the Homebrew tap install method (`charmbracelet/tap/crush`)
+- **AND** Windows includes the winget install method (`charmbracelet.crush`)
+
+#### Scenario: Probing Crush version
+
+- **WHEN** Quantex probes the installed version of Crush
+- **THEN** it runs `crush --version` and parses the output
+
+#### Scenario: Planning Crush updates
+
+- **WHEN** Quantex plans an update for a Crush installation that supports self-update
+- **THEN** the catalog exposes `crush update` as the agent self-update command
+
 ### Requirement: Kilo CLI MUST use the current supported display name
 
 Quantex SHALL expose the Kilo catalog entry with the display name `Kilo CLI` while keeping the canonical agent slug `kilo`.

--- a/src/agents/definitions/crush.ts
+++ b/src/agents/definitions/crush.ts
@@ -1,0 +1,23 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, bunInstall, npmInstall, wingetInstall } from '../methods'
+
+export const crush: AgentDefinition = {
+  name: 'crush',
+  displayName: 'Crush',
+  homepage: 'https://github.com/charmbracelet/crush',
+  packages: {
+    npm: '@charmland/crush',
+  },
+  binaryName: 'crush',
+  selfUpdate: {
+    command: ['crush', 'update'],
+  },
+  versionProbe: {
+    command: ['crush', '--version'],
+  },
+  platforms: {
+    windows: [bunInstall(), npmInstall(), wingetInstall('charmbracelet.crush')],
+    macos: [bunInstall(), npmInstall(), brewInstall('charmbracelet/tap/crush')],
+    linux: [bunInstall(), npmInstall(), brewInstall('charmbracelet/tap/crush')],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -2,6 +2,7 @@ import type { AgentDefinition } from './types'
 import { claude } from './definitions/claude'
 import { codex } from './definitions/codex'
 import { copilot } from './definitions/copilot'
+import { crush } from './definitions/crush'
 import { cursor } from './definitions/cursor'
 import { droid } from './definitions/droid'
 import { gemini } from './definitions/gemini'
@@ -12,7 +13,21 @@ import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
 
-const agents: AgentDefinition[] = [claude, codex, copilot, cursor, droid, gemini, kimi, kilo, opencode, pi, qoder, qwen]
+const agents: AgentDefinition[] = [
+  claude,
+  codex,
+  copilot,
+  crush,
+  cursor,
+  droid,
+  gemini,
+  kimi,
+  kilo,
+  opencode,
+  pi,
+  qoder,
+  qwen,
+]
 
 export function getAllAgents(): AgentDefinition[] {
   return agents
@@ -26,7 +41,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
   return getAgentByLookupName(name)
 }
 
-export { claude, codex, copilot, cursor, droid, gemini, kimi, kilo, opencode, pi, qoder, qwen }
+export { claude, codex, copilot, crush, cursor, droid, gemini, kimi, kilo, opencode, pi, qoder, qwen }
 export type {
   AgentDefinition,
   AgentPackageMetadata,


### PR DESCRIPTION
## Summary

Add Charmbracelet Crush as a supported agent in the Quantex catalog with lifecycle-focused metadata for installation, inspection, version probing, and self-update.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `add-crush-agent`
- Discussion:

## Validation

- [ ] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature
- Release: patch - bug fix
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Crush install methods: Homebrew tap (`charmbracelet/tap/crush`), npm (`@charmland/crush`), bun, winget (`charmbracelet.crush`). Self-update via `crush update`, version probe via `crush --version`.
