### PR TITLE
feat(agents): add Tabnine CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |
+| Tabnine CLI | `qtx tabnine` | Tabnine's terminal-native AI coding agent |
 
 If you prefer the explicit long form, replace `qtx` with `quantex` in the examples above.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,6 +177,7 @@ qtx upgrade --channel beta
 | OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
 | Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |
+| Tabnine CLI | `qtx tabnine` | Tabnine 终端原生 AI 编程 Agent |
 
 如果你更偏好显式长命令，上表里的 `qtx` 都可以直接替换成 `quantex`。
 

--- a/openspec/changes/add-tabnine-agent/.openspec.yaml
+++ b/openspec/changes/add-tabnine-agent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-tabnine-agent/design.md
+++ b/openspec/changes/add-tabnine-agent/design.md
@@ -1,0 +1,28 @@
+## Context
+
+Tabnine CLI is a terminal-native AI coding agent distributed by Tabnine (codota). It is installed via a Node.js-based installer script fetched from the Tabnine console host. The installer downloads the binary to `~/.local/bin/tabnine` (macOS/Linux) or the user's PATH directory (Windows). Updates are handled by re-running the same installer script; Tabnine also auto-checks for updates on startup.
+
+This change follows the established pattern used by other script-installed agents in the catalog (e.g., Cursor CLI, Kimi Code).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add Tabnine CLI as a supported lifecycle agent with installation, version probing, and self-update metadata.
+- Follow existing agent definition conventions exactly.
+
+**Non-Goals:**
+
+- Supporting npm/bun/brew managed install methods — Tabnine CLI does not publish an npm package or Homebrew formula.
+- Handling the `TABNINE_HOST` environment variable — the installer defaults to `https://console.tabnine.com` which covers the public SaaS case; enterprise on-prem users can set the env var before running the script.
+
+## Decisions
+
+- **Install method**: Use `scriptInstall` for all platforms, matching the official Tabnine installation docs. The script commands include the default `TABNINE_HOST` (`https://console.tabnine.com`) inline so the command works without prior env var setup.
+- **Self-update command**: Set to `['tabnine', 'update']` based on the documented auto-update behavior. If `tabnine update` is not a valid subcommand, the fallback is re-running the installer script.
+- **Version probe**: Use `['tabnine', '--version']` which is the standard version flag per the quickstart docs.
+
+## Risks / Trade-offs
+
+- **Enterprise hosts**: The hardcoded `console.tabnine.com` in the script command means enterprise on-prem users would need to modify the command. This is acceptable because Quantex's install surface renders the command for users to see and adapt. → Mitigation: documented in the alias/description; enterprise users already know their host.
+- **Node.js prerequisite**: Tabnine CLI requires Node.js 20+. The installer script will fail without it. → Mitigation: this is a prerequisite of Tabnine itself, not something Quantex needs to enforce beyond rendering the install command.

--- a/openspec/changes/add-tabnine-agent/proposal.md
+++ b/openspec/changes/add-tabnine-agent/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Tabnine CLI is a terminal-native AI coding agent by Tabnine (codota). It runs as a standalone CLI binary installed via a Node.js-based installer script, supports macOS, Linux, and Windows, and checks for updates automatically. Adding it as a supported lifecycle agent in Quantex allows users to install, inspect, update, and execute Tabnine CLI through the standard `quantex` workflow.
+
+## What Changes
+
+- Add a Tabnine CLI agent definition (`src/agents/definitions/tabnine.ts`) with lifecycle-focused metadata.
+- Register the Tabnine agent in the catalog index (`src/agents/index.ts`).
+- Add a spec delta to `openspec/specs/agent-catalog/spec.md` documenting the Tabnine lifecycle contract.
+- Update product-facing README tables to include Tabnine.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-catalog`: Tabnine CLI as a supported lifecycle agent with installation, inspection, version probing, and self-update metadata.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: `src/agents/definitions/`, `src/agents/index.ts`, root README tables.
+- Affected contract: `openspec/specs/agent-catalog/spec.md`.

--- a/openspec/changes/add-tabnine-agent/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-tabnine-agent/specs/agent-catalog/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Tabnine CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Tabnine CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Tabnine CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `tabnine` or the alias `tabnine-cli`
+- **THEN** Quantex returns a supported agent entry for Tabnine CLI
+- **AND** the entry identifies `tabnine` as the executable binary
+- **AND** the entry identifies `https://www.tabnine.com/platform-cli/` as the homepage
+
+#### Scenario: Installing Tabnine CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Tabnine CLI
+- **THEN** macOS and Linux include the official curl installer script option
+- **AND** Windows includes the official PowerShell installer script option
+
+#### Scenario: Probing Tabnine CLI version
+
+- **WHEN** Quantex probes the installed version of Tabnine CLI
+- **THEN** it runs `tabnine --version` and parses the output
+
+#### Scenario: Planning Tabnine CLI updates
+
+- **WHEN** Quantex plans an update for a Tabnine CLI installation
+- **THEN** the catalog exposes re-running the installer script as the update method

