### PR TITLE
feat(agents): add Junie CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,20 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
+| Crush | `qtx crush` | Charmbracelet's terminal coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
 | Droid | `qtx droid` | Factory AI software engineering agent CLI |
+| ForgeCode | `qtx forgecode` | Antinomy's AI coding agent CLI |
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |
+| Goose | `qtx goose` | Block's AI coding agent CLI |
+| Junie CLI | `qtx junie` | JetBrains' AI coding agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
+| Kimi Code | `qtx kimi` | Moonshot AI's coding agent CLI |
+| Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |
+| Qwen Code | `qtx qwen` | Qwen's AI coding assistant CLI |
 
 If you prefer the explicit long form, replace `qtx` with `quantex` in the examples above.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,13 +171,20 @@ qtx upgrade --channel beta
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
+| Crush | `qtx crush` | Charmbracelet 终端编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
 | Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
+| ForgeCode | `qtx forgecode` | Antinomy AI 编程 Agent CLI |
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |
+| Goose | `qtx goose` | Block AI Agent CLI |
+| Junie CLI | `qtx junie` | JetBrains 官方 AI 编程 Agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
+| Kimi Code | `qtx kimi` | Moonshot AI 编程 Agent CLI |
+| Kiro CLI | `qtx kiro` | Amazon AI 编程 Agent CLI |
 | OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
 | Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |
+| Qwen Code | `qtx qwen` | Qwen AI 编程助手 CLI |
 
 如果你更偏好显式长命令，上表里的 `qtx` 都可以直接替换成 `quantex`。
 

--- a/openspec/changes/add-junie-agent-support/.openspec.yaml
+++ b/openspec/changes/add-junie-agent-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-junie-agent-support/design.md
+++ b/openspec/changes/add-junie-agent-support/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Junie CLI is distributed by JetBrains through multiple upstream channels: an npm package (`@jetbrains/junie`), platform install scripts, and a Homebrew tap for macOS/Linux. The official CLI reference documents `junie --version` and automated update checks (`--skip-update-check`, `auto-update` config), but it does not document a dedicated `junie update` style command.
+
+Quantex already models similar agents with a single catalog entry that carries the lifecycle metadata used by install, inspect, resolve, exec, and update planning. Junie support should fit that existing shape without adding product-specific command exceptions.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add Junie as a supported Quantex lifecycle agent with verified upstream metadata.
+- Prefer install methods that preserve Quantex's managed-update behavior when the user installs through npm or Bun.
+- Preserve official script and Homebrew paths so human-facing guidance and fallback installs stay aligned with upstream documentation.
+
+**Non-Goals:**
+
+- Add Junie-specific runtime behaviors beyond catalog metadata.
+- Implement a synthetic self-update command when upstream does not document one.
+- Model Junie's GitHub Action, ACP mode, or IDE-specific workflows in this change.
+
+## Decisions
+
+### 1. Use `junie` as both the canonical slug and executable name
+
+The upstream binary command is `junie`, and it is specific enough to serve as the Quantex-facing identifier without aliases or branding exceptions.
+
+### 2. Expose Bun and npm managed installs on all platforms, plus official scripts and Homebrew where documented
+
+Junie publishes the `@jetbrains/junie` package on npm, so Quantex can support both npm and Bun managed installs consistently with other package-backed agents. On macOS and Linux, the catalog also keeps the official shell installer and the Homebrew tap formula. On Windows, the catalog keeps the official PowerShell install script.
+
+Using managed methods first preserves stronger Quantex lifecycle behavior for installs performed through `quantex install junie`, while still keeping the upstream script paths available for users who prefer them.
+
+### 3. Record a version probe but no self-update command
+
+The CLI reference documents `junie --version`, so Quantex should use that as the explicit version probe. Upstream documentation describes automated update checks and configuration flags, not a dedicated update subcommand, so the catalog should omit `selfUpdate` rather than inventing one.
+
+### 4. Use the explicit Homebrew tap formula identifier in the catalog
+
+JetBrains documentation and repository text currently show slightly different Homebrew tap wording, but the public tap repository exists at `jetbrains-junie/homebrew-junie`. Quantex should record the install target as `jetbrains-junie/junie/junie`, which maps directly to a brew-installable formula path and avoids needing separate tap-state assumptions in the catalog.
+
+## Risks / Trade-offs
+
+- [Users may expect script-first installs because JetBrains quickstart leads with scripts] -> Keep the official scripts in the catalog and document managed installs as additional supported lifecycle paths.
+- [Script-installed Junie remains outside Quantex-managed update flows] -> Omit a fake self-update command and rely on Junie's documented automatic update-check behavior.
+- [Homebrew naming could drift upstream again] -> Store the fully qualified tap formula path and keep the agent-catalog spec tied to the currently resolvable upstream tap repository.

