### PR TITLE
feat(agents): add ForgeCode agent support

### DIFF
--- a/openspec/changes/add-forgecode-agent/.openspec.yaml
+++ b/openspec/changes/add-forgecode-agent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-forgecode-agent/design.md
+++ b/openspec/changes/add-forgecode-agent/design.md
@@ -1,0 +1,17 @@
+# Design: add-forgecode-agent
+
+## Approach
+
+Add ForgeCode as a new agent definition following the established pattern used by other agents (Crush, Kimi, Qwen, etc.).
+
+## Key decisions
+
+1. **Canonical name `forgecode`**: The npm package is `forgecode` and the product is called ForgeCode. Using `forgecode` as canonical name avoids collision with the generic `forge` binary name and matches user expectations (`quantex install forgecode`).
+
+2. **Alias `forge`**: The installed binary is `forge`, so adding it as a lookup alias lets users run `quantex forge` or look it up by binary name.
+
+3. **Install methods**: ForgeCode supports npm (`forgecode` package) and an official curl/PowerShell install script. No Homebrew or winget methods are documented yet. The script installs are placed last as fallback options.
+
+4. **Self-update**: `forge update` is the documented self-update command.
+
+5. **No Windows winget**: No winget package is documented for ForgeCode yet.

--- a/openspec/changes/add-forgecode-agent/proposal.md
+++ b/openspec/changes/add-forgecode-agent/proposal.md
@@ -1,0 +1,38 @@
+# Proposal: add-forgecode-agent
+
+## Summary
+
+Add ForgeCode (by Antinomy) as a supported agent in the Quantex agent catalog.
+
+## Motivation
+
+ForgeCode is an AI-powered coding agent CLI (binary: `forge`) that supports 300+ models and runs on macOS, Linux, and Windows. It has a growing user base and is installable via npm (`forgecode`) and an official curl script. Adding it to the catalog lets Quantex users install, inspect, update, and run ForgeCode through the standard lifecycle commands.
+
+## Proposed changes
+
+1. **New agent definition**: `src/agents/definitions/forgecode.ts`
+   - Canonical name: `forgecode`
+   - Lookup aliases: `forge`
+   - Display name: `ForgeCode`
+   - Binary: `forge`
+   - Homepage: `https://forgecode.dev`
+   - npm package: `forgecode`
+   - Self-update command: `forge update`
+   - Version probe: `forge --version`
+   - Platforms:
+     - macOS: `bunInstall()`, `npmInstall()`, `scriptInstall('curl -fsSL https://forgecode.dev/cli | sh')`
+     - Linux: `bunInstall()`, `npmInstall()`, `scriptInstall('curl -fsSL https://forgecode.dev/cli | sh')`
+     - Windows: `bunInstall()`, `npmInstall()`, `scriptInstall('irm https://forgecode.dev/cli | iex')`
+
+2. **Register in index**: `src/agents/index.ts` — import and add `forgecode` to the agents array and re-export line.
+
+3. **Spec update**: `openspec/specs/agent-catalog/spec.md` — add a `ForgeCode MUST be a supported lifecycle agent` requirement with lookup, install, version probe, and update planning scenarios.
+
+## Affected specs
+
+- `openspec/specs/agent-catalog/spec.md`
+
+## Risks
+
+- The `forge` binary name is generic and could conflict with other tools. Using `forgecode` as canonical name mitigates this.
+- No Homebrew or winget install methods documented yet; only npm and script installs are available.

--- a/openspec/changes/add-forgecode-agent/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-forgecode-agent/specs/agent-catalog/spec.md
@@ -1,0 +1,32 @@
+# Agent Catalog — ForgeCode delta
+
+## ADDED Requirements
+
+### Requirement: ForgeCode MUST be a supported lifecycle agent
+
+Quantex SHALL include ForgeCode (by Antinomy) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up ForgeCode
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `forgecode` or the alias `forge`
+- **THEN** Quantex returns a supported agent entry for ForgeCode
+- **AND** the entry identifies `forge` as the executable binary
+- **AND** the entry identifies `forgecode` as its npm package metadata
+- **AND** the entry identifies `https://forgecode.dev` as the homepage
+
+#### Scenario: Installing ForgeCode through supported methods
+
+- **WHEN** Quantex renders or executes install options for ForgeCode
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official curl install script option
+- **AND** Windows includes the official PowerShell install script option
+
+#### Scenario: Probing ForgeCode version
+
+- **WHEN** Quantex probes the installed version of ForgeCode
+- **THEN** it runs `forge --version` and parses the output
+
+#### Scenario: Planning ForgeCode updates
+
+- **WHEN** Quantex plans an update for a ForgeCode installation that supports self-update
+- **THEN** the catalog exposes `forge update` as the agent self-update command

