### PR TITLE
docs(agent-catalog): define support matrix fields

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ GitHub workflow guidance:
 - [github-collaboration.md](./github-collaboration.md)
 - [releases.md](./releases.md)
 - [skill-installation-and-distribution.md](./skill-installation-and-distribution.md)
+- [agent-support-matrix.md](./agent-support-matrix.md)
 
 Operational runbooks:
 

--- a/docs/agent-support-matrix.md
+++ b/docs/agent-support-matrix.md
@@ -1,0 +1,57 @@
+# Agent Support Matrix
+
+This page defines the review format for Quantex agent-support coverage. It is a documentation and planning aid, not the runtime source of truth.
+
+## Source Of Truth
+
+- `supported` entries must match implemented definitions in `src/agents/definitions/*.ts`.
+- `in-progress` entries should point to an active OpenSpec change when one exists.
+- `candidate` and `excluded` entries are evaluation states only; they do not create product guarantees.
+
+## Required Fields
+
+| Field | Meaning |
+|---|---|
+| Product | The upstream product name shown to humans. |
+| Canonical slug | The stable Quantex identifier used for lookup, docs, and future catalog work. |
+| Binary command | The upstream executable command Quantex resolves or would resolve at runtime. |
+| Aliases | Optional accepted lookup aliases, including executable aliases when they differ from the canonical slug. |
+| Status | One of `supported`, `in-progress`, `candidate`, or `excluded`. |
+| Notes | Short rationale, blockers, or exception details. |
+
+## Naming Rule
+
+Default rule:
+
+- Use the upstream executable command as the canonical slug when the executable is stable, product-specific, and suitable as a user-facing identifier.
+
+Exception rule:
+
+- Keep a branded canonical slug when the executable command is too generic, ambiguous, or otherwise unsuitable as the primary Quantex identifier.
+- In those cases, record the executable separately in `Binary command` and note the exception in `Notes`.
+- Add the executable to `Aliases` when that improves lookup and does not weaken the branded slug.
+
+## Status Meanings
+
+| Status | Meaning |
+|---|---|
+| `supported` | Implemented in `src/agents/definitions/*.ts` and exposed by the Quantex catalog. |
+| `in-progress` | Active implementation or spec work is underway in the repository. |
+| `candidate` | Worth evaluating for support, but not yet accepted into implementation. |
+| `excluded` | Intentionally outside the Quantex mainline support scope. |
+
+## Example Rows
+
+| Product | Canonical slug | Binary command | Aliases | Status | Notes |
+|---|---|---|---|---|---|
+| Claude Code | `claude` | `claude` | - | `supported` | Default rule: branded product and executable already match. |
+| GitHub Copilot CLI | `copilot` | `copilot` | - | `supported` | Quantex identifier follows the executable command. |
+| Cursor CLI | `cursor` | `agent` | `agent` | `supported` | Exception rule: `agent` is too generic to use as the primary Quantex slug. |
+| Crush | `crush` | `crush` | - | `in-progress` | Track through the active OpenSpec change while implementation is unfinished. |
+| Warp | `warp` | `warp` | - | `excluded` | Terminal product rather than a Quantex-style lifecycle agent CLI. |
+
+## Maintenance Notes
+
+- Prefer updating this page together with any catalog naming or support-status decisions.
+- Do not copy long installer details here; keep the matrix focused on identity and support state.
+- If support-matrix maintenance becomes noisy, follow up with automation that derives supported rows from `src/agents/definitions/*.ts`.

--- a/openspec/changes/agent-support-matrix-fields/.openspec.yaml
+++ b/openspec/changes/agent-support-matrix-fields/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/agent-support-matrix-fields/design.md
+++ b/openspec/changes/agent-support-matrix-fields/design.md
@@ -1,0 +1,42 @@
+## Context
+
+Quantex already models three related identifiers in practice:
+
+- a canonical catalog key (`name`)
+- a user-facing product name (`displayName`)
+- an executable command (`binaryName`)
+
+The current repository does not document how those fields should be presented in a reviewable support matrix, or when `name` should follow `binaryName` versus stay brand-specific.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define a stable support-matrix schema for documentation and review.
+- Reduce manual interpretation when evaluating whether a new tool should use its executable name as the canonical slug.
+- Keep the decision lightweight and documentation-first for this round.
+
+**Non-Goals:**
+
+- No runtime code changes.
+- No renaming of existing agent definitions in this change.
+- No addition of new supported agents in this change.
+
+## Decisions
+
+- **Canonical slug remains the primary Quantex identifier**: the support matrix will treat the Quantex canonical slug as the key used by lookup, docs, and future catalog work.
+- **Binary command is a first-class separate field**: the matrix will always display the upstream executable command separately from the canonical slug.
+- **Default naming rule follows the executable**: when an upstream command is stable, product-specific, and suitable for user-facing identification, the canonical slug should match the executable command.
+- **Generic executable exception stays branded**: when the executable name is generic, ambiguous, or likely to collide with broader terminology, Quantex should keep a branded canonical slug and expose the executable through the binary-command field and aliases.
+- **Documentation page, not README table**: the full matrix belongs in `docs/agent-support-matrix.md`; the README should remain lightweight.
+
+## Risks / Trade-offs
+
+- [Temporary mismatch] Existing entries may not yet satisfy the new default rule. → Mitigation: this change documents the rule first and leaves implementation follow-up to later catalog changes.
+- [Documentation drift] A hand-maintained matrix can drift from the catalog. → Mitigation: make the matrix explicitly reference canonical fields from `src/agents/definitions/*.ts` and keep `supported` status tied to implemented definitions.
+
+## Migration Plan
+
+- Add the OpenSpec delta for the naming rule and support-matrix fields.
+- Add the docs page and docs index link without changing runtime surfaces.
+- Leave any catalog renames or generator work for follow-up implementation changes.