--- a/openspec/changes/add-junie-agent-support/proposal.md
+++ b/openspec/changes/add-junie-agent-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+This request changes the supported agent catalog, install metadata, and version-probe behavior, so it requires an OpenSpec-backed change before implementation. Junie CLI is now publicly documented by JetBrains across terminal, IDE, and CI workflows, but Quantex cannot currently install, inspect, or launch it as a first-class lifecycle agent.
+
+## What Changes
+
+- Add a Junie CLI agent definition with verified lifecycle metadata: canonical slug, display name, homepage, npm package metadata, executable name, install methods, and version probe.
+- Register Junie in the runtime agent catalog and root exports so lookup, inspection, resolution, and execution surfaces can use it.
+- Extend the agent-catalog contract with a Junie requirement that records the supported install paths and the lack of a dedicated self-update command.
+- Refresh the product README agent tables so the documented supported-agent list matches the actual catalog after adding Junie.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add Junie CLI as a supported lifecycle agent with verified install methods and version-probe behavior.
+
+## Impact
+
+- `src/agents/definitions/junie.ts` - new Junie catalog entry
+- `src/agents/index.ts` and `src/index.ts` - register and re-export Junie
+- `test/agents.test.ts` and `test/index.test.ts` - verify Junie metadata and exports
+- `openspec/specs/agent-catalog/spec.md` - add the Junie requirement
+- `README.md` and `README.zh-CN.md` - sync supported-agent tables with the current catalog

--- a/openspec/changes/add-junie-agent-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-junie-agent-support/specs/agent-catalog/spec.md
@@ -1,0 +1,32 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Junie CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Junie CLI (by JetBrains) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Junie CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `junie`
+- **THEN** Quantex returns a supported agent entry for Junie CLI
+- **AND** the entry identifies `junie` as the executable binary
+- **AND** the entry identifies `@jetbrains/junie` as its npm package metadata
+- **AND** the entry identifies `https://junie.jetbrains.com/docs/junie-cli.html` as the homepage
+
+#### Scenario: Installing Junie CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Junie CLI
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official curl install script option and the Homebrew tap formula install method (`jetbrains-junie/junie/junie`)
+- **AND** Windows includes the official PowerShell install script option (`iex (irm 'https://junie.jetbrains.com/install.ps1')`)
+
+#### Scenario: Probing Junie CLI version
+
+- **WHEN** Quantex probes the installed version of Junie CLI
+- **THEN** it runs `junie --version` and parses the output
+
+#### Scenario: Planning Junie CLI updates
+
+- **WHEN** Quantex plans an update for a Junie CLI installation
+- **THEN** the catalog does not expose a self-update command because upstream documentation describes automated update checks rather than a dedicated update subcommand

