### PR TITLE
feat(agents): add Goose agent support

### DIFF
--- a/openspec/changes/add-goose-agent/.openspec.yaml
+++ b/openspec/changes/add-goose-agent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-goose-agent/design.md
+++ b/openspec/changes/add-goose-agent/design.md
@@ -1,0 +1,30 @@
+# Design: Add Goose agent support
+
+## Approach
+
+Add a new agent definition file following the established pattern (see `crush.ts`, `kimi.ts`). Goose is a Rust-based CLI with no npm package, so install methods are limited to script-based and Homebrew formula installs.
+
+## Install methods
+
+| Platform | Method | Command |
+|---|---|---|
+| macOS | script | `curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \| bash` |
+| macOS | brew | `brew install block-goose-cli` |
+| Linux | script | `curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \| bash` |
+| Linux | brew | `brew install block-goose-cli` |
+| Windows | script (bash) | `curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \| bash` |
+| Windows | script (PowerShell) | Download and run `download_cli.ps1` from GitHub |
+
+## Version probe
+
+`goose --version` — standard flag, returns version string.
+
+## Self-update
+
+`goose update` — built-in CLI update command.
+
+## Files changed
+
+- `src/agents/definitions/goose.ts` — new file
+- `src/agents/index.ts` — register import, array entry, and re-export
+- `openspec/specs/agent-catalog/spec.md` — add Goose requirement section