--- a/openspec/changes/agent-support-matrix-fields/proposal.md
+++ b/openspec/changes/agent-support-matrix-fields/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Users and maintainers need a single support-matrix view that distinguishes Quantex's canonical agent slug from the upstream CLI command name. Without an explicit rule, entries such as Cursor (`cursor` vs `agent`) require repeated manual interpretation and make catalog reviews drift-prone.
+
+## What Changes
+
+- Define support-matrix field rules for product name, canonical slug, binary command, aliases, and support status.
+- Document the default naming rule: prefer the upstream CLI command as the canonical slug when it is stable and product-specific.
+- Document the exception rule: keep a branded canonical slug when the executable name is too generic or ambiguous, and record the executable separately as the binary command.
+- Add a repository docs page for the agent support matrix so supported, in-progress, candidate, and excluded tools can be reviewed without changing runtime code.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-catalog`: clarify canonical slug versus binary command semantics and define the support-matrix documentation fields used to review catalog entries
+
+## Impact
+
+- `openspec/specs/agent-catalog/spec.md`
+- `docs/agent-support-matrix.md`
+- `docs/README.md`

--- a/openspec/changes/agent-support-matrix-fields/specs/agent-catalog/spec.md
+++ b/openspec/changes/agent-support-matrix-fields/specs/agent-catalog/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Supported agent catalog entries MUST expose canonical slug and executable command semantics
+
+Quantex SHALL treat the canonical agent slug and the executable command as related but distinct catalog fields. The canonical slug is the stable Quantex identifier for lookup, docs, and catalog review, while the executable command identifies the actual CLI binary Quantex resolves and runs.
+
+#### Scenario: A supported agent uses a product-specific executable
+
+- **WHEN** an upstream CLI executable name is stable, product-specific, and suitable as a user-facing identifier
+- **THEN** Quantex uses that executable name as the canonical slug by default
+- **AND** the catalog continues to expose the same value as the executable command
+
+#### Scenario: A supported agent uses a generic or ambiguous executable
+
+- **WHEN** an upstream CLI executable name is too generic or ambiguous to serve as the primary Quantex identifier
+- **THEN** Quantex keeps a branded canonical slug
+- **AND** the catalog exposes the executable command separately
+- **AND** Quantex may accept the executable command as a lookup alias when doing so improves discovery without weakening the canonical slug
+
+### Requirement: Support-matrix documentation MUST use stable catalog review fields
+
+Quantex SHALL document agent support reviews with a stable support-matrix field set that separates product naming, canonical identification, executable command naming, and support status.
+
+#### Scenario: Recording a support-matrix row
+
+- **WHEN** Quantex documents a supported, in-progress, candidate, or excluded tool in the support matrix
+- **THEN** the row includes the product name, canonical slug, binary command, aliases, status, and notes
+- **AND** supported rows derive their canonical slug and binary command from the implemented agent definition
+- **AND** in-progress rows reference the active OpenSpec change or implementation tracker when available
+
+#### Scenario: Reviewing an exception to the default naming rule
+
+- **WHEN** the canonical slug does not match the executable command
+- **THEN** the support matrix notes that exception explicitly
+- **AND** the rationale explains why the executable command is not suitable as the primary Quantex slug

--- a/openspec/changes/agent-support-matrix-fields/tasks.md
+++ b/openspec/changes/agent-support-matrix-fields/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract
+
+- [x] 1.1 Document canonical slug, binary command, aliases, and status rules in the OpenSpec agent-catalog delta.
+- [x] 1.2 Record the default-vs-exception naming rule for when the canonical slug should follow the executable.
+
+## 2. Documentation
+
+- [x] 2.1 Add a docs page that defines the support-matrix fields and status meanings.
+- [x] 2.2 Link the support-matrix page from the docs index.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run openspec:validate`.
+- [x] 3.5 Run `bun run memory:check`.


### PR DESCRIPTION
## Summary

Define a stable agent-support matrix format for Quantex catalog reviews.
Document how canonical slugs, binary commands, aliases, and support status should be represented without changing runtime behavior.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/agent-support-matrix-fields/`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Behavior did not change, so `bun run test` was not required for this docs and contract-only update.

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This PR establishes the review/documentation contract only. Any future agent-catalog renames or generator automation should follow in separate implementation changes.