--- a/openspec/changes/add-junie-agent-support/tasks.md
+++ b/openspec/changes/add-junie-agent-support/tasks.md
@@ -1,0 +1,19 @@
+## 1. Catalog Support
+
+- [x] 1.1 Add `src/agents/definitions/junie.ts` with verified Junie lifecycle metadata.
+- [x] 1.2 Register Junie in `src/agents/index.ts` and `src/index.ts`.
+- [x] 1.3 Add the Junie requirement to `openspec/specs/agent-catalog/spec.md`.
+
+## 2. Tests And Docs
+
+- [x] 2.1 Add or update automated tests for Junie metadata and root exports.
+- [x] 2.2 Sync `README.md` and `README.zh-CN.md` supported-agent tables with the implemented catalog.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.
+- [x] 3.6 Run `bun run memory:check`.

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -169,6 +169,35 @@ Quantex SHALL include Goose (by Block) in the supported agent catalog with lifec
 - **WHEN** Quantex plans an update for a Goose installation that supports self-update
 - **THEN** the catalog exposes `goose update` as the agent self-update command
 
+### Requirement: Junie CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Junie CLI (by JetBrains) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Junie CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `junie`
+- **THEN** Quantex returns a supported agent entry for Junie CLI
+- **AND** the entry identifies `junie` as the executable binary
+- **AND** the entry identifies `@jetbrains/junie` as its npm package metadata
+- **AND** the entry identifies `https://junie.jetbrains.com/docs/junie-cli.html` as the homepage
+
+#### Scenario: Installing Junie CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Junie CLI
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official curl install script option and the Homebrew tap formula install method (`jetbrains-junie/junie/junie`)
+- **AND** Windows includes the official PowerShell install script option (`iex (irm 'https://junie.jetbrains.com/install.ps1')`)
+
+#### Scenario: Probing Junie CLI version
+
+- **WHEN** Quantex probes the installed version of Junie CLI
+- **THEN** it runs `junie --version` and parses the output
+
+#### Scenario: Planning Junie CLI updates
+
+- **WHEN** Quantex plans an update for a Junie CLI installation
+- **THEN** the catalog does not expose a self-update command because upstream documentation describes automated update checks rather than a dedicated update subcommand
+
 ### Requirement: Kilo CLI MUST use the current supported display name
 
 Quantex SHALL expose the Kilo catalog entry with the display name `Kilo CLI` while keeping the canonical agent slug `kilo`.

