### PR TITLE
feat(agents): add CodeBuddy CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 |-------|-------------|-------------|
 | Amp | `qtx amp` | Sourcegraph's frontier AI coding agent CLI |
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
+| CodeBuddy Code | `qtx codebuddy` | Tencent's official AI coding assistant CLI |
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,6 +169,7 @@ qtx upgrade --channel beta
 |-------|----------|------|
 | Amp | `qtx amp` | Sourcegraph 前沿 AI 编程 Agent CLI |
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
+| CodeBuddy Code | `qtx codebuddy` | 腾讯官方 AI 编程助手 CLI |
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |

--- a/openspec/changes/add-codebuddy-cli-support/.openspec.yaml
+++ b/openspec/changes/add-codebuddy-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-codebuddy-cli-support/design.md
+++ b/openspec/changes/add-codebuddy-cli-support/design.md
@@ -1,0 +1,43 @@
+# Design: Add CodeBuddy agent support
+
+## Approach
+
+Add a new agent definition file that follows the existing lifecycle-focused catalog pattern used by `qoder.ts`, `forgecode.ts`, and `kiro.ts`. CodeBuddy exposes a stable executable name (`codebuddy`), an npm package (`@tencent-ai/codebuddy-code`), an official Homebrew tap formula, official native install scripts, a version command, and a built-in update command, so no new catalog shape or installer abstraction is needed.
+
+Use `codebuddy` as the canonical Quantex slug because it matches the upstream executable and is product-specific. Add `codebuddy-code` as a lookup alias so users can also resolve the product/package spelling shown in upstream package-manager docs.
+
+## Install methods
+
+| Platform | Method | Command |
+|---|---|---|
+| macOS | bun | `bun add -g @tencent-ai/codebuddy-code` |
+| macOS | npm | `npm install -g @tencent-ai/codebuddy-code` |
+| macOS | script | `curl -fsSL https://www.codebuddy.cn/cli/install.sh \| bash` |
+| macOS | brew | `brew install Tencent-CodeBuddy/tap/codebuddy-code` |
+| Linux | bun | `bun add -g @tencent-ai/codebuddy-code` |
+| Linux | npm | `npm install -g @tencent-ai/codebuddy-code` |
+| Linux | script | `curl -fsSL https://www.codebuddy.cn/cli/install.sh \| bash` |
+| Linux | brew | `brew install Tencent-CodeBuddy/tap/codebuddy-code` |
+| Windows | bun | `bun add -g @tencent-ai/codebuddy-code` |
+| Windows | npm | `npm install -g @tencent-ai/codebuddy-code` |
+| Windows | script | `irm https://www.codebuddy.cn/cli/install.ps1 \| iex` |
+
+The native script channel is documented upstream as a beta install path, but it is still an official installation method and works with the documented `codebuddy update` lifecycle.
+
+## Version probe
+
+`codebuddy --version` — documented upstream as the verification command after installation.
+
+## Self-update
+
+`codebuddy update` — documented upstream as the built-in command that detects the existing install method and updates accordingly.
+
+## Files changed
+
+- `src/agents/definitions/codebuddy.ts` — new file
+- `src/agents/index.ts` — register import, array entry, and re-export
+- `src/index.ts` — re-export CodeBuddy from the package root
+- `test/agents.test.ts` — add registry, install-method, version-probe, and alias coverage
+- `test/index.test.ts` — add root-export and lookup coverage
+- `openspec/specs/agent-catalog/spec.md` — add CodeBuddy requirement section
+- `README.md`, `README.zh-CN.md` — add CodeBuddy to static supported-agent tables

--- a/openspec/changes/add-codebuddy-cli-support/proposal.md
+++ b/openspec/changes/add-codebuddy-cli-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+CodeBuddy Code is an officially documented AI coding CLI with stable install, version, and update commands, but Quantex does not yet recognize it as a supported lifecycle agent. Users who install CodeBuddy today cannot use `quantex install codebuddy`, `quantex inspect codebuddy`, or `quantex update codebuddy` through the same catalog contract as the rest of the supported agent set.
+
+## What Changes
+
+- Add a CodeBuddy agent definition with lifecycle metadata: canonical slug, lookup alias, homepage, npm package metadata, binary name, install methods, version probe, and self-update command.
+- Register CodeBuddy through the built-in agent catalog and root exports so existing lookup, install, ensure, inspect, resolve, exec, and update surfaces can use it.
+- Update the agent-catalog OpenSpec contract and the static supported-agent README tables so product-facing references match the expanded CLI surface.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add CodeBuddy Code as a supported lifecycle agent with verified install, version-probe, lookup, and update metadata.
+
+## Impact
+
+- `src/agents/definitions/codebuddy.ts` — new lifecycle metadata definition
+- `src/agents/index.ts` — register import, array entry, and re-export
+- `src/index.ts` — re-export the built-in CodeBuddy definition from the root surface
+- `test/agents.test.ts`, `test/index.test.ts` — registry and export coverage
+- `openspec/specs/agent-catalog/spec.md` — add the CodeBuddy requirement
+- `README.md`, `README.zh-CN.md` — keep static supported-agent tables aligned with the current CLI surface

