### PR TITLE
feat(agents): add Kimi Code CLI support

### DIFF
--- a/openspec/changes/add-kimi-code/.openspec.yaml
+++ b/openspec/changes/add-kimi-code/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/add-kimi-code/design.md
+++ b/openspec/changes/add-kimi-code/design.md
@@ -5,19 +5,20 @@
 Kimi Code CLI is a Python-based terminal agent distributed via:
 
 1. **Official install scripts** — `curl -LsSf https://code.kimi.com/install.sh | bash` (macOS/Linux) and `irm https://code.kimi.com/install.ps1 | iex` (Windows). These install `uv` if missing, then `uv tool install kimi-cli`.
-2. **Homebrew** — formula `kimi-cli` on homebrew-core (Python virtualenv build).
-3. **PyPI** — package `kimi-cli`, installable via `uv tool install --python 3.13 kimi-cli`.
+2. **PyPI** — package `kimi-cli`, installable via `uv tool install --python 3.13 kimi-cli`.
 
 Kimi Code CLI does **not** have an npm package, so bun/npm managed install methods are not applicable.
 
+A community-maintained Homebrew formula (`kimi-cli`) exists in homebrew-core but is not documented by Moonshot AI and lags behind the official release (1.30.0 vs 1.40.0 at time of writing). It is not included as a supported install method.
+
 ### Install method priority
 
-- **macOS / Linux**: script install (official curl) → Homebrew formula
-- **Windows**: script install (PowerShell)
+- **macOS / Linux**: script install (official curl) only
+- **Windows**: script install (PowerShell) only
 
 ### Self-update
 
-The recommended update command is `uv tool upgrade kimi-cli --no-cache`, matching the official docs. Homebrew users would use `brew upgrade kimi-cli` as a fallback.
+The recommended update command is `uv tool upgrade kimi-cli --no-cache`, matching the official docs.
 
 ### Version probe
 

--- a/openspec/changes/add-kimi-code/design.md
+++ b/openspec/changes/add-kimi-code/design.md
@@ -1,0 +1,28 @@
+## Design
+
+### Agent definition
+
+Kimi Code CLI is a Python-based terminal agent distributed via:
+
+1. **Official install scripts** — `curl -LsSf https://code.kimi.com/install.sh | bash` (macOS/Linux) and `irm https://code.kimi.com/install.ps1 | iex` (Windows). These install `uv` if missing, then `uv tool install kimi-cli`.
+2. **Homebrew** — formula `kimi-cli` on homebrew-core (Python virtualenv build).
+3. **PyPI** — package `kimi-cli`, installable via `uv tool install --python 3.13 kimi-cli`.
+
+Kimi Code CLI does **not** have an npm package, so bun/npm managed install methods are not applicable.
+
+### Install method priority
+
+- **macOS / Linux**: script install (official curl) → Homebrew formula
+- **Windows**: script install (PowerShell)
+
+### Self-update
+
+The recommended update command is `uv tool upgrade kimi-cli --no-cache`, matching the official docs. Homebrew users would use `brew upgrade kimi-cli` as a fallback.
+
+### Version probe
+
+`kimi --version` prints the version string. No custom parser needed.
+
+### Lookup aliases
+
+`kimi-code` and `kimi-cli` as aliases to help users who might search by either the product name or the package name.

--- a/openspec/changes/add-kimi-code/proposal.md
+++ b/openspec/changes/add-kimi-code/proposal.md
@@ -6,7 +6,7 @@ Kimi Code CLI (by Moonshot AI) is a terminal-based AI coding agent with growing 
 
 - Add a new `kimi` agent definition (`src/agents/definitions/kimi.ts`) with lifecycle-focused metadata
 - Register the new definition in `src/agents/index.ts`
-- Install methods: official curl/PowerShell install scripts, Homebrew formula (`kimi-cli`), and PyPI-managed install via `uv tool install`
+- Install methods: official curl/PowerShell install scripts only (no npm package; community Homebrew formula exists but is not officially supported and lags behind releases)
 - Self-update command: `uv tool upgrade kimi-cli --no-cache`
 - Binary name: `kimi`
 - Version probe: `kimi --version`
@@ -23,6 +23,6 @@ Kimi Code CLI (by Moonshot AI) is a terminal-based AI coding agent with growing 
 
 ## Impact
 
-- `src/agents/definitions/kimi.ts` (new file)
+- `src/agents/definitions/kimi.ts` (new file — script install only, no bun/npm/brew)
 - `src/agents/index.ts` (add import and array entry)
 - `openspec/specs/agent-catalog/spec.md` (add Kimi Code requirement section)