--- a/src/agents/definitions/junie.ts
+++ b/src/agents/definitions/junie.ts
@@ -1,0 +1,30 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, bunInstall, npmInstall, scriptInstall } from '../methods'
+
+export const junie: AgentDefinition = {
+  name: 'junie',
+  displayName: 'Junie CLI',
+  homepage: 'https://junie.jetbrains.com/docs/junie-cli.html',
+  packages: {
+    npm: '@jetbrains/junie',
+  },
+  binaryName: 'junie',
+  versionProbe: {
+    command: ['junie', '--version'],
+  },
+  platforms: {
+    windows: [bunInstall(), npmInstall(), scriptInstall("iex (irm 'https://junie.jetbrains.com/install.ps1')")],
+    macos: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://junie.jetbrains.com/install.sh | bash'),
+      brewInstall('jetbrains-junie/junie/junie'),
+    ],
+    linux: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://junie.jetbrains.com/install.sh | bash'),
+      brewInstall('jetbrains-junie/junie/junie'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -9,6 +9,7 @@ import { droid } from './definitions/droid'
 import { forgecode } from './definitions/forgecode'
 import { gemini } from './definitions/gemini'
 import { goose } from './definitions/goose'
+import { junie } from './definitions/junie'
 import { kilo } from './definitions/kilo'
 import { kimi } from './definitions/kimi'
 import { kiro } from './definitions/kiro'
@@ -28,6 +29,7 @@ const agents: AgentDefinition[] = [
   forgecode,
   gemini,
   goose,
+  junie,
   kimi,
   kilo,
   kiro,
@@ -60,6 +62,7 @@ export {
   forgecode,
   gemini,
   goose,
+  junie,
   kimi,
   kilo,
   kiro,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export {
   getAgentByLookupName,
   getAgentByNameOrAlias,
   getAllAgents,
+  junie,
   kilo,
   opencode,
   pi,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -7,6 +7,7 @@ import { copilot } from '../src/agents/definitions/copilot'
 import { cursor } from '../src/agents/definitions/cursor'
 import { droid } from '../src/agents/definitions/droid'
 import { gemini } from '../src/agents/definitions/gemini'
+import { junie } from '../src/agents/definitions/junie'
 import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
 import { pi } from '../src/agents/definitions/pi'
@@ -208,6 +209,41 @@ describe('gemini', () => {
     expect(gemini.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'gemini-cli')).toBeDefined()
     expect(gemini.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'gemini-cli')).toBeDefined()
     expect(gemini.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('junie', () => {
+  it('has valid structure', () => {
+    validateAgent(junie)
+    expect(junie.name).toBe('junie')
+    expect(junie.lookupAliases).toBeUndefined()
+    expect(junie.displayName).toBe('Junie CLI')
+    expect(junie.packages?.npm).toBe('@jetbrains/junie')
+    expect(junie.binaryName).toBe('junie')
+    expect(junie.homepage).toBe('https://junie.jetbrains.com/docs/junie-cli.html')
+    expect(junie.selfUpdate).toBeUndefined()
+    expect(junie.versionProbe?.command).toEqual(['junie', '--version'])
+  })
+
+  it('supports managed installs on all platforms plus official script and brew paths', () => {
+    expect(junie.platforms.windows!.find(m => m.type === 'bun')).toBeDefined()
+    expect(junie.platforms.windows!.find(m => m.type === 'npm')).toBeDefined()
+    expect(
+      junie.platforms.windows!.find(m => m.type === 'script' && m.command.includes('junie.jetbrains.com/install.ps1')),
+    ).toBeDefined()
+
+    expect(
+      junie.platforms.macos!.find(m => m.type === 'script' && m.command.includes('junie.jetbrains.com/install.sh')),
+    ).toBeDefined()
+    expect(
+      junie.platforms.linux!.find(m => m.type === 'script' && m.command.includes('junie.jetbrains.com/install.sh')),
+    ).toBeDefined()
+    expect(
+      junie.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'jetbrains-junie/junie/junie'),
+    ).toBeDefined()
+    expect(
+      junie.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'jetbrains-junie/junie/junie'),
+    ).toBeDefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,6 +9,7 @@ import {
   getAgentByLookupName,
   getAgentByNameOrAlias,
   getAllAgents,
+  junie,
   inspectAgent,
   kilo,
   opencode,
@@ -78,6 +79,14 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('kilo')
   })
 
+  it('junie has correct structure', () => {
+    const agent = getAgentByNameOrAlias('junie')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('Junie CLI')
+    expect(agent!.packages?.npm).toBe('@jetbrains/junie')
+    expect(agent!.binaryName).toBe('junie')
+  })
+
   it('qoder has correct structure', () => {
     const agent = getAgentByNameOrAlias('qoder')
     expect(agent).toBeDefined()
@@ -92,6 +101,7 @@ describe('agent definitions', () => {
     expect(cursor.name).toBe('cursor')
     expect(droid.name).toBe('droid')
     expect(gemini.name).toBe('gemini')
+    expect(junie.name).toBe('junie')
     expect(kilo.name).toBe('kilo')
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')


### PR DESCRIPTION
## Summary

Add Junie CLI to the supported agent catalog with verified install metadata, a `junie --version` probe, and no synthetic self-update command. This also syncs the OpenSpec contract and README supported-agent tables so docs match the runtime catalog.

## Linked Artifacts

- Issue: not applicable
- ADR: not applicable
- OpenSpec: `add-junie-agent-support`
- Discussion: not applicable

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

README agent tables now include Junie and the previously supported agents that were missing from the product docs, so the published support list matches the implemented catalog.
