### PR TITLE
feat: add auggie cli support

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,17 +167,24 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 
 | Agent | Run Command | Description |
 |-------|-------------|-------------|
+| Auggie CLI | `qtx auggie` | Augment's official terminal coding agent |
 | Amp | `qtx amp` | Sourcegraph's frontier AI coding agent CLI |
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
+| Crush | `qtx crush` | Charmbracelet's AI coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
 | Droid | `qtx droid` | Factory AI software engineering agent CLI |
+| ForgeCode | `qtx forgecode` | Antinomy AI coding agent CLI |
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |
+| Goose | `qtx goose` | Block's open-source extensible AI agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
+| Kimi Code | `qtx kimi` | Moonshot AI terminal coding agent CLI |
+| Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |
+| Qwen Code | `qtx qwen` | QwenLM's open-source AI coding agent CLI |
 
 If you prefer the explicit long form, replace `qtx` with `quantex` in the examples above.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,17 +167,24 @@ qtx upgrade --channel beta
 
 | Agent | 启动命令 | 描述 |
 |-------|----------|------|
+| Auggie CLI | `qtx auggie` | Augment 官方终端编程 Agent CLI |
 | Amp | `qtx amp` | Sourcegraph 前沿 AI 编程 Agent CLI |
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
+| Crush | `qtx crush` | Charmbracelet AI 编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
 | Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
+| ForgeCode | `qtx forgecode` | Antinomy AI 编程 Agent CLI |
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |
+| Goose | `qtx goose` | Block 开源可扩展 AI Agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
+| Kimi Code | `qtx kimi` | Moonshot AI 终端编程 Agent CLI |
+| Kiro CLI | `qtx kiro` | Amazon AI 编程 Agent CLI |
 | OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
 | Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |
+| Qwen Code | `qtx qwen` | QwenLM 开源 AI 编程 Agent CLI |
 
 如果你更偏好显式长命令，上表里的 `qtx` 都可以直接替换成 `quantex`。
 

--- a/openspec/changes/add-auggie-cli-support/.openspec.yaml
+++ b/openspec/changes/add-auggie-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-auggie-cli-support/design.md
+++ b/openspec/changes/add-auggie-cli-support/design.md
@@ -1,0 +1,40 @@
+# Design: Add Auggie CLI support
+
+## Decision
+
+Add Auggie CLI as a managed npm/bun agent on macOS and Linux, using the canonical Quantex slug `auggie`, the executable binary `auggie`, `auggie --version` for version probing, and `auggie upgrade` for explicit self-update metadata.
+
+## Agent Definition
+
+| Field | Value |
+|---|---|
+| name | `auggie` |
+| lookupAliases | (none) |
+| displayName | `Auggie CLI` |
+| homepage | `https://docs.augmentcode.com/cli/overview` |
+| packages | `@augmentcode/auggie` |
+| binaryName | `auggie` |
+| selfUpdate | `auggie upgrade` |
+| versionProbe | `auggie --version` |
+
+## Install Methods
+
+| Platform | Method | Command |
+|---|---|---|
+| macOS | bun | `bun add -g @augmentcode/auggie` |
+| macOS | npm | `npm install -g @augmentcode/auggie` |
+| Linux | bun | `bun add -g @augmentcode/auggie` |
+| Linux | npm | `npm install -g @augmentcode/auggie` |
+
+## Rationale
+
+- Auggie is published as the npm package `@augmentcode/auggie` and exposes the `auggie` binary; both npm and Bun execution were validated against the published package metadata and CLI entrypoint.
+- Upstream documents explicit manual upgrades through `auggie upgrade`, so Quantex should record that command as lifecycle metadata even though Auggie also auto-updates during interactive sessions.
+- Upstream documents support for macOS, Linux, and Windows WSL rather than native Windows. Quantex already treats WSL as `linux`, so this change should not advertise a native `windows` install method.
+- The upstream docs currently document a stricter Node requirement than the published package metadata, but Quantex does not yet model engine requirements inside the agent catalog. This change keeps scope to supported lifecycle metadata.
+
+## Non-Goals
+
+- Model Auggie authentication, account setup, or workspace-indexing behavior in Quantex metadata
+- Add native Windows support that the upstream docs do not currently claim
+- Expand Quantex's catalog schema to capture runtime prerequisites such as Node version requirements

