### PR TITLE
feat(agents): add Amp agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Manage AI coding assistant CLIs from one lifecycle-focused command line.
 
 </div>
 
-Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding agents. It gives Claude Code, Codex, Gemini, Kilo Code, Cursor, OpenCode, and other assistant CLIs a shared surface for installation, inspection, updates, removal, execution, and machine-readable automation. This README uses the shorter `qtx` form as the recommended entry point, while `quantex` remains the fully equivalent long command name.
+Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding agents. It gives Amp, Claude Code, Codex, Gemini, Kilo Code, Cursor, OpenCode, and other assistant CLIs a shared surface for installation, inspection, updates, removal, execution, and machine-readable automation. This README uses the shorter `qtx` form as the recommended entry point, while `quantex` remains the fully equivalent long command name.
 
 ## Why Quantex
 
@@ -167,6 +167,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 
 | Agent | Run Command | Description |
 |-------|-------------|-------------|
+| Amp | `qtx amp` | Sourcegraph's frontier AI coding agent CLI |
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,7 +16,7 @@
 
 </div>
 
-Quantex 是一个 `human-friendly + agent-friendly` 的 agent lifecycle CLI。它帮你把 Claude Code、Codex、Gemini、Kilo Code、Cursor、OpenCode 等 AI 编程助手的生命周期操作统一到一组稳定命令里：人可以直接用，自动化脚本和 coding agent 也可以用结构化输出可靠调用。本文默认使用更短的 `qtx` 作为推荐入口，`quantex` 是完全等价的完整命令名。
+Quantex 是一个 `human-friendly + agent-friendly` 的 agent lifecycle CLI。它帮你把 Amp、Claude Code、Codex、Gemini、Kilo Code、Cursor、OpenCode 等 AI 编程助手的生命周期操作统一到一组稳定命令里：人可以直接用，自动化脚本和 coding agent 也可以用结构化输出可靠调用。本文默认使用更短的 `qtx` 作为推荐入口，`quantex` 是完全等价的完整命令名。
 
 ## 为什么用 Quantex
 
@@ -167,6 +167,7 @@ qtx upgrade --channel beta
 
 | Agent | 启动命令 | 描述 |
 |-------|----------|------|
+| Amp | `qtx amp` | Sourcegraph 前沿 AI 编程 Agent CLI |
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |

--- a/openspec/changes/add-amp-agent/.openspec.yaml
+++ b/openspec/changes/add-amp-agent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-amp-agent/design.md
+++ b/openspec/changes/add-amp-agent/design.md
@@ -1,0 +1,31 @@
+## Design
+
+Add Amp as a supported agent entry following the established catalog pattern.
+
+### Agent definition
+
+- File: `src/agents/definitions/amp.ts`
+- Canonical name: `amp`
+- Display name: `Amp`
+- Homepage: `https://ampcode.com/`
+- NPM package: `@sourcegraph/amp`
+- Binary name: `amp`
+- Self-update command: `amp update`
+- Version probe command: `amp version`
+- Install methods: bun and npm on all three platforms (macOS, Linux, Windows)
+
+No Homebrew or winget install methods — Sourcegraph Amp is distributed exclusively via npm.
+
+### Registration
+
+- Import and add to the `agents` array in `src/agents/index.ts` (alphabetically first).
+- Re-export from the same file.
+
+### Spec update
+
+- Add a new requirement to `openspec/specs/agent-catalog/spec.md` covering lookup, install, version probe, and update scenarios for Amp.
+
+### README updates
+
+- Add Amp row to the Supported Agents table in `README.md` and `README.zh-CN.md`.
+- Add Amp to the intro paragraph agent list in both files.

--- a/openspec/changes/add-amp-agent/proposal.md
+++ b/openspec/changes/add-amp-agent/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Amp by Sourcegraph is a frontier coding agent CLI with a growing user base. Quantex users should be able to install, inspect, update, and launch Amp through the standard `quantex` lifecycle commands.
+
+## What Changes
+
+- Add a new supported agent entry for Amp (`amp`) to the agent catalog.
+- Register npm-compatible and bun-compatible install methods on all platforms (macOS, Linux, Windows).
+- Register `amp version` as the version probe command.
+- Register `amp update` as the self-update command.
+- Update the agent-catalog spec to include Amp lifecycle requirements.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-catalog`: Amp is a supported lifecycle agent with install, inspect, resolve, execute, update, and version-probe capabilities.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Affected code: `src/agents/definitions/amp.ts`, `src/agents/index.ts`.
+- Affected contract: `openspec/specs/agent-catalog/spec.md`.

--- a/openspec/changes/add-amp-agent/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-amp-agent/specs/agent-catalog/spec.md
@@ -1,0 +1,28 @@
+## NEW Requirements
+
+### Requirement: Amp MUST be a supported lifecycle agent
+
+Quantex SHALL include Amp (by Sourcegraph) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Amp
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `amp`
+- **THEN** Quantex returns a supported agent entry for Amp
+- **AND** the entry identifies `amp` as the executable binary
+- **AND** the entry identifies `@sourcegraph/amp` as its npm package metadata
+- **AND** the entry identifies `https://ampcode.com/` as the homepage
+
+#### Scenario: Installing Amp through supported methods
+
+- **WHEN** Quantex renders or executes install options for Amp
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+
+#### Scenario: Probing Amp version
+
+- **WHEN** Quantex probes the installed version of Amp
+- **THEN** it runs `amp version` and parses the output
+
+#### Scenario: Planning Amp updates
+
+- **WHEN** Quantex plans an update for an Amp installation that supports self-update
+- **THEN** the catalog exposes `amp update` as the agent self-update command