--- a/openspec/changes/add-codebuddy-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-codebuddy-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,32 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: CodeBuddy Code MUST be a supported lifecycle agent
+
+Quantex SHALL include CodeBuddy Code in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up CodeBuddy Code
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `codebuddy` or the alias `codebuddy-code`
+- **THEN** Quantex returns a supported agent entry for CodeBuddy Code
+- **AND** the entry identifies `codebuddy` as the executable binary
+- **AND** the entry identifies `@tencent-ai/codebuddy-code` as its npm package metadata
+- **AND** the entry identifies `https://www.codebuddy.cn/docs/cli/installation` as the homepage
+
+#### Scenario: Installing CodeBuddy Code through supported methods
+
+- **WHEN** Quantex renders or executes install options for CodeBuddy Code
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official Homebrew tap formula and curl installer options
+- **AND** Windows includes the official PowerShell installer option
+
+#### Scenario: Probing CodeBuddy Code version
+
+- **WHEN** Quantex probes the installed version of CodeBuddy Code
+- **THEN** it runs `codebuddy --version` and parses the output
+
+#### Scenario: Planning CodeBuddy Code updates
+
+- **WHEN** Quantex plans an update for a CodeBuddy Code installation that supports self-update
+- **THEN** the catalog exposes `codebuddy update` as the agent self-update command

--- a/openspec/changes/add-codebuddy-cli-support/tasks.md
+++ b/openspec/changes/add-codebuddy-cli-support/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: Add CodeBuddy agent support
+
+## 1. OpenSpec and docs
+
+- [x] 1.1 Add the proposal, design, tasks, and `agent-catalog` spec delta for CodeBuddy support.
+- [x] 1.2 Update the static supported-agent tables in `README.md` and `README.zh-CN.md`.
+
+## 2. Catalog implementation
+
+- [x] 2.1 Create `src/agents/definitions/codebuddy.ts` with verified lifecycle metadata.
+- [x] 2.2 Register and re-export CodeBuddy through `src/agents/index.ts` and `src/index.ts`.
+- [x] 2.3 Add test coverage for CodeBuddy lookup aliases, install methods, version probe, and root exports.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.