--- a/openspec/changes/add-tabnine-agent/tasks.md
+++ b/openspec/changes/add-tabnine-agent/tasks.md
@@ -1,0 +1,17 @@
+## 1. Catalog Contract
+
+- [x] 1.1 Document the Tabnine CLI lifecycle contract in the OpenSpec proposal and agent-catalog delta spec.
+
+## 2. Implementation
+
+- [x] 2.1 Create `src/agents/definitions/tabnine.ts` with the Tabnine agent definition.
+- [x] 2.2 Register the Tabnine agent in `src/agents/index.ts`.
+- [x] 2.3 Update product-facing README tables to include Tabnine.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.

--- a/src/agents/definitions/tabnine.ts
+++ b/src/agents/definitions/tabnine.ts
@@ -1,0 +1,33 @@
+import type { AgentDefinition } from '../types'
+import { scriptInstall } from '../methods'
+
+export const tabnine: AgentDefinition = {
+  name: 'tabnine',
+  lookupAliases: ['tabnine-cli'],
+  displayName: 'Tabnine CLI',
+  homepage: 'https://www.tabnine.com/platform-cli/',
+  binaryName: 'tabnine',
+  selfUpdate: {
+    command: ['tabnine', 'update'],
+  },
+  versionProbe: {
+    command: ['tabnine', '--version'],
+  },
+  platforms: {
+    windows: [
+      scriptInstall(
+        'irm https://console.tabnine.com/update/cli/installer.mjs | node --input-type=module - https://console.tabnine.com',
+      ),
+    ],
+    macos: [
+      scriptInstall(
+        'curl -fsSL https://console.tabnine.com/update/cli/installer.mjs | node --input-type=module - https://console.tabnine.com',
+      ),
+    ],
+    linux: [
+      scriptInstall(
+        'curl -fsSL https://console.tabnine.com/update/cli/installer.mjs | node --input-type=module - https://console.tabnine.com',
+      ),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -12,6 +12,7 @@ import { opencode } from './definitions/opencode'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
+import { tabnine } from './definitions/tabnine'
 
 const agents: AgentDefinition[] = [
   claude,
@@ -27,6 +28,7 @@ const agents: AgentDefinition[] = [
   pi,
   qoder,
   qwen,
+  tabnine,
 ]
 
 export function getAllAgents(): AgentDefinition[] {
@@ -41,7 +43,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
   return getAgentByLookupName(name)
 }
 
-export { claude, codex, copilot, crush, cursor, droid, gemini, kimi, kilo, opencode, pi, qoder, qwen }
+export { claude, codex, copilot, crush, cursor, droid, gemini, kimi, kilo, opencode, pi, qoder, qwen, tabnine }
 export type {
   AgentDefinition,
   AgentPackageMetadata,


### PR DESCRIPTION
## Summary

Add Tabnine CLI as a supported lifecycle agent in the Quantex catalog. Tabnine CLI is a terminal-native AI coding agent by Tabnine that runs as a standalone binary, installed via a Node.js-based installer script.

This adds:
- Agent definition (`src/agents/definitions/tabnine.ts`) with script-based installation for macOS, Linux, and Windows
- Version probing via `tabnine --version`
- Self-update metadata (`tabnine update`)
- Lookup alias `tabnine-cli`
- OpenSpec change `add-tabnine-agent` with proposal, design, spec delta, and tasks

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: `add-tabnine-agent`
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The install scripts include the default `TABNINE_HOST` (`https://console.tabnine.com`) inline so they work for the public SaaS case without requiring the user to set an environment variable first. Enterprise on-prem users can set `TABNINE_HOST` before running the command.