--- a/openspec/changes/add-auggie-cli-support/proposal.md
+++ b/openspec/changes/add-auggie-cli-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Auggie CLI is Augment's terminal coding agent, and users expect `quantex install auggie`, `quantex info auggie`, and `quantex update auggie` to work like the rest of the supported agent catalog. Quantex does not currently recognize Auggie even though its install, version, and upgrade surfaces are documented upstream.
+
+## What Changes
+
+- Add an Auggie CLI agent definition with verified lifecycle metadata for install, version probing, and update planning
+- Register Auggie in the supported agent catalog so lifecycle commands can resolve it
+- Update product-facing supported-agent tables to include Auggie and reflect the current catalog
+- Add an OpenSpec delta for the Auggie catalog contract
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add Auggie CLI as a supported lifecycle agent with install, version probe, and self-update requirements
+
+## Impact
+
+- `src/agents/definitions/auggie.ts` — new agent definition
+- `src/agents/index.ts` — register Auggie in the catalog
+- `test/agents.test.ts` and `test/utils/version.test.ts` — cover Auggie metadata and version parsing expectations
+- `README.md` and `README.zh-CN.md` — include Auggie in supported-agent tables and sync the catalog list
+- `openspec/changes/add-auggie-cli-support/specs/agent-catalog/spec.md` — define the Auggie contract

--- a/openspec/changes/add-auggie-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-auggie-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Auggie CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Auggie CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Auggie CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `auggie`
+- **THEN** Quantex returns a supported agent entry for Auggie CLI
+- **AND** the entry identifies `auggie` as the executable binary
+- **AND** the entry identifies `@augmentcode/auggie` as its npm package metadata
+
+#### Scenario: Installing Auggie CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Auggie CLI
+- **THEN** macOS and Linux include npm-compatible and bun-compatible managed install methods
+- **AND** Quantex does not advertise a native Windows install method while the upstream docs only claim Windows support through WSL
+
+#### Scenario: Probing Auggie CLI version
+
+- **WHEN** Quantex probes the installed version of Auggie CLI
+- **THEN** it runs `auggie --version` and parses the output
+
+#### Scenario: Planning Auggie CLI updates
+
+- **WHEN** Quantex plans an update for an Auggie CLI installation that supports self-update
+- **THEN** the catalog exposes `auggie upgrade` as the agent self-update command

--- a/openspec/changes/add-auggie-cli-support/tasks.md
+++ b/openspec/changes/add-auggie-cli-support/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Add Auggie CLI support
+
+- [x] Add the OpenSpec proposal, design, and agent-catalog delta for Auggie CLI support
+- [x] Create `src/agents/definitions/auggie.ts` and register Auggie in `src/agents/index.ts`
+- [x] Add tests covering Auggie metadata, lookup behavior, and version parsing expectations
+- [x] Update product-facing supported-agent tables to include Auggie and sync the current catalog
+- [x] Validate with `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`