--- a/src/agents/definitions/codebuddy.ts
+++ b/src/agents/definitions/codebuddy.ts
@@ -1,0 +1,34 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, bunInstall, npmInstall, scriptInstall } from '../methods'
+
+export const codebuddy: AgentDefinition = {
+  name: 'codebuddy',
+  lookupAliases: ['codebuddy-code'],
+  displayName: 'CodeBuddy Code',
+  homepage: 'https://www.codebuddy.cn/docs/cli/installation',
+  packages: {
+    npm: '@tencent-ai/codebuddy-code',
+  },
+  binaryName: 'codebuddy',
+  selfUpdate: {
+    command: ['codebuddy', 'update'],
+  },
+  versionProbe: {
+    command: ['codebuddy', '--version'],
+  },
+  platforms: {
+    windows: [bunInstall(), npmInstall(), scriptInstall('irm https://www.codebuddy.cn/cli/install.ps1 | iex')],
+    macos: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://www.codebuddy.cn/cli/install.sh | bash'),
+      brewInstall('Tencent-CodeBuddy/tap/codebuddy-code'),
+    ],
+    linux: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://www.codebuddy.cn/cli/install.sh | bash'),
+      brewInstall('Tencent-CodeBuddy/tap/codebuddy-code'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,6 +1,7 @@
 import type { AgentDefinition } from './types'
 import { amp } from './definitions/amp'
 import { claude } from './definitions/claude'
+import { codebuddy } from './definitions/codebuddy'
 import { codex } from './definitions/codex'
 import { copilot } from './definitions/copilot'
 import { crush } from './definitions/crush'
@@ -20,6 +21,7 @@ import { qwen } from './definitions/qwen'
 const agents: AgentDefinition[] = [
   amp,
   claude,
+  codebuddy,
   codex,
   copilot,
   crush,
@@ -28,8 +30,8 @@ const agents: AgentDefinition[] = [
   forgecode,
   gemini,
   goose,
-  kimi,
   kilo,
+  kimi,
   kiro,
   opencode,
   pi,
@@ -52,6 +54,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
 export {
   amp,
   claude,
+  codebuddy,
   codex,
   copilot,
   crush,
@@ -60,8 +63,8 @@ export {
   forgecode,
   gemini,
   goose,
-  kimi,
   kilo,
+  kimi,
   kiro,
   opencode,
   pi,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 export type { AgentUpdateContext, AgentUpdateProvider, AgentUpdateStrategy } from './agent-update'
 export {
   claude,
+  codebuddy,
   codex,
   copilot,
   cursor,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -2,6 +2,7 @@ import type { AgentDefinition } from '../src/agents/types'
 import { describe, expect, it } from 'vitest'
 import { getAgentByLookupName, getAgentByNameOrAlias, getAllAgents } from '../src/agents'
 import { claude } from '../src/agents/definitions/claude'
+import { codebuddy } from '../src/agents/definitions/codebuddy'
 import { codex } from '../src/agents/definitions/codex'
 import { copilot } from '../src/agents/definitions/copilot'
 import { cursor } from '../src/agents/definitions/cursor'
@@ -113,6 +114,54 @@ describe('codex', () => {
     expect(codex.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'codex')).toBeDefined()
     expect(codex.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'codex')).toBeDefined()
     expect(codex.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('codebuddy', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('codebuddy')).toBe(codebuddy)
+  })
+
+  it('is registered for lookup by package-style alias', () => {
+    expect(getAgentByNameOrAlias('codebuddy-code')).toBe(codebuddy)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(codebuddy)
+    expect(codebuddy.name).toBe('codebuddy')
+    expect(codebuddy.lookupAliases).toEqual(['codebuddy-code'])
+    expect(codebuddy.displayName).toBe('CodeBuddy Code')
+    expect(codebuddy.packages?.npm).toBe('@tencent-ai/codebuddy-code')
+    expect(codebuddy.binaryName).toBe('codebuddy')
+    expect(codebuddy.homepage).toBe('https://www.codebuddy.cn/docs/cli/installation')
+    expect(codebuddy.selfUpdate?.command).toEqual(['codebuddy', 'update'])
+    expect(codebuddy.versionProbe?.command).toEqual(['codebuddy', '--version'])
+  })
+
+  it('script install returns correct strings per platform', () => {
+    expect(
+      codebuddy.platforms.windows!.find(m => m.type === 'script' && m.command.includes('codebuddy.cn/cli/install.ps1')),
+    ).toBeDefined()
+    expect(
+      codebuddy.platforms.macos!.find(m => m.type === 'script' && m.command.includes('codebuddy.cn/cli/install.sh')),
+    ).toBeDefined()
+    expect(
+      codebuddy.platforms.linux!.find(m => m.type === 'script' && m.command.includes('codebuddy.cn/cli/install.sh')),
+    ).toBeDefined()
+  })
+
+  it('brew install returns correct strings per platform', () => {
+    expect(
+      codebuddy.platforms.macos!.find(
+        m => m.type === 'brew' && m.packageName === 'Tencent-CodeBuddy/tap/codebuddy-code',
+      ),
+    ).toBeDefined()
+    expect(
+      codebuddy.platforms.linux!.find(
+        m => m.type === 'brew' && m.packageName === 'Tencent-CodeBuddy/tap/codebuddy-code',
+      ),
+    ).toBeDefined()
+    expect(codebuddy.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  codebuddy,
   codex,
   copilot,
   createUpdatePlan,
@@ -38,6 +39,11 @@ describe('agent registry', () => {
     expect(agent?.name).toBe('cursor')
   })
 
+  it('resolves CodeBuddy by package-style alias', () => {
+    const agent = getAgentByLookupName('codebuddy-code')
+    expect(agent?.name).toBe('codebuddy')
+  })
+
   it('resolves Qoder by executable alias', () => {
     const agent = getAgentByLookupName('qodercli')
     expect(agent?.name).toBe('qoder')
@@ -60,6 +66,14 @@ describe('agent definitions', () => {
     expect(agent!.displayName).toBe('Codex CLI')
     expect(agent!.packages?.npm).toBe('@openai/codex')
     expect(agent!.binaryName).toBe('codex')
+  })
+
+  it('codebuddy has correct structure', () => {
+    const agent = getAgentByNameOrAlias('codebuddy')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('CodeBuddy Code')
+    expect(agent!.packages?.npm).toBe('@tencent-ai/codebuddy-code')
+    expect(agent!.binaryName).toBe('codebuddy')
   })
 
   it('opencode has correct structure', () => {
@@ -87,6 +101,7 @@ describe('agent definitions', () => {
   })
 
   it('re-exports all built-in agents from root index', () => {
+    expect(codebuddy.name).toBe('codebuddy')
     expect(codex.name).toBe('codex')
     expect(copilot.name).toBe('copilot')
     expect(cursor.name).toBe('cursor')


### PR DESCRIPTION
## Summary

Add CodeBuddy Code to the supported Quantex agent catalog so users can install, inspect, resolve, run, and update it through the standard lifecycle surface.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/add-codebuddy-cli-support/`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The new catalog entry uses `codebuddy` as the canonical slug, accepts `codebuddy-code` as a lookup alias, and records the official npm, Homebrew tap, native install script, version probe, and self-update command from the upstream CodeBuddy CLI docs.