--- a/openspec/changes/add-amp-agent/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-amp-agent/specs/agent-catalog/spec.md
@@ -1,4 +1,4 @@
-## NEW Requirements
+## ADDED Requirements
 
 ### Requirement: Amp MUST be a supported lifecycle agent
 

--- a/openspec/changes/add-amp-agent/tasks.md
+++ b/openspec/changes/add-amp-agent/tasks.md
@@ -1,0 +1,9 @@
+## Tasks
+
+- [x] Create agent definition `src/agents/definitions/amp.ts`
+- [x] Register amp in `src/agents/index.ts` (import, array, re-export)
+- [x] Add Amp requirement to `openspec/specs/agent-catalog/spec.md`
+- [x] Update Supported Agents table in `README.md`
+- [x] Update Supported Agents table in `README.zh-CN.md`
+- [x] Validation: lint, format:check, typecheck, test, build
+- [x] CLI smoke test: `bun dist/cli.mjs inspect amp --json`

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -115,6 +115,33 @@ Quantex SHALL include Crush (by Charmbracelet) in the supported agent catalog wi
 
 - **WHEN** Quantex plans an update for a Crush installation that supports self-update
 - **THEN** the catalog exposes `crush update` as the agent self-update command
+### Requirement: Amp MUST be a supported lifecycle agent
+
+Quantex SHALL include Amp (by Sourcegraph) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Amp
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `amp`
+- **THEN** Quantex returns a supported agent entry for Amp
+- **AND** the entry identifies `amp` as the executable binary
+- **AND** the entry identifies `@sourcegraph/amp` as its npm package metadata
+- **AND** the entry identifies `https://ampcode.com/` as the homepage
+
+#### Scenario: Installing Amp through supported methods
+
+- **WHEN** Quantex renders or executes install options for Amp
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+
+#### Scenario: Probing Amp version
+
+- **WHEN** Quantex probes the installed version of Amp
+- **THEN** it runs `amp version` and parses the output
+
+#### Scenario: Planning Amp updates
+
+- **WHEN** Quantex plans an update for an Amp installation that supports self-update
+- **THEN** the catalog exposes `amp update` as the agent self-update command
+
 ### Requirement: Goose MUST be a supported lifecycle agent
 
 Quantex SHALL include Goose (by Block) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.

--- a/src/agents/definitions/amp.ts
+++ b/src/agents/definitions/amp.ts
@@ -1,0 +1,23 @@
+import type { AgentDefinition } from '../types'
+import { bunInstall, npmInstall } from '../methods'
+
+export const amp: AgentDefinition = {
+  name: 'amp',
+  displayName: 'Amp',
+  homepage: 'https://ampcode.com/',
+  packages: {
+    npm: '@sourcegraph/amp',
+  },
+  binaryName: 'amp',
+  selfUpdate: {
+    command: ['amp', 'update'],
+  },
+  versionProbe: {
+    command: ['amp', 'version'],
+  },
+  platforms: {
+    windows: [bunInstall(), npmInstall()],
+    macos: [bunInstall(), npmInstall()],
+    linux: [bunInstall(), npmInstall()],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,4 +1,5 @@
 import type { AgentDefinition } from './types'
+import { amp } from './definitions/amp'
 import { claude } from './definitions/claude'
 import { codex } from './definitions/codex'
 import { copilot } from './definitions/copilot'
@@ -17,6 +18,7 @@ import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
 
 const agents: AgentDefinition[] = [
+  amp,
   claude,
   codex,
   copilot,
@@ -48,6 +50,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
 }
 
 export {
+  amp,
   claude,
   codex,
   copilot,


### PR DESCRIPTION
## Summary

Add Sourcegraph Amp CLI as a supported lifecycle agent in the Quantex catalog. Users can now `qtx install amp`, `qtx inspect amp`, `qtx update amp`, and `qtx amp` (shortcut execution).

Amp is distributed via npm (`@sourcegraph/amp`) on all platforms, supports `amp update` for self-update, and `amp version` for version probing.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `add-amp-agent`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (341 tests pass)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Amp has no Homebrew formula or winget package — install is npm/bun only on all platforms. The existing `amp` Homebrew formula is an unrelated terminal text editor.