--- a/src/agents/definitions/auggie.ts
+++ b/src/agents/definitions/auggie.ts
@@ -1,0 +1,22 @@
+import type { AgentDefinition } from '../types'
+import { bunInstall, npmInstall } from '../methods'
+
+export const auggie: AgentDefinition = {
+  name: 'auggie',
+  displayName: 'Auggie CLI',
+  homepage: 'https://docs.augmentcode.com/cli/overview',
+  packages: {
+    npm: '@augmentcode/auggie',
+  },
+  binaryName: 'auggie',
+  selfUpdate: {
+    command: ['auggie', 'upgrade'],
+  },
+  versionProbe: {
+    command: ['auggie', '--version'],
+  },
+  platforms: {
+    macos: [bunInstall(), npmInstall()],
+    linux: [bunInstall(), npmInstall()],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,5 +1,6 @@
 import type { AgentDefinition } from './types'
 import { amp } from './definitions/amp'
+import { auggie } from './definitions/auggie'
 import { claude } from './definitions/claude'
 import { codex } from './definitions/codex'
 import { copilot } from './definitions/copilot'
@@ -18,6 +19,7 @@ import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
 
 const agents: AgentDefinition[] = [
+  auggie,
   amp,
   claude,
   codex,
@@ -50,6 +52,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
 }
 
 export {
+  auggie,
   amp,
   claude,
   codex,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -1,6 +1,7 @@
 import type { AgentDefinition } from '../src/agents/types'
 import { describe, expect, it } from 'vitest'
 import { getAgentByLookupName, getAgentByNameOrAlias, getAllAgents } from '../src/agents'
+import { auggie } from '../src/agents/definitions/auggie'
 import { claude } from '../src/agents/definitions/claude'
 import { codex } from '../src/agents/definitions/codex'
 import { copilot } from '../src/agents/definitions/copilot'
@@ -65,6 +66,32 @@ function validateAgent(agent: AgentDefinition): void {
     }
   }
 }
+
+describe('auggie', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('auggie')).toBe(auggie)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(auggie)
+    expect(auggie.name).toBe('auggie')
+    expect(auggie.lookupAliases).toBeUndefined()
+    expect(auggie.displayName).toBe('Auggie CLI')
+    expect(auggie.packages?.npm).toBe('@augmentcode/auggie')
+    expect(auggie.binaryName).toBe('auggie')
+    expect(auggie.homepage).toBe('https://docs.augmentcode.com/cli/overview')
+    expect(auggie.selfUpdate?.command).toEqual(['auggie', 'upgrade'])
+    expect(auggie.versionProbe?.command).toEqual(['auggie', '--version'])
+  })
+
+  it('supports bun and npm installs on macOS and Linux only', () => {
+    expect(auggie.platforms.macos!.find(m => m.type === 'bun')).toBeDefined()
+    expect(auggie.platforms.macos!.find(m => m.type === 'npm')).toBeDefined()
+    expect(auggie.platforms.linux!.find(m => m.type === 'bun')).toBeDefined()
+    expect(auggie.platforms.linux!.find(m => m.type === 'npm')).toBeDefined()
+    expect(auggie.platforms.windows).toBeUndefined()
+  })
+})
 
 describe('claude', () => {
   it('has valid structure', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -22,6 +22,13 @@ describe('agent registry', () => {
     expect(agents.length).toBeGreaterThanOrEqual(9)
   })
 
+  it('finds auggie by name', () => {
+    const agent = getAgentByNameOrAlias('auggie')
+    expect(agent).toBeDefined()
+    expect(agent!.name).toBe('auggie')
+    expect(agent!.binaryName).toBe('auggie')
+  })
+
   it('finds agent by name', () => {
     const agent = getAgentByNameOrAlias('claude')
     expect(agent).toBeDefined()

--- a/test/utils/version.test.ts
+++ b/test/utils/version.test.ts
@@ -73,6 +73,15 @@ describe('getInstalledVersion', () => {
     expect(version).toBe('0.118.0')
   })
 
+  it('extracts version from commit-suffixed output', async () => {
+    const { getInstalledVersion } = await import('../../src/utils/version')
+    mockSpawn.mockReturnValue(createMockProcess(0, '0.25.0 (commit b7668abc)\n'))
+    const version = await getInstalledVersion('auggie', {
+      command: ['auggie', '--version'],
+    })
+    expect(version).toBe('0.25.0')
+  })
+
   it('extracts version from multi-line output (first line)', async () => {
     const { getInstalledVersion } = await import('../../src/utils/version')
     mockSpawn.mockReturnValue(


### PR DESCRIPTION
## Summary

Add Auggie CLI to the supported Quantex agent catalog with verified install, version probe, and self-update metadata, plus OpenSpec coverage and README updates.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/add-auggie-cli-support/`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Auggie is intentionally modeled as macOS/Linux-only in Quantex because upstream docs currently describe Windows support through WSL rather than native Windows.