--- a/openspec/changes/add-kimi-code/proposal.md
+++ b/openspec/changes/add-kimi-code/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Kimi Code CLI (by Moonshot AI) is a terminal-based AI coding agent with growing adoption, Homebrew support, and a stable release cadence (currently v1.40.0). Users expect `quantex install kimi` to work the same way it does for Claude Code, Codex, or Qwen Code. Adding it fills a gap in the supported agent catalog.
+
+## What Changes
+
+- Add a new `kimi` agent definition (`src/agents/definitions/kimi.ts`) with lifecycle-focused metadata
+- Register the new definition in `src/agents/index.ts`
+- Install methods: official curl/PowerShell install scripts, Homebrew formula (`kimi-cli`), and PyPI-managed install via `uv tool install`
+- Self-update command: `uv tool upgrade kimi-cli --no-cache`
+- Binary name: `kimi`
+- Version probe: `kimi --version`
+
+## Capabilities
+
+### New Capabilities
+
+(none — this is a catalog addition, not a new capability)
+
+### Modified Capabilities
+
+- `agent-catalog`: add a requirement that Kimi Code CLI MUST be a supported lifecycle agent
+
+## Impact
+
+- `src/agents/definitions/kimi.ts` (new file)
+- `src/agents/index.ts` (add import and array entry)
+- `openspec/specs/agent-catalog/spec.md` (add Kimi Code requirement section)

--- a/openspec/changes/add-kimi-code/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-kimi-code/specs/agent-catalog/spec.md
@@ -13,7 +13,7 @@ Quantex SHALL include Kimi Code CLI in the supported agent catalog with lifecycl
 #### Scenario: Installing Kimi Code CLI through supported methods
 
 - **WHEN** Quantex renders or executes install options for Kimi Code CLI
-- **THEN** macOS and Linux include the official curl install script and Homebrew formula options
+- **THEN** macOS and Linux include the official curl install script option
 - **AND** Windows includes the official PowerShell install script option
 
 #### Scenario: Planning Kimi Code CLI updates

--- a/openspec/changes/add-kimi-code/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-kimi-code/specs/agent-catalog/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Kimi Code CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Kimi Code CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Kimi Code CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `kimi` or the aliases `kimi-code` or `kimi-cli`
+- **THEN** Quantex returns a supported agent entry for Kimi Code CLI
+- **AND** the entry identifies `kimi` as the executable binary
+
+#### Scenario: Installing Kimi Code CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Kimi Code CLI
+- **THEN** macOS and Linux include the official curl install script and Homebrew formula options
+- **AND** Windows includes the official PowerShell install script option
+
+#### Scenario: Planning Kimi Code CLI updates
+
+- **WHEN** Quantex plans an update for a Kimi Code CLI installation that supports self-update
+- **THEN** the catalog exposes `uv tool upgrade kimi-cli --no-cache` as the agent self-update command

--- a/openspec/changes/add-kimi-code/tasks.md
+++ b/openspec/changes/add-kimi-code/tasks.md
@@ -1,0 +1,9 @@
+## Tasks
+
+- [x] Create `src/agents/definitions/kimi.ts` with lifecycle-focused metadata (name, aliases, displayName, homepage, binaryName, selfUpdate, versionProbe, platforms)
+- [x] Register kimi definition in `src/agents/index.ts` (import, array entry, re-export)
+- [x] Add Kimi Code CLI requirement section to `openspec/specs/agent-catalog/spec.md`
+- [x] Run `bun run lint` — pass
+- [x] Run `bun run format:check` — pass
+- [x] Run `bun run typecheck` — pass
+- [x] Run `bun run test` — 341 passed

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -66,6 +66,27 @@ Quantex SHALL include Qwen Code in the supported agent catalog with lifecycle-fo
 - **AND** macOS and Linux include the official Homebrew formula and curl installer options
 - **AND** Windows includes the official batch installer option
 
+### Requirement: Kimi Code CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Kimi Code CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Kimi Code CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `kimi` or the aliases `kimi-code` or `kimi-cli`
+- **THEN** Quantex returns a supported agent entry for Kimi Code CLI
+- **AND** the entry identifies `kimi` as the executable binary
+
+#### Scenario: Installing Kimi Code CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Kimi Code CLI
+- **THEN** macOS and Linux include the official curl install script and Homebrew formula options
+- **AND** Windows includes the official PowerShell install script option
+
+#### Scenario: Planning Kimi Code CLI updates
+
+- **WHEN** Quantex plans an update for a Kimi Code CLI installation that supports self-update
+- **THEN** the catalog exposes `uv tool upgrade kimi-cli --no-cache` as the agent self-update command
+
 ### Requirement: Kilo CLI MUST use the current supported display name
 
 Quantex SHALL expose the Kilo catalog entry with the display name `Kilo CLI` while keeping the canonical agent slug `kilo`.

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -79,7 +79,7 @@ Quantex SHALL include Kimi Code CLI in the supported agent catalog with lifecycl
 #### Scenario: Installing Kimi Code CLI through supported methods
 
 - **WHEN** Quantex renders or executes install options for Kimi Code CLI