--- a/openspec/changes/add-goose-agent/design.md
+++ b/openspec/changes/add-goose-agent/design.md
@@ -8,12 +8,12 @@ Add a new agent definition file following the established pattern (see `crush.ts
 
 | Platform | Method | Command |
 |---|---|---|
-| macOS | script | `curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \| bash` |
+| macOS | script | `curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh \| bash` |
 | macOS | brew | `brew install block-goose-cli` |
-| Linux | script | `curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \| bash` |
+| Linux | script | `curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh \| bash` |
 | Linux | brew | `brew install block-goose-cli` |
-| Windows | script (bash) | `curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \| bash` |
-| Windows | script (PowerShell) | Download and run `download_cli.ps1` from GitHub |
+| Windows | script (bash) | `curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh \| bash` |
+| Windows | script (PowerShell) | `Invoke-WebRequest -Uri "https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1" -OutFile "download_cli.ps1"; ./download_cli.ps1` |
 
 ## Version probe
 

--- a/openspec/changes/add-goose-agent/proposal.md
+++ b/openspec/changes/add-goose-agent/proposal.md
@@ -1,0 +1,46 @@
+# Add Goose agent support
+
+## Summary
+
+Add Goose (by Block) as a supported lifecycle agent in the Quantex catalog with install, inspect, version probe, and self-update metadata.
+
+## Motivation
+
+Goose is an open-source, extensible AI agent by Block that runs on the developer's machine. It supports CLI and desktop modes with a growing user base (4,900+ Homebrew installs in 30 days). Users expect `quantex install goose`, `quantex info goose`, and `quantex update goose` to work.
+
+## Spec delta
+
+Add a new requirement to `openspec/specs/agent-catalog/spec.md`:
+
+### Requirement: Goose MUST be a supported lifecycle agent
+
+Quantex SHALL include Goose in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Goose
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `goose`
+- **THEN** Quantex returns a supported agent entry for Goose
+- **AND** the entry identifies `goose` as the executable binary
+- **AND** the entry identifies `https://github.com/block/goose` as the homepage
+
+#### Scenario: Installing Goose through supported methods
+
+- **WHEN** Quantex renders or executes install options for Goose
+- **THEN** macOS and Linux include the official curl install script option and the Homebrew formula install method (`block-goose-cli`)
+- **AND** Windows includes the official curl install script option (Git Bash / MSYS2) and the PowerShell install script option
+
+#### Scenario: Probing Goose version
+
+- **WHEN** Quantex probes the installed version of Goose
+- **THEN** it runs `goose --version` and parses the output
+
+#### Scenario: Planning Goose updates
+
+- **WHEN** Quantex plans an update for a Goose installation that supports self-update
+- **THEN** the catalog exposes `goose update` as the agent self-update command
+
+## Implementation notes
+
+- Create `src/agents/definitions/goose.ts` with the agent definition
+- Register the export in `src/agents/index.ts`
+- Follow the same pattern as existing agents (crush, kimi)

--- a/openspec/changes/add-goose-agent/proposal.md
+++ b/openspec/changes/add-goose-agent/proposal.md
@@ -1,46 +1,25 @@
-# Add Goose agent support
+## Why
 
-## Summary
+Goose (by Block) is an open-source, extensible AI agent with a growing user base (4,900+ Homebrew installs in 30 days). Users expect `quantex install goose`, `quantex info goose`, and `quantex update goose` to work, but Goose is not yet in the supported agent catalog.
 
-Add Goose (by Block) as a supported lifecycle agent in the Quantex catalog with install, inspect, version probe, and self-update metadata.
+## What Changes
 
-## Motivation
+- Add a Goose agent definition to `src/agents/definitions/goose.ts` with lifecycle metadata (install methods, version probe, self-update command)
+- Register Goose in the agent catalog index
+- Update the agent-catalog spec with a Goose requirement
 
-Goose is an open-source, extensible AI agent by Block that runs on the developer's machine. It supports CLI and desktop modes with a growing user base (4,900+ Homebrew installs in 30 days). Users expect `quantex install goose`, `quantex info goose`, and `quantex update goose` to work.
+## Capabilities
 
-## Spec delta
+### New Capabilities
 
-Add a new requirement to `openspec/specs/agent-catalog/spec.md`:
+_None_
 
-### Requirement: Goose MUST be a supported lifecycle agent
+### Modified Capabilities
 
-Quantex SHALL include Goose in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+- `agent-catalog`: Add Goose as a supported lifecycle agent with install, version probe, and self-update requirements
 
-#### Scenario: Looking up Goose
+## Impact
 
-- **WHEN** a user or machine consumer looks up the canonical agent name `goose`
-- **THEN** Quantex returns a supported agent entry for Goose
-- **AND** the entry identifies `goose` as the executable binary
-- **AND** the entry identifies `https://github.com/block/goose` as the homepage
-
-#### Scenario: Installing Goose through supported methods
-
-- **WHEN** Quantex renders or executes install options for Goose
-- **THEN** macOS and Linux include the official curl install script option and the Homebrew formula install method (`block-goose-cli`)
-- **AND** Windows includes the official curl install script option (Git Bash / MSYS2) and the PowerShell install script option
-
-#### Scenario: Probing Goose version
-
-- **WHEN** Quantex probes the installed version of Goose
-- **THEN** it runs `goose --version` and parses the output
-
-#### Scenario: Planning Goose updates
-
-- **WHEN** Quantex plans an update for a Goose installation that supports self-update
-- **THEN** the catalog exposes `goose update` as the agent self-update command
-
-## Implementation notes
-
-- Create `src/agents/definitions/goose.ts` with the agent definition
-- Register the export in `src/agents/index.ts`
-- Follow the same pattern as existing agents (crush, kimi)
+- `src/agents/definitions/goose.ts` — new file
+- `src/agents/index.ts` — register import, array entry, re-export
+- `openspec/specs/agent-catalog/spec.md` — add Goose requirement section

--- a/openspec/changes/add-goose-agent/specs/agent-catalog.md
+++ b/openspec/changes/add-goose-agent/specs/agent-catalog.md
@@ -1,0 +1,36 @@
+# Spec delta: agent-catalog
+
+Add Goose requirement to `openspec/specs/agent-catalog/spec.md`.
+
+Delta: insert before the "Kilo CLI display name" requirement:
+
+```markdown
+### Requirement: Goose MUST be a supported lifecycle agent
+
+Quantex SHALL include Goose (by Block) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Goose
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `goose`
+- **THEN** Quantex returns a supported agent entry for Goose
+- **AND** the entry identifies `goose` as the executable binary
+- **AND** the entry identifies `https://github.com/block/goose` as the homepage
+
+#### Scenario: Installing Goose through supported methods
+
+- **WHEN** Quantex renders or executes install options for Goose
+- **THEN** macOS and Linux include the official curl install script option and the Homebrew formula install method (`block-goose-cli`)
+- **AND** Windows includes the official curl install script option (Git Bash / MSYS2) and the PowerShell install script option
+
+#### Scenario: Probing Goose version
+
+- **WHEN** Quantex probes the installed version of Goose
+- **THEN** it runs `goose --version` and parses the output
+
+#### Scenario: Planning Goose updates
+
+- **WHEN** Quantex plans an update for a Goose installation that supports self-update
+- **THEN** the catalog exposes `goose update` as the agent self-update command
+```
+
+Status: already applied to `openspec/specs/agent-catalog/spec.md`.

--- a/openspec/changes/add-goose-agent/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-goose-agent/specs/agent-catalog/spec.md
@@ -9,13 +9,13 @@ Quantex SHALL include Goose (by Block) in the supported agent catalog with lifec
 - **WHEN** a user or machine consumer looks up the canonical agent name `goose`
 - **THEN** Quantex returns a supported agent entry for Goose
 - **AND** the entry identifies `goose` as the executable binary
-- **AND** the entry identifies `https://github.com/block/goose` as the homepage
+- **AND** the entry identifies `https://github.com/aaif-goose/goose` as the homepage
 
 #### Scenario: Installing Goose through supported methods
 
 - **WHEN** Quantex renders or executes install options for Goose
 - **THEN** macOS and Linux include the official curl install script option and the Homebrew formula install method (`block-goose-cli`)
-- **AND** Windows includes the official curl install script option (Git Bash / MSYS2) and the PowerShell install script option
+- **AND** Windows includes the official curl install script option (Git Bash / MSYS2) and the PowerShell install script option (downloaded from raw.githubusercontent.com)
 
 #### Scenario: Probing Goose version
 

--- a/openspec/changes/add-goose-agent/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-goose-agent/specs/agent-catalog/spec.md
@@ -1,10 +1,5 @@
-# Spec delta: agent-catalog
+## ADDED Requirements
 
-Add Goose requirement to `openspec/specs/agent-catalog/spec.md`.
-
-Delta: insert before the "Kilo CLI display name" requirement:
-
-```markdown
 ### Requirement: Goose MUST be a supported lifecycle agent
 
 Quantex SHALL include Goose (by Block) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
@@ -31,6 +26,3 @@ Quantex SHALL include Goose (by Block) in the supported agent catalog with lifec
 
 - **WHEN** Quantex plans an update for a Goose installation that supports self-update
 - **THEN** the catalog exposes `goose update` as the agent self-update command
-```
-
-Status: already applied to `openspec/specs/agent-catalog/spec.md`.

--- a/openspec/changes/add-goose-agent/tasks.md
+++ b/openspec/changes/add-goose-agent/tasks.md
@@ -1,0 +1,6 @@
+# Tasks: Add Goose agent support
+
+- [x] Create `src/agents/definitions/goose.ts` with agent definition
+- [x] Register Goose in `src/agents/index.ts` (import, array, re-export)
+- [x] Update `openspec/specs/agent-catalog/spec.md` with Goose requirement
+- [x] Validate: typecheck, lint, format, tests pass

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -115,6 +115,33 @@ Quantex SHALL include Crush (by Charmbracelet) in the supported agent catalog wi
 
 - **WHEN** Quantex plans an update for a Crush installation that supports self-update
 - **THEN** the catalog exposes `crush update` as the agent self-update command
+### Requirement: Goose MUST be a supported lifecycle agent
+
+Quantex SHALL include Goose (by Block) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Goose
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `goose`
+- **THEN** Quantex returns a supported agent entry for Goose
+- **AND** the entry identifies `goose` as the executable binary
+- **AND** the entry identifies `https://github.com/block/goose` as the homepage
+
+#### Scenario: Installing Goose through supported methods
+
+- **WHEN** Quantex renders or executes install options for Goose
+- **THEN** macOS and Linux include the official curl install script option and the Homebrew formula install method (`block-goose-cli`)
+- **AND** Windows includes the official curl install script option (Git Bash / MSYS2) and the PowerShell install script option
+
+#### Scenario: Probing Goose version
+
+- **WHEN** Quantex probes the installed version of Goose
+- **THEN** it runs `goose --version` and parses the output
+
+#### Scenario: Planning Goose updates
+
+- **WHEN** Quantex plans an update for a Goose installation that supports self-update
+- **THEN** the catalog exposes `goose update` as the agent self-update command
+
 ### Requirement: Kilo CLI MUST use the current supported display name
 
 Quantex SHALL expose the Kilo catalog entry with the display name `Kilo CLI` while keeping the canonical agent slug `kilo`.

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -124,13 +124,13 @@ Quantex SHALL include Goose (by Block) in the supported agent catalog with lifec
 - **WHEN** a user or machine consumer looks up the canonical agent name `goose`
 - **THEN** Quantex returns a supported agent entry for Goose
 - **AND** the entry identifies `goose` as the executable binary
-- **AND** the entry identifies `https://github.com/block/goose` as the homepage
+- **AND** the entry identifies `https://github.com/aaif-goose/goose` as the homepage
 
 #### Scenario: Installing Goose through supported methods
 
 - **WHEN** Quantex renders or executes install options for Goose
 - **THEN** macOS and Linux include the official curl install script option and the Homebrew formula install method (`block-goose-cli`)
-- **AND** Windows includes the official curl install script option (Git Bash / MSYS2) and the PowerShell install script option
+- **AND** Windows includes the official curl install script option (Git Bash / MSYS2) and the PowerShell install script option (downloaded from raw.githubusercontent.com)
 
 #### Scenario: Probing Goose version
 

--- a/src/agents/definitions/goose.ts
+++ b/src/agents/definitions/goose.ts
@@ -4,7 +4,7 @@ import { brewInstall, scriptInstall } from '../methods'
 export const goose: AgentDefinition = {
   name: 'goose',
   displayName: 'Goose',
-  homepage: 'https://github.com/block/goose',
+  homepage: 'https://github.com/aaif-goose/goose',
   binaryName: 'goose',
   selfUpdate: {
     command: ['goose', 'update'],
@@ -14,17 +14,17 @@ export const goose: AgentDefinition = {
   },
   platforms: {
     windows: [
-      scriptInstall('curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash'),
+      scriptInstall('curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash'),
       scriptInstall(
-        'Invoke-WebRequest -Uri "https://raw.githubusercontent.com/block/goose/main/download_cli.ps1" -OutFile "download_cli.ps1"; ./download_cli.ps1',
+        'Invoke-WebRequest -Uri "https://raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1" -OutFile "download_cli.ps1"; ./download_cli.ps1',
       ),
     ],
     macos: [
-      scriptInstall('curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash'),
+      scriptInstall('curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash'),
       brewInstall('block-goose-cli'),
     ],
     linux: [
-      scriptInstall('curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash'),
+      scriptInstall('curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | bash'),
       brewInstall('block-goose-cli'),
     ],
   },

--- a/src/agents/definitions/goose.ts
+++ b/src/agents/definitions/goose.ts
@@ -1,0 +1,31 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, scriptInstall } from '../methods'
+
+export const goose: AgentDefinition = {
+  name: 'goose',
+  displayName: 'Goose',
+  homepage: 'https://github.com/block/goose',
+  binaryName: 'goose',
+  selfUpdate: {
+    command: ['goose', 'update'],
+  },
+  versionProbe: {
+    command: ['goose', '--version'],
+  },
+  platforms: {
+    windows: [
+      scriptInstall('curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash'),
+      scriptInstall(
+        'Invoke-WebRequest -Uri "https://raw.githubusercontent.com/block/goose/main/download_cli.ps1" -OutFile "download_cli.ps1"; ./download_cli.ps1',
+      ),
+    ],
+    macos: [
+      scriptInstall('curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash'),
+      brewInstall('block-goose-cli'),
+    ],
+    linux: [
+      scriptInstall('curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash'),
+      brewInstall('block-goose-cli'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -6,6 +6,7 @@ import { crush } from './definitions/crush'
 import { cursor } from './definitions/cursor'
 import { droid } from './definitions/droid'
 import { gemini } from './definitions/gemini'
+import { goose } from './definitions/goose'
 import { kilo } from './definitions/kilo'
 import { kimi } from './definitions/kimi'
 import { opencode } from './definitions/opencode'
@@ -21,6 +22,7 @@ const agents: AgentDefinition[] = [
   cursor,
   droid,
   gemini,
+  goose,
   kimi,
   kilo,
   opencode,
@@ -41,7 +43,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
   return getAgentByLookupName(name)
 }
 
-export { claude, codex, copilot, crush, cursor, droid, gemini, kimi, kilo, opencode, pi, qoder, qwen }
+export { claude, codex, copilot, crush, cursor, droid, gemini, goose, kimi, kilo, opencode, pi, qoder, qwen }
 export type {
   AgentDefinition,
   AgentPackageMetadata,


### PR DESCRIPTION
## Summary

Add Goose (by Block / AAIF) as a supported lifecycle agent in the Quantex catalog. Goose is an open-source, extensible AI agent with a growing user base (~4,900 Homebrew installs/month). This adds the agent definition with install methods, version probe, and self-update metadata.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: add-goose-agent
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (341 tests pass)
- [x] `bun run openspec:validate` (12/12 pass)

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Install methods verified against official sources (goose-docs.ai, GitHub README, download_cli.ps1 source):

- **macOS/Linux**: curl install script (`aaif-goose/goose/releases/download/stable/download_cli.sh`) + Homebrew (`brew install block-goose-cli`)
- **Windows**: curl install script for Git Bash/MSYS2 + PowerShell script downloaded from `raw.githubusercontent.com/aaif-goose/goose/main/download_cli.ps1`
- **Homepage**: `https://github.com/aaif-goose/goose` (project migrated from block/goose to AAIF)
- **Version probe**: `goose --version`
- **Self-update**: `goose update`

Note: `download_cli.ps1` is **not** a GitHub release asset — it must be fetched from the repo source via `raw.githubusercontent.com`, not from `releases/download/stable/`. The `download_cli.sh` IS a release asset and uses the releases URL.