--- a/openspec/changes/add-forgecode-agent/tasks.md
+++ b/openspec/changes/add-forgecode-agent/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: add-forgecode-agent
+
+- [x] Create ForgeCode agent definition (`src/agents/definitions/forgecode.ts`)
+- [x] Register ForgeCode in agent index (`src/agents/index.ts`)
+- [x] Update agent-catalog spec (`openspec/specs/agent-catalog/spec.md`)
+- [x] Run validation (lint, format, typecheck, test)
+- [ ] Validate OpenSpec change completeness

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -151,3 +151,32 @@ Quantex SHALL expose the Kilo catalog entry with the display name `Kilo CLI` whi
 - **WHEN** a user or machine consumer inspects the supported `kilo` agent entry
 - **THEN** Quantex reports the display name `Kilo CLI`
 - **AND** the entry continues to identify `kilo` as the canonical agent name and executable binary
+
+### Requirement: ForgeCode MUST be a supported lifecycle agent
+
+Quantex SHALL include ForgeCode (by Antinomy) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up ForgeCode
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `forgecode` or the alias `forge`
+- **THEN** Quantex returns a supported agent entry for ForgeCode
+- **AND** the entry identifies `forge` as the executable binary
+- **AND** the entry identifies `forgecode` as its npm package metadata
+- **AND** the entry identifies `https://forgecode.dev` as the homepage
+
+#### Scenario: Installing ForgeCode through supported methods
+
+- **WHEN** Quantex renders or executes install options for ForgeCode
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official curl install script option
+- **AND** Windows includes the official PowerShell install script option
+
+#### Scenario: Probing ForgeCode version
+
+- **WHEN** Quantex probes the installed version of ForgeCode
+- **THEN** it runs `forge --version` and parses the output
+
+#### Scenario: Planning ForgeCode updates
+
+- **WHEN** Quantex plans an update for a ForgeCode installation that supports self-update
+- **THEN** the catalog exposes `forge update` as the agent self-update command

--- a/src/agents/definitions/forgecode.ts
+++ b/src/agents/definitions/forgecode.ts
@@ -1,0 +1,24 @@
+import type { AgentDefinition } from '../types'
+import { bunInstall, npmInstall, scriptInstall } from '../methods'
+
+export const forgecode: AgentDefinition = {
+  name: 'forgecode',
+  lookupAliases: ['forge'],
+  displayName: 'ForgeCode',
+  homepage: 'https://forgecode.dev',
+  packages: {
+    npm: 'forgecode',
+  },
+  binaryName: 'forge',
+  selfUpdate: {
+    command: ['forge', 'update'],
+  },
+  versionProbe: {
+    command: ['forge', '--version'],
+  },
+  platforms: {
+    windows: [bunInstall(), npmInstall(), scriptInstall('irm https://forgecode.dev/cli | iex')],
+    macos: [bunInstall(), npmInstall(), scriptInstall('curl -fsSL https://forgecode.dev/cli | sh')],
+    linux: [bunInstall(), npmInstall(), scriptInstall('curl -fsSL https://forgecode.dev/cli | sh')],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -5,6 +5,7 @@ import { copilot } from './definitions/copilot'
 import { crush } from './definitions/crush'
 import { cursor } from './definitions/cursor'
 import { droid } from './definitions/droid'
+import { forgecode } from './definitions/forgecode'
 import { gemini } from './definitions/gemini'
 import { goose } from './definitions/goose'
 import { kilo } from './definitions/kilo'
@@ -21,6 +22,7 @@ const agents: AgentDefinition[] = [
   crush,
   cursor,
   droid,
+  forgecode,
   gemini,
   goose,
   kimi,
@@ -43,7 +45,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
   return getAgentByLookupName(name)
 }
 
-export { claude, codex, copilot, crush, cursor, droid, gemini, goose, kimi, kilo, opencode, pi, qoder, qwen }
+export { claude, codex, copilot, crush, cursor, droid, forgecode, gemini, goose, kimi, kilo, opencode, pi, qoder, qwen }
 export type {
   AgentDefinition,
   AgentPackageMetadata,


### PR DESCRIPTION
## Summary

Add ForgeCode (by Antinomy) as a supported lifecycle agent in the Quantex agent catalog. ForgeCode is an AI-powered coding agent CLI (binary: `forge`) supporting 300+ models across macOS, Linux, and Windows. It is installable via npm (`forgecode`), bun, and official curl/PowerShell install scripts.

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: add-forgecode-agent
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- Canonical agent name is `forgecode` (matching the npm package name) with `forge` as a lookup alias.
- No Homebrew or winget install methods are documented for ForgeCode yet; only npm/bun and script installs are included.