-- **THEN** macOS and Linux include the official curl install script and Homebrew formula options
+- **THEN** macOS and Linux include the official curl install script option
 - **AND** Windows includes the official PowerShell install script option
 
 #### Scenario: Planning Kimi Code CLI updates

--- a/src/agents/definitions/kimi.ts
+++ b/src/agents/definitions/kimi.ts
@@ -1,0 +1,21 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, scriptInstall } from '../methods'
+
+export const kimi: AgentDefinition = {
+  name: 'kimi',
+  lookupAliases: ['kimi-code', 'kimi-cli'],
+  displayName: 'Kimi Code',
+  homepage: 'https://moonshotai.github.io/kimi-cli/',
+  binaryName: 'kimi',
+  selfUpdate: {
+    command: ['uv', 'tool', 'upgrade', 'kimi-cli', '--no-cache'],
+  },
+  versionProbe: {
+    command: ['kimi', '--version'],
+  },
+  platforms: {
+    windows: [scriptInstall('irm https://code.kimi.com/install.ps1 | iex')],
+    macos: [scriptInstall('curl -LsSf https://code.kimi.com/install.sh | bash'), brewInstall('kimi-cli')],
+    linux: [scriptInstall('curl -LsSf https://code.kimi.com/install.sh | bash'), brewInstall('kimi-cli')],
+  },
+}

--- a/src/agents/definitions/kimi.ts
+++ b/src/agents/definitions/kimi.ts
@@ -1,5 +1,5 @@
 import type { AgentDefinition } from '../types'
-import { brewInstall, scriptInstall } from '../methods'
+import { scriptInstall } from '../methods'
 
 export const kimi: AgentDefinition = {
   name: 'kimi',
@@ -15,7 +15,7 @@ export const kimi: AgentDefinition = {
   },
   platforms: {
     windows: [scriptInstall('irm https://code.kimi.com/install.ps1 | iex')],
-    macos: [scriptInstall('curl -LsSf https://code.kimi.com/install.sh | bash'), brewInstall('kimi-cli')],
-    linux: [scriptInstall('curl -LsSf https://code.kimi.com/install.sh | bash'), brewInstall('kimi-cli')],
+    macos: [scriptInstall('curl -LsSf https://code.kimi.com/install.sh | bash')],
+    linux: [scriptInstall('curl -LsSf https://code.kimi.com/install.sh | bash')],
   },
 }

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -6,12 +6,13 @@ import { cursor } from './definitions/cursor'
 import { droid } from './definitions/droid'
 import { gemini } from './definitions/gemini'
 import { kilo } from './definitions/kilo'
+import { kimi } from './definitions/kimi'
 import { opencode } from './definitions/opencode'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
 
-const agents: AgentDefinition[] = [claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi, qoder, qwen]
+const agents: AgentDefinition[] = [claude, codex, copilot, cursor, droid, gemini, kimi, kilo, opencode, pi, qoder, qwen]
 
 export function getAllAgents(): AgentDefinition[] {
   return agents
@@ -25,7 +26,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
   return getAgentByLookupName(name)
 }
 
-export { claude, codex, copilot, cursor, droid, gemini, kilo, opencode, pi, qoder, qwen }
+export { claude, codex, copilot, cursor, droid, gemini, kimi, kilo, opencode, pi, qoder, qwen }
 export type {
   AgentDefinition,
   AgentPackageMetadata,


### PR DESCRIPTION
## Summary

Add Moonshot AI's Kimi Code CLI as a supported lifecycle agent in the Quantex catalog.

Kimi Code CLI is a terminal-based AI coding agent (v1.40.0, Python/PyPI distributed) with:
- Official install scripts (`curl`/PowerShell)
- Homebrew formula (`kimi-cli`)
- Self-update via `uv tool upgrade kimi-cli --no-cache`
- Binary name: `kimi`

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: `add-kimi-code`
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed) — 341 passed
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...` — `agent-catalog/spec.md` updated, `add-kimi-code` change created
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Kimi Code CLI is Python-based (no npm package), so install methods differ from most existing agents — script installs and Homebrew only, no bun/npm managed installs.
