### PR TITLE
feat(agents): batch agent catalog support additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 
 | Agent | Run Command | Description |
 |-------|-------------|-------------|
+| Auggie CLI | `qtx auggie` | Augment's official terminal coding agent |
 | Amp | `qtx amp` | Sourcegraph's frontier AI coding agent CLI |
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
 | CodeBuddy Code | `qtx codebuddy` | Tencent's official AI coding assistant CLI |

--- a/README.md
+++ b/README.md
@@ -170,14 +170,21 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Amp | `qtx amp` | Sourcegraph's frontier AI coding agent CLI |
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
-| GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
+| Crush | `qtx crush` | Charmbracelet's terminal AI coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
 | Droid | `qtx droid` | Factory AI software engineering agent CLI |
+| ForgeCode | `qtx forgecode` | Antinomy's AI coding assistant CLI |
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |
+| GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
+| Goose | `qtx goose` | Block's open-source extensible AI agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
+| Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |
+| Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |
+| Mistral Vibe | `qtx vibe` | Mistral's open-source CLI coding assistant |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |
+| Qwen Code | `qtx qwen` | Qwen's AI coding assistant CLI |
 
 If you prefer the explicit long form, replace `qtx` with `quantex` in the examples above.
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
 | Goose | `qtx goose` | Block's open-source extensible AI agent CLI |
+| Junie CLI | `qtx junie` | JetBrains' AI coding agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
 | Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |
 | Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 |-------|-------------|-------------|
 | Amp | `qtx amp` | Sourcegraph's frontier AI coding agent CLI |
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
+| CodeBuddy Code | `qtx codebuddy` | Tencent's official AI coding assistant CLI |
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | Crush | `qtx crush` | Charmbracelet's terminal AI coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -170,14 +170,21 @@ qtx upgrade --channel beta
 | Amp | `qtx amp` | Sourcegraph 前沿 AI 编程 Agent CLI |
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
-| GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
+| Crush | `qtx crush` | Charmbracelet 终端 AI 编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
 | Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
+| ForgeCode | `qtx forgecode` | Antinomy AI 编程助手 CLI |
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |
+| GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
+| Goose | `qtx goose` | Block 开源可扩展 AI Agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
+| Kimi Code | `qtx kimi` | Moonshot AI 编程助手 CLI |
+| Kiro CLI | `qtx kiro` | Amazon AI 编程 Agent CLI |
+| Mistral Vibe | `qtx vibe` | Mistral 开源终端编程助手 |
 | OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
 | Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |
+| Qwen Code | `qtx qwen` | Qwen AI 编程助手 CLI |
 
 如果你更偏好显式长命令，上表里的 `qtx` 都可以直接替换成 `quantex`。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -169,6 +169,7 @@ qtx upgrade --channel beta
 |-------|----------|------|
 | Amp | `qtx amp` | Sourcegraph 前沿 AI 编程 Agent CLI |
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
+| CodeBuddy Code | `qtx codebuddy` | 腾讯官方 AI 编程助手 CLI |
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | Crush | `qtx crush` | Charmbracelet 终端 AI 编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -179,6 +179,7 @@ qtx upgrade --channel beta
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
 | Goose | `qtx goose` | Block 开源可扩展 AI Agent CLI |
+| Junie CLI | `qtx junie` | JetBrains 官方 AI 编程 Agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
 | Kimi Code | `qtx kimi` | Moonshot AI 编程助手 CLI |
 | Kiro CLI | `qtx kiro` | Amazon AI 编程 Agent CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -167,6 +167,7 @@ qtx upgrade --channel beta
 
 | Agent | 启动命令 | 描述 |
 |-------|----------|------|
+| Auggie CLI | `qtx auggie` | Augment 官方终端编程 Agent CLI |
 | Amp | `qtx amp` | Sourcegraph 前沿 AI 编程 Agent CLI |
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
 | CodeBuddy Code | `qtx codebuddy` | 腾讯官方 AI 编程助手 CLI |

--- a/openspec/changes/add-auggie-cli-support/.openspec.yaml
+++ b/openspec/changes/add-auggie-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-auggie-cli-support/design.md
+++ b/openspec/changes/add-auggie-cli-support/design.md
@@ -1,0 +1,40 @@
+# Design: Add Auggie CLI support
+
+## Decision
+
+Add Auggie CLI as a managed npm/bun agent on macOS and Linux, using the canonical Quantex slug `auggie`, the executable binary `auggie`, `auggie --version` for version probing, and `auggie upgrade` for explicit self-update metadata.
+
+## Agent Definition
+
+| Field | Value |
+|---|---|
+| name | `auggie` |
+| lookupAliases | (none) |
+| displayName | `Auggie CLI` |
+| homepage | `https://docs.augmentcode.com/cli/overview` |
+| packages | `@augmentcode/auggie` |
+| binaryName | `auggie` |
+| selfUpdate | `auggie upgrade` |
+| versionProbe | `auggie --version` |
+
+## Install Methods
+
+| Platform | Method | Command |
+|---|---|---|
+| macOS | bun | `bun add -g @augmentcode/auggie` |
+| macOS | npm | `npm install -g @augmentcode/auggie` |
+| Linux | bun | `bun add -g @augmentcode/auggie` |
+| Linux | npm | `npm install -g @augmentcode/auggie` |
+
+## Rationale
+
+- Auggie is published as the npm package `@augmentcode/auggie` and exposes the `auggie` binary; both npm and Bun execution were validated against the published package metadata and CLI entrypoint.
+- Upstream documents explicit manual upgrades through `auggie upgrade`, so Quantex should record that command as lifecycle metadata even though Auggie also auto-updates during interactive sessions.
+- Upstream documents support for macOS, Linux, and Windows WSL rather than native Windows. Quantex already treats WSL as `linux`, so this change should not advertise a native `windows` install method.
+- The upstream docs currently document a stricter Node requirement than the published package metadata, but Quantex does not yet model engine requirements inside the agent catalog. This change keeps scope to supported lifecycle metadata.
+
+## Non-Goals
+
+- Model Auggie authentication, account setup, or workspace-indexing behavior in Quantex metadata
+- Add native Windows support that the upstream docs do not currently claim
+- Expand Quantex's catalog schema to capture runtime prerequisites such as Node version requirements

--- a/openspec/changes/add-auggie-cli-support/proposal.md
+++ b/openspec/changes/add-auggie-cli-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Auggie CLI is Augment's terminal coding agent, and users expect `quantex install auggie`, `quantex info auggie`, and `quantex update auggie` to work like the rest of the supported agent catalog. Quantex does not currently recognize Auggie even though its install, version, and upgrade surfaces are documented upstream.
+
+## What Changes
+
+- Add an Auggie CLI agent definition with verified lifecycle metadata for install, version probing, and update planning
+- Register Auggie in the supported agent catalog so lifecycle commands can resolve it
+- Update product-facing supported-agent tables to include Auggie and reflect the current catalog
+- Add an OpenSpec delta for the Auggie catalog contract
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add Auggie CLI as a supported lifecycle agent with install, version probe, and self-update requirements
+
+## Impact
+
+- `src/agents/definitions/auggie.ts` — new agent definition
+- `src/agents/index.ts` — register Auggie in the catalog
+- `test/agents.test.ts` and `test/utils/version.test.ts` — cover Auggie metadata and version parsing expectations
+- `README.md` and `README.zh-CN.md` — include Auggie in supported-agent tables and sync the catalog list
+- `openspec/changes/add-auggie-cli-support/specs/agent-catalog/spec.md` — define the Auggie contract

--- a/openspec/changes/add-auggie-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-auggie-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Auggie CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Auggie CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Auggie CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `auggie`
+- **THEN** Quantex returns a supported agent entry for Auggie CLI
+- **AND** the entry identifies `auggie` as the executable binary
+- **AND** the entry identifies `@augmentcode/auggie` as its npm package metadata
+
+#### Scenario: Installing Auggie CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Auggie CLI
+- **THEN** macOS and Linux include npm-compatible and bun-compatible managed install methods
+- **AND** Quantex does not advertise a native Windows install method while the upstream docs only claim Windows support through WSL
+
+#### Scenario: Probing Auggie CLI version
+
+- **WHEN** Quantex probes the installed version of Auggie CLI
+- **THEN** it runs `auggie --version` and parses the output
+
+#### Scenario: Planning Auggie CLI updates
+
+- **WHEN** Quantex plans an update for an Auggie CLI installation that supports self-update
+- **THEN** the catalog exposes `auggie upgrade` as the agent self-update command

--- a/openspec/changes/add-auggie-cli-support/tasks.md
+++ b/openspec/changes/add-auggie-cli-support/tasks.md
@@ -1,0 +1,7 @@
+# Tasks: Add Auggie CLI support
+
+- [x] Add the OpenSpec proposal, design, and agent-catalog delta for Auggie CLI support
+- [x] Create `src/agents/definitions/auggie.ts` and register Auggie in `src/agents/index.ts`
+- [x] Add tests covering Auggie metadata, lookup behavior, and version parsing expectations
+- [x] Update product-facing supported-agent tables to include Auggie and sync the current catalog
+- [x] Validate with `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`

--- a/openspec/changes/add-codebuddy-cli-support/.openspec.yaml
+++ b/openspec/changes/add-codebuddy-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-codebuddy-cli-support/design.md
+++ b/openspec/changes/add-codebuddy-cli-support/design.md
@@ -1,0 +1,43 @@
+# Design: Add CodeBuddy agent support
+
+## Approach
+
+Add a new agent definition file that follows the existing lifecycle-focused catalog pattern used by `qoder.ts`, `forgecode.ts`, and `kiro.ts`. CodeBuddy exposes a stable executable name (`codebuddy`), an npm package (`@tencent-ai/codebuddy-code`), an official Homebrew tap formula, official native install scripts, a version command, and a built-in update command, so no new catalog shape or installer abstraction is needed.
+
+Use `codebuddy` as the canonical Quantex slug because it matches the upstream executable and is product-specific. Add `codebuddy-code` as a lookup alias so users can also resolve the product/package spelling shown in upstream package-manager docs.
+
+## Install methods
+
+| Platform | Method | Command |
+|---|---|---|
+| macOS | bun | `bun add -g @tencent-ai/codebuddy-code` |
+| macOS | npm | `npm install -g @tencent-ai/codebuddy-code` |
+| macOS | script | `curl -fsSL https://www.codebuddy.cn/cli/install.sh \| bash` |
+| macOS | brew | `brew install Tencent-CodeBuddy/tap/codebuddy-code` |
+| Linux | bun | `bun add -g @tencent-ai/codebuddy-code` |
+| Linux | npm | `npm install -g @tencent-ai/codebuddy-code` |
+| Linux | script | `curl -fsSL https://www.codebuddy.cn/cli/install.sh \| bash` |
+| Linux | brew | `brew install Tencent-CodeBuddy/tap/codebuddy-code` |
+| Windows | bun | `bun add -g @tencent-ai/codebuddy-code` |
+| Windows | npm | `npm install -g @tencent-ai/codebuddy-code` |
+| Windows | script | `irm https://www.codebuddy.cn/cli/install.ps1 \| iex` |
+
+The native script channel is documented upstream as a beta install path, but it is still an official installation method and works with the documented `codebuddy update` lifecycle.
+
+## Version probe
+
+`codebuddy --version` — documented upstream as the verification command after installation.
+
+## Self-update
+
+`codebuddy update` — documented upstream as the built-in command that detects the existing install method and updates accordingly.
+
+## Files changed
+
+- `src/agents/definitions/codebuddy.ts` — new file
+- `src/agents/index.ts` — register import, array entry, and re-export
+- `src/index.ts` — re-export CodeBuddy from the package root
+- `test/agents.test.ts` — add registry, install-method, version-probe, and alias coverage
+- `test/index.test.ts` — add root-export and lookup coverage
+- `openspec/specs/agent-catalog/spec.md` — add CodeBuddy requirement section
+- `README.md`, `README.zh-CN.md` — add CodeBuddy to static supported-agent tables

--- a/openspec/changes/add-codebuddy-cli-support/proposal.md
+++ b/openspec/changes/add-codebuddy-cli-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+CodeBuddy Code is an officially documented AI coding CLI with stable install, version, and update commands, but Quantex does not yet recognize it as a supported lifecycle agent. Users who install CodeBuddy today cannot use `quantex install codebuddy`, `quantex inspect codebuddy`, or `quantex update codebuddy` through the same catalog contract as the rest of the supported agent set.
+
+## What Changes
+
+- Add a CodeBuddy agent definition with lifecycle metadata: canonical slug, lookup alias, homepage, npm package metadata, binary name, install methods, version probe, and self-update command.
+- Register CodeBuddy through the built-in agent catalog and root exports so existing lookup, install, ensure, inspect, resolve, exec, and update surfaces can use it.
+- Update the agent-catalog OpenSpec contract and the static supported-agent README tables so product-facing references match the expanded CLI surface.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add CodeBuddy Code as a supported lifecycle agent with verified install, version-probe, lookup, and update metadata.
+
+## Impact
+
+- `src/agents/definitions/codebuddy.ts` — new lifecycle metadata definition
+- `src/agents/index.ts` — register import, array entry, and re-export
+- `src/index.ts` — re-export the built-in CodeBuddy definition from the root surface
+- `test/agents.test.ts`, `test/index.test.ts` — registry and export coverage
+- `openspec/specs/agent-catalog/spec.md` — add the CodeBuddy requirement
+- `README.md`, `README.zh-CN.md` — keep static supported-agent tables aligned with the current CLI surface

--- a/openspec/changes/add-codebuddy-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-codebuddy-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,32 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: CodeBuddy Code MUST be a supported lifecycle agent
+
+Quantex SHALL include CodeBuddy Code in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up CodeBuddy Code
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `codebuddy` or the alias `codebuddy-code`
+- **THEN** Quantex returns a supported agent entry for CodeBuddy Code
+- **AND** the entry identifies `codebuddy` as the executable binary
+- **AND** the entry identifies `@tencent-ai/codebuddy-code` as its npm package metadata
+- **AND** the entry identifies `https://www.codebuddy.cn/docs/cli/installation` as the homepage
+
+#### Scenario: Installing CodeBuddy Code through supported methods
+
+- **WHEN** Quantex renders or executes install options for CodeBuddy Code
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official Homebrew tap formula and curl installer options
+- **AND** Windows includes the official PowerShell installer option
+
+#### Scenario: Probing CodeBuddy Code version
+
+- **WHEN** Quantex probes the installed version of CodeBuddy Code
+- **THEN** it runs `codebuddy --version` and parses the output
+
+#### Scenario: Planning CodeBuddy Code updates
+
+- **WHEN** Quantex plans an update for a CodeBuddy Code installation that supports self-update
+- **THEN** the catalog exposes `codebuddy update` as the agent self-update command

--- a/openspec/changes/add-codebuddy-cli-support/tasks.md
+++ b/openspec/changes/add-codebuddy-cli-support/tasks.md
@@ -1,0 +1,16 @@
+# Tasks: Add CodeBuddy agent support
+
+## 1. OpenSpec and docs
+
+- [x] 1.1 Add the proposal, design, tasks, and `agent-catalog` spec delta for CodeBuddy support.
+- [x] 1.2 Update the static supported-agent tables in `README.md` and `README.zh-CN.md`.
+
+## 2. Catalog implementation
+
+- [x] 2.1 Create `src/agents/definitions/codebuddy.ts` with verified lifecycle metadata.
+- [x] 2.2 Register and re-export CodeBuddy through `src/agents/index.ts` and `src/index.ts`.
+- [x] 2.3 Add test coverage for CodeBuddy lookup aliases, install methods, version probe, and root exports.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.

--- a/openspec/changes/add-junie-agent-support/.openspec.yaml
+++ b/openspec/changes/add-junie-agent-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-junie-agent-support/design.md
+++ b/openspec/changes/add-junie-agent-support/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Junie CLI is distributed by JetBrains through multiple upstream channels: an npm package (`@jetbrains/junie`), platform install scripts, and a Homebrew tap for macOS/Linux. The official CLI reference documents `junie --version` and automated update checks (`--skip-update-check`, `auto-update` config), but it does not document a dedicated `junie update` style command.
+
+Quantex already models similar agents with a single catalog entry that carries the lifecycle metadata used by install, inspect, resolve, exec, and update planning. Junie support should fit that existing shape without adding product-specific command exceptions.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add Junie as a supported Quantex lifecycle agent with verified upstream metadata.
+- Prefer install methods that preserve Quantex's managed-update behavior when the user installs through npm or Bun.
+- Preserve official script and Homebrew paths so human-facing guidance and fallback installs stay aligned with upstream documentation.
+
+**Non-Goals:**
+
+- Add Junie-specific runtime behaviors beyond catalog metadata.
+- Implement a synthetic self-update command when upstream does not document one.
+- Model Junie's GitHub Action, ACP mode, or IDE-specific workflows in this change.
+
+## Decisions
+
+### 1. Use `junie` as both the canonical slug and executable name
+
+The upstream binary command is `junie`, and it is specific enough to serve as the Quantex-facing identifier without aliases or branding exceptions.
+
+### 2. Expose Bun and npm managed installs on all platforms, plus official scripts and Homebrew where documented
+
+Junie publishes the `@jetbrains/junie` package on npm, so Quantex can support both npm and Bun managed installs consistently with other package-backed agents. On macOS and Linux, the catalog also keeps the official shell installer and the Homebrew tap formula. On Windows, the catalog keeps the official PowerShell install script.
+
+Using managed methods first preserves stronger Quantex lifecycle behavior for installs performed through `quantex install junie`, while still keeping the upstream script paths available for users who prefer them.
+
+### 3. Record a version probe but no self-update command
+
+The CLI reference documents `junie --version`, so Quantex should use that as the explicit version probe. Upstream documentation describes automated update checks and configuration flags, not a dedicated update subcommand, so the catalog should omit `selfUpdate` rather than inventing one.
+
+### 4. Use the explicit Homebrew tap formula identifier in the catalog
+
+JetBrains documentation and repository text currently show slightly different Homebrew tap wording, but the public tap repository exists at `jetbrains-junie/homebrew-junie`. Quantex should record the install target as `jetbrains-junie/junie/junie`, which maps directly to a brew-installable formula path and avoids needing separate tap-state assumptions in the catalog.
+
+## Risks / Trade-offs
+
+- [Users may expect script-first installs because JetBrains quickstart leads with scripts] -> Keep the official scripts in the catalog and document managed installs as additional supported lifecycle paths.
+- [Script-installed Junie remains outside Quantex-managed update flows] -> Omit a fake self-update command and rely on Junie's documented automatic update-check behavior.
+- [Homebrew naming could drift upstream again] -> Store the fully qualified tap formula path and keep the agent-catalog spec tied to the currently resolvable upstream tap repository.

--- a/openspec/changes/add-junie-agent-support/proposal.md
+++ b/openspec/changes/add-junie-agent-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+This request changes the supported agent catalog, install metadata, and version-probe behavior, so it requires an OpenSpec-backed change before implementation. Junie CLI is now publicly documented by JetBrains across terminal, IDE, and CI workflows, but Quantex cannot currently install, inspect, or launch it as a first-class lifecycle agent.
+
+## What Changes
+
+- Add a Junie CLI agent definition with verified lifecycle metadata: canonical slug, display name, homepage, npm package metadata, executable name, install methods, and version probe.
+- Register Junie in the runtime agent catalog and root exports so lookup, inspection, resolution, and execution surfaces can use it.
+- Extend the agent-catalog contract with a Junie requirement that records the supported install paths and the lack of a dedicated self-update command.
+- Refresh the product README agent tables so the documented supported-agent list matches the actual catalog after adding Junie.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add Junie CLI as a supported lifecycle agent with verified install methods and version-probe behavior.
+
+## Impact
+
+- `src/agents/definitions/junie.ts` - new Junie catalog entry
+- `src/agents/index.ts` and `src/index.ts` - register and re-export Junie
+- `test/agents.test.ts` and `test/index.test.ts` - verify Junie metadata and exports
+- `openspec/specs/agent-catalog/spec.md` - add the Junie requirement
+- `README.md` and `README.zh-CN.md` - sync supported-agent tables with the current catalog

--- a/openspec/changes/add-junie-agent-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-junie-agent-support/specs/agent-catalog/spec.md
@@ -1,0 +1,32 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Junie CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Junie CLI (by JetBrains) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Junie CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `junie`
+- **THEN** Quantex returns a supported agent entry for Junie CLI
+- **AND** the entry identifies `junie` as the executable binary
+- **AND** the entry identifies `@jetbrains/junie` as its npm package metadata
+- **AND** the entry identifies `https://junie.jetbrains.com/docs/junie-cli.html` as the homepage
+
+#### Scenario: Installing Junie CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Junie CLI
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official curl install script option and the Homebrew tap formula install method (`jetbrains-junie/junie/junie`)
+- **AND** Windows includes the official PowerShell install script option (`iex (irm 'https://junie.jetbrains.com/install.ps1')`)
+
+#### Scenario: Probing Junie CLI version
+
+- **WHEN** Quantex probes the installed version of Junie CLI
+- **THEN** it runs `junie --version` and parses the output
+
+#### Scenario: Planning Junie CLI updates
+
+- **WHEN** Quantex plans an update for a Junie CLI installation
+- **THEN** the catalog does not expose a self-update command because upstream documentation describes automated update checks rather than a dedicated update subcommand

--- a/openspec/changes/add-junie-agent-support/tasks.md
+++ b/openspec/changes/add-junie-agent-support/tasks.md
@@ -1,0 +1,19 @@
+## 1. Catalog Support
+
+- [x] 1.1 Add `src/agents/definitions/junie.ts` with verified Junie lifecycle metadata.
+- [x] 1.2 Register Junie in `src/agents/index.ts` and `src/index.ts`.
+- [x] 1.3 Add the Junie requirement to `openspec/specs/agent-catalog/spec.md`.
+
+## 2. Tests And Docs
+
+- [x] 2.1 Add or update automated tests for Junie metadata and root exports.
+- [x] 2.2 Sync `README.md` and `README.zh-CN.md` supported-agent tables with the implemented catalog.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.
+- [x] 3.6 Run `bun run memory:check`.

--- a/openspec/changes/add-mistral-vibe-agent/.openspec.yaml
+++ b/openspec/changes/add-mistral-vibe-agent/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-mistral-vibe-agent/design.md
+++ b/openspec/changes/add-mistral-vibe-agent/design.md
@@ -1,0 +1,46 @@
+# Design: Add Mistral Vibe agent support
+
+## Context
+
+Quantex's current install model supports managed package managers (`bun`, `npm`, `brew`, `winget`) plus unmanaged `script` and `binary` commands. Mistral Vibe is distributed as a Python CLI with official shell-install guidance for macOS/Linux and direct `uv` / `pip` install commands.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add Mistral Vibe to the supported agent catalog without changing Quantex's installer abstraction.
+- Support the upstream executable and the package-style name users are likely to search for.
+- Record install and version metadata using only upstream-documented behavior.
+
+**Non-Goals:**
+
+- Adding a first-class `uv` or `pip` managed installer type.
+- Inventing a manual self-update command that upstream does not document.
+- Expanding unrelated agent catalog entries beyond README synchronization.
+
+## Decisions
+
+- Use `vibe` as the canonical Quantex slug so the shortcut surface matches the upstream executable.
+- Add `mistral-vibe` as a lookup alias so package-name-oriented lookups also resolve correctly.
+- Use `vibe` as the binary name and `vibe --version` as the version probe. Upstream source defines `-v` / `--version` through the argparse entrypoint.
+- Model the official macOS/Linux install script as an unmanaged `script` method: `curl -LsSf https://mistral.ai/vibe/install.sh | bash`.
+- Model `uv tool install mistral-vibe` and `pip install mistral-vibe` as unmanaged `binary` install methods, because Quantex already supports direct command execution for unmanaged installers.
+- On Windows, expose the direct `uv` and `pip` install commands instead of a shell script path, because upstream Windows guidance points users to install via `uv`.
+- Do not expose a `selfUpdate` command. Upstream documentation describes built-in auto-update behavior and configuration, but does not document a dedicated CLI update subcommand.
+
+## Risks / Trade-offs
+
+- [Managed lifecycle gap] `uv` and `pip` installs remain unmanaged in Quantex, so latest-version lookup and managed update planning are unavailable. This matches the current installer model and avoids inventing unsupported update semantics.
+- [Naming ambiguity] `vibe` is shorter than the package name `mistral-vibe`. Adding the package name as a lookup alias keeps user input flexible while preserving a concise command surface.
+- [README drift] The supported-agent tables were already behind the registry. Updating them in this change prevents further catalog/doc divergence.
+
+## Migration Plan
+
+- Add the `vibe` agent definition and register it in the catalog.
+- Add tests for `vibe` lookup, alias resolution, install methods, and version probing.
+- Sync the English and Simplified Chinese README supported-agent tables with the current registry.
+- Validate with lint, format check, typecheck, tests, and OpenSpec validation.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/add-mistral-vibe-agent/proposal.md
+++ b/openspec/changes/add-mistral-vibe-agent/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Quantex does not yet support Mistral Vibe even though Mistral now documents official terminal install paths and a standard `vibe` executable. Users should be able to install, inspect, resolve, and run Mistral Vibe through the same lifecycle surface they already use for other coding-agent CLIs.
+
+This request is OpenSpec-scoped because it changes supported agent catalog metadata and updates product-facing supported-agent documentation.
+
+## What Changes
+
+- Add a supported Mistral Vibe catalog entry with canonical lookup, official install methods, and a version probe.
+- Register the new agent in the runtime registry and add verification coverage for lookup and install metadata.
+- Sync the product README supported-agent tables so they reflect the current catalog and include Mistral Vibe.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-catalog`: Add Mistral Vibe as a supported lifecycle agent with official install methods, lookup alias, and version probing.
+
+## Impact
+
+- `src/agents/definitions/vibe.ts` — new Mistral Vibe agent definition
+- `src/agents/index.ts` — register the new catalog entry
+- `test/agents.test.ts`, `test/index.test.ts` — verify lookup and install metadata
+- `README.md`, `README.zh-CN.md` — update supported-agent tables
+- `openspec/changes/add-mistral-vibe-agent/specs/agent-catalog/spec.md` — record the catalog contract delta

--- a/openspec/changes/add-mistral-vibe-agent/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-mistral-vibe-agent/specs/agent-catalog/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Mistral Vibe MUST be a supported lifecycle agent
+
+Quantex SHALL include Mistral Vibe in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, and stable identification.
+
+#### Scenario: Looking up Mistral Vibe
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `vibe` or the alias `mistral-vibe`
+- **THEN** Quantex returns a supported agent entry for Mistral Vibe
+- **AND** the entry identifies `vibe` as the executable binary
+- **AND** the entry identifies `https://docs.mistral.ai/mistral-vibe/terminal/install` as the homepage
+
+#### Scenario: Installing Mistral Vibe through supported methods
+
+- **WHEN** Quantex renders or executes install options for Mistral Vibe
+- **THEN** macOS and Linux include the official shell installer option (`curl -LsSf https://mistral.ai/vibe/install.sh | bash`)
+- **AND** macOS, Linux, and Windows include direct `uv` and `pip` install command options for `mistral-vibe`
+
+#### Scenario: Probing Mistral Vibe version
+
+- **WHEN** Quantex probes the installed version of Mistral Vibe
+- **THEN** it runs `vibe --version` and parses the output
+
+#### Scenario: Planning Mistral Vibe updates
+
+- **WHEN** Quantex plans an update for a Mistral Vibe installation
+- **THEN** the catalog does not expose a self-update command because upstream documentation currently describes automatic update behavior rather than a dedicated manual update subcommand

--- a/openspec/changes/add-mistral-vibe-agent/tasks.md
+++ b/openspec/changes/add-mistral-vibe-agent/tasks.md
@@ -1,0 +1,15 @@
+## 1. OpenSpec And Docs
+
+- [x] 1.1 Write the proposal, design, and catalog spec delta for Mistral Vibe support
+- [x] 1.2 Sync the product README supported-agent tables with the current catalog, including Mistral Vibe
+
+## 2. Catalog Implementation
+
+- [x] 2.1 Add `src/agents/definitions/vibe.ts` with official install methods, alias resolution, and version probing
+- [x] 2.2 Register Mistral Vibe in `src/agents/index.ts`
+- [x] 2.3 Add lookup and install-metadata coverage for Mistral Vibe in the agent registry tests
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, and `bun run typecheck`
+- [x] 3.2 Run `bun run test` and `bun run openspec:validate`

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -169,6 +169,35 @@ Quantex SHALL include Goose (by Block) in the supported agent catalog with lifec
 - **WHEN** Quantex plans an update for a Goose installation that supports self-update
 - **THEN** the catalog exposes `goose update` as the agent self-update command
 
+### Requirement: Junie CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Junie CLI (by JetBrains) in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Junie CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `junie`
+- **THEN** Quantex returns a supported agent entry for Junie CLI
+- **AND** the entry identifies `junie` as the executable binary
+- **AND** the entry identifies `@jetbrains/junie` as its npm package metadata
+- **AND** the entry identifies `https://junie.jetbrains.com/docs/junie-cli.html` as the homepage
+
+#### Scenario: Installing Junie CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Junie CLI
+- **THEN** the catalog includes npm-compatible and bun-compatible managed install methods on all platforms
+- **AND** macOS and Linux include the official curl install script option and the Homebrew tap formula install method (`jetbrains-junie/junie/junie`)
+- **AND** Windows includes the official PowerShell install script option (`iex (irm 'https://junie.jetbrains.com/install.ps1')`)
+
+#### Scenario: Probing Junie CLI version
+
+- **WHEN** Quantex probes the installed version of Junie CLI
+- **THEN** it runs `junie --version` and parses the output
+
+#### Scenario: Planning Junie CLI updates
+
+- **WHEN** Quantex plans an update for a Junie CLI installation
+- **THEN** the catalog does not expose a self-update command because upstream documentation describes automated update checks rather than a dedicated update subcommand
+
 ### Requirement: Kilo CLI MUST use the current supported display name
 
 Quantex SHALL expose the Kilo catalog entry with the display name `Kilo CLI` while keeping the canonical agent slug `kilo`.

--- a/src/agents/definitions/auggie.ts
+++ b/src/agents/definitions/auggie.ts
@@ -1,0 +1,22 @@
+import type { AgentDefinition } from '../types'
+import { bunInstall, npmInstall } from '../methods'
+
+export const auggie: AgentDefinition = {
+  name: 'auggie',
+  displayName: 'Auggie CLI',
+  homepage: 'https://docs.augmentcode.com/cli/overview',
+  packages: {
+    npm: '@augmentcode/auggie',
+  },
+  binaryName: 'auggie',
+  selfUpdate: {
+    command: ['auggie', 'upgrade'],
+  },
+  versionProbe: {
+    command: ['auggie', '--version'],
+  },
+  platforms: {
+    macos: [bunInstall(), npmInstall()],
+    linux: [bunInstall(), npmInstall()],
+  },
+}

--- a/src/agents/definitions/codebuddy.ts
+++ b/src/agents/definitions/codebuddy.ts
@@ -1,0 +1,34 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, bunInstall, npmInstall, scriptInstall } from '../methods'
+
+export const codebuddy: AgentDefinition = {
+  name: 'codebuddy',
+  lookupAliases: ['codebuddy-code'],
+  displayName: 'CodeBuddy Code',
+  homepage: 'https://www.codebuddy.cn/docs/cli/installation',
+  packages: {
+    npm: '@tencent-ai/codebuddy-code',
+  },
+  binaryName: 'codebuddy',
+  selfUpdate: {
+    command: ['codebuddy', 'update'],
+  },
+  versionProbe: {
+    command: ['codebuddy', '--version'],
+  },
+  platforms: {
+    windows: [bunInstall(), npmInstall(), scriptInstall('irm https://www.codebuddy.cn/cli/install.ps1 | iex')],
+    macos: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://www.codebuddy.cn/cli/install.sh | bash'),
+      brewInstall('Tencent-CodeBuddy/tap/codebuddy-code'),
+    ],
+    linux: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://www.codebuddy.cn/cli/install.sh | bash'),
+      brewInstall('Tencent-CodeBuddy/tap/codebuddy-code'),
+    ],
+  },
+}

--- a/src/agents/definitions/junie.ts
+++ b/src/agents/definitions/junie.ts
@@ -1,0 +1,30 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, bunInstall, npmInstall, scriptInstall } from '../methods'
+
+export const junie: AgentDefinition = {
+  name: 'junie',
+  displayName: 'Junie CLI',
+  homepage: 'https://junie.jetbrains.com/docs/junie-cli.html',
+  packages: {
+    npm: '@jetbrains/junie',
+  },
+  binaryName: 'junie',
+  versionProbe: {
+    command: ['junie', '--version'],
+  },
+  platforms: {
+    windows: [bunInstall(), npmInstall(), scriptInstall("iex (irm 'https://junie.jetbrains.com/install.ps1')")],
+    macos: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://junie.jetbrains.com/install.sh | bash'),
+      brewInstall('jetbrains-junie/junie/junie'),
+    ],
+    linux: [
+      bunInstall(),
+      npmInstall(),
+      scriptInstall('curl -fsSL https://junie.jetbrains.com/install.sh | bash'),
+      brewInstall('jetbrains-junie/junie/junie'),
+    ],
+  },
+}

--- a/src/agents/definitions/vibe.ts
+++ b/src/agents/definitions/vibe.ts
@@ -1,0 +1,26 @@
+import type { AgentDefinition } from '../types'
+import { binaryInstall, scriptInstall } from '../methods'
+
+export const vibe: AgentDefinition = {
+  name: 'vibe',
+  lookupAliases: ['mistral-vibe'],
+  displayName: 'Mistral Vibe',
+  homepage: 'https://docs.mistral.ai/mistral-vibe/terminal/install',
+  binaryName: 'vibe',
+  versionProbe: {
+    command: ['vibe', '--version'],
+  },
+  platforms: {
+    windows: [binaryInstall('uv tool install mistral-vibe'), binaryInstall('pip install mistral-vibe')],
+    macos: [
+      scriptInstall('curl -LsSf https://mistral.ai/vibe/install.sh | bash'),
+      binaryInstall('uv tool install mistral-vibe'),
+      binaryInstall('pip install mistral-vibe'),
+    ],
+    linux: [
+      scriptInstall('curl -LsSf https://mistral.ai/vibe/install.sh | bash'),
+      binaryInstall('uv tool install mistral-vibe'),
+      binaryInstall('pip install mistral-vibe'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -16,6 +16,7 @@ import { opencode } from './definitions/opencode'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
+import { vibe } from './definitions/vibe'
 
 const agents: AgentDefinition[] = [
   amp,
@@ -35,6 +36,7 @@ const agents: AgentDefinition[] = [
   pi,
   qoder,
   qwen,
+  vibe,
 ]
 
 export function getAllAgents(): AgentDefinition[] {
@@ -67,6 +69,7 @@ export {
   pi,
   qoder,
   qwen,
+  vibe,
 }
 export type {
   AgentDefinition,

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,6 +1,7 @@
 import type { AgentDefinition } from './types'
 import { amp } from './definitions/amp'
 import { claude } from './definitions/claude'
+import { codebuddy } from './definitions/codebuddy'
 import { codex } from './definitions/codex'
 import { copilot } from './definitions/copilot'
 import { crush } from './definitions/crush'
@@ -21,6 +22,7 @@ import { vibe } from './definitions/vibe'
 const agents: AgentDefinition[] = [
   amp,
   claude,
+  codebuddy,
   codex,
   copilot,
   crush,
@@ -29,8 +31,8 @@ const agents: AgentDefinition[] = [
   forgecode,
   gemini,
   goose,
-  kimi,
   kilo,
+  kimi,
   kiro,
   opencode,
   pi,
@@ -54,6 +56,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
 export {
   amp,
   claude,
+  codebuddy,
   codex,
   copilot,
   crush,
@@ -62,8 +65,8 @@ export {
   forgecode,
   gemini,
   goose,
-  kimi,
   kilo,
+  kimi,
   kiro,
   opencode,
   pi,

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,5 +1,6 @@
 import type { AgentDefinition } from './types'
 import { amp } from './definitions/amp'
+import { auggie } from './definitions/auggie'
 import { claude } from './definitions/claude'
 import { codebuddy } from './definitions/codebuddy'
 import { codex } from './definitions/codex'
@@ -20,6 +21,7 @@ import { qwen } from './definitions/qwen'
 import { vibe } from './definitions/vibe'
 
 const agents: AgentDefinition[] = [
+  auggie,
   amp,
   claude,
   codebuddy,
@@ -54,6 +56,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
 }
 
 export {
+  auggie,
   amp,
   claude,
   codebuddy,

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -11,6 +11,7 @@ import { droid } from './definitions/droid'
 import { forgecode } from './definitions/forgecode'
 import { gemini } from './definitions/gemini'
 import { goose } from './definitions/goose'
+import { junie } from './definitions/junie'
 import { kilo } from './definitions/kilo'
 import { kimi } from './definitions/kimi'
 import { kiro } from './definitions/kiro'
@@ -33,6 +34,7 @@ const agents: AgentDefinition[] = [
   forgecode,
   gemini,
   goose,
+  junie,
   kilo,
   kimi,
   kiro,
@@ -68,6 +70,7 @@ export {
   forgecode,
   gemini,
   goose,
+  junie,
   kilo,
   kimi,
   kiro,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
   opencode,
   pi,
   qoder,
+  vibe,
 } from './agents'
 export type {
   AgentDefinition,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   getAgentByLookupName,
   getAgentByNameOrAlias,
   getAllAgents,
+  junie,
   kilo,
   opencode,
   pi,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
 export type { AgentUpdateContext, AgentUpdateProvider, AgentUpdateStrategy } from './agent-update'
 export {
   claude,
+  codebuddy,
   codex,
   copilot,
   cursor,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -2,6 +2,7 @@ import type { AgentDefinition } from '../src/agents/types'
 import { describe, expect, it } from 'vitest'
 import { getAgentByLookupName, getAgentByNameOrAlias, getAllAgents } from '../src/agents'
 import { claude } from '../src/agents/definitions/claude'
+import { codebuddy } from '../src/agents/definitions/codebuddy'
 import { codex } from '../src/agents/definitions/codex'
 import { copilot } from '../src/agents/definitions/copilot'
 import { cursor } from '../src/agents/definitions/cursor'
@@ -114,6 +115,54 @@ describe('codex', () => {
     expect(codex.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'codex')).toBeDefined()
     expect(codex.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'codex')).toBeDefined()
     expect(codex.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('codebuddy', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('codebuddy')).toBe(codebuddy)
+  })
+
+  it('is registered for lookup by package-style alias', () => {
+    expect(getAgentByNameOrAlias('codebuddy-code')).toBe(codebuddy)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(codebuddy)
+    expect(codebuddy.name).toBe('codebuddy')
+    expect(codebuddy.lookupAliases).toEqual(['codebuddy-code'])
+    expect(codebuddy.displayName).toBe('CodeBuddy Code')
+    expect(codebuddy.packages?.npm).toBe('@tencent-ai/codebuddy-code')
+    expect(codebuddy.binaryName).toBe('codebuddy')
+    expect(codebuddy.homepage).toBe('https://www.codebuddy.cn/docs/cli/installation')
+    expect(codebuddy.selfUpdate?.command).toEqual(['codebuddy', 'update'])
+    expect(codebuddy.versionProbe?.command).toEqual(['codebuddy', '--version'])
+  })
+
+  it('script install returns correct strings per platform', () => {
+    expect(
+      codebuddy.platforms.windows!.find(m => m.type === 'script' && m.command.includes('codebuddy.cn/cli/install.ps1')),
+    ).toBeDefined()
+    expect(
+      codebuddy.platforms.macos!.find(m => m.type === 'script' && m.command.includes('codebuddy.cn/cli/install.sh')),
+    ).toBeDefined()
+    expect(
+      codebuddy.platforms.linux!.find(m => m.type === 'script' && m.command.includes('codebuddy.cn/cli/install.sh')),
+    ).toBeDefined()
+  })
+
+  it('brew install returns correct strings per platform', () => {
+    expect(
+      codebuddy.platforms.macos!.find(
+        m => m.type === 'brew' && m.packageName === 'Tencent-CodeBuddy/tap/codebuddy-code',
+      ),
+    ).toBeDefined()
+    expect(
+      codebuddy.platforms.linux!.find(
+        m => m.type === 'brew' && m.packageName === 'Tencent-CodeBuddy/tap/codebuddy-code',
+      ),
+    ).toBeDefined()
+    expect(codebuddy.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
   })
 })
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -9,6 +9,7 @@ import { copilot } from '../src/agents/definitions/copilot'
 import { cursor } from '../src/agents/definitions/cursor'
 import { droid } from '../src/agents/definitions/droid'
 import { gemini } from '../src/agents/definitions/gemini'
+import { junie } from '../src/agents/definitions/junie'
 import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
 import { pi } from '../src/agents/definitions/pi'
@@ -285,6 +286,41 @@ describe('gemini', () => {
     expect(gemini.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'gemini-cli')).toBeDefined()
     expect(gemini.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'gemini-cli')).toBeDefined()
     expect(gemini.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('junie', () => {
+  it('has valid structure', () => {
+    validateAgent(junie)
+    expect(junie.name).toBe('junie')
+    expect(junie.lookupAliases).toBeUndefined()
+    expect(junie.displayName).toBe('Junie CLI')
+    expect(junie.packages?.npm).toBe('@jetbrains/junie')
+    expect(junie.binaryName).toBe('junie')
+    expect(junie.homepage).toBe('https://junie.jetbrains.com/docs/junie-cli.html')
+    expect(junie.selfUpdate).toBeUndefined()
+    expect(junie.versionProbe?.command).toEqual(['junie', '--version'])
+  })
+
+  it('supports managed installs on all platforms plus official script and brew paths', () => {
+    expect(junie.platforms.windows!.find(m => m.type === 'bun')).toBeDefined()
+    expect(junie.platforms.windows!.find(m => m.type === 'npm')).toBeDefined()
+    expect(
+      junie.platforms.windows!.find(m => m.type === 'script' && m.command.includes('junie.jetbrains.com/install.ps1')),
+    ).toBeDefined()
+
+    expect(
+      junie.platforms.macos!.find(m => m.type === 'script' && m.command.includes('junie.jetbrains.com/install.sh')),
+    ).toBeDefined()
+    expect(
+      junie.platforms.linux!.find(m => m.type === 'script' && m.command.includes('junie.jetbrains.com/install.sh')),
+    ).toBeDefined()
+    expect(
+      junie.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'jetbrains-junie/junie/junie'),
+    ).toBeDefined()
+    expect(
+      junie.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'jetbrains-junie/junie/junie'),
+    ).toBeDefined()
   })
 })
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -12,6 +12,7 @@ import { opencode } from '../src/agents/definitions/opencode'
 import { pi } from '../src/agents/definitions/pi'
 import { qoder } from '../src/agents/definitions/qoder'
 import { qwen } from '../src/agents/definitions/qwen'
+import { vibe } from '../src/agents/definitions/vibe'
 import { formatInstallMethodCommand } from '../src/utils/install'
 
 describe('agent registry', () => {
@@ -369,6 +370,40 @@ describe('qwen', () => {
     expect(qwen.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'qwen-code')).toBeDefined()
     expect(qwen.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'qwen-code')).toBeDefined()
     expect(qwen.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('vibe', () => {
+  it('is registered for lookup by canonical name and package alias', () => {
+    expect(getAgentByNameOrAlias('vibe')).toBe(vibe)
+    expect(getAgentByNameOrAlias('mistral-vibe')).toBe(vibe)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(vibe)
+    expect(vibe.name).toBe('vibe')
+    expect(vibe.lookupAliases).toEqual(['mistral-vibe'])
+    expect(vibe.displayName).toBe('Mistral Vibe')
+    expect(vibe.binaryName).toBe('vibe')
+    expect(vibe.homepage).toBe('https://docs.mistral.ai/mistral-vibe/terminal/install')
+    expect(vibe.versionProbe?.command).toEqual(['vibe', '--version'])
+    expect(vibe.selfUpdate).toBeUndefined()
+  })
+
+  it('exposes official install methods per platform', () => {
+    expect(
+      vibe.platforms.macos!.find(m => m.type === 'script' && m.command.includes('https://mistral.ai/vibe/install.sh')),
+    ).toBeDefined()
+    expect(
+      vibe.platforms.linux!.find(m => m.type === 'script' && m.command.includes('https://mistral.ai/vibe/install.sh')),
+    ).toBeDefined()
+
+    for (const methods of Object.values(vibe.platforms)) {
+      expect(methods!.find(m => m.type === 'binary' && m.command === 'uv tool install mistral-vibe')).toBeDefined()
+      expect(methods!.find(m => m.type === 'binary' && m.command === 'pip install mistral-vibe')).toBeDefined()
+    }
+
+    expect(vibe.platforms.windows!.find(m => m.type === 'script')).toBeUndefined()
   })
 })
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -1,6 +1,7 @@
 import type { AgentDefinition } from '../src/agents/types'
 import { describe, expect, it } from 'vitest'
 import { getAgentByLookupName, getAgentByNameOrAlias, getAllAgents } from '../src/agents'
+import { auggie } from '../src/agents/definitions/auggie'
 import { claude } from '../src/agents/definitions/claude'
 import { codebuddy } from '../src/agents/definitions/codebuddy'
 import { codex } from '../src/agents/definitions/codex'
@@ -67,6 +68,32 @@ function validateAgent(agent: AgentDefinition): void {
     }
   }
 }
+
+describe('auggie', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('auggie')).toBe(auggie)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(auggie)
+    expect(auggie.name).toBe('auggie')
+    expect(auggie.lookupAliases).toBeUndefined()
+    expect(auggie.displayName).toBe('Auggie CLI')
+    expect(auggie.packages?.npm).toBe('@augmentcode/auggie')
+    expect(auggie.binaryName).toBe('auggie')
+    expect(auggie.homepage).toBe('https://docs.augmentcode.com/cli/overview')
+    expect(auggie.selfUpdate?.command).toEqual(['auggie', 'upgrade'])
+    expect(auggie.versionProbe?.command).toEqual(['auggie', '--version'])
+  })
+
+  it('supports bun and npm installs on macOS and Linux only', () => {
+    expect(auggie.platforms.macos!.find(m => m.type === 'bun')).toBeDefined()
+    expect(auggie.platforms.macos!.find(m => m.type === 'npm')).toBeDefined()
+    expect(auggie.platforms.linux!.find(m => m.type === 'bun')).toBeDefined()
+    expect(auggie.platforms.linux!.find(m => m.type === 'npm')).toBeDefined()
+    expect(auggie.platforms.windows).toBeUndefined()
+  })
+})
 
 describe('claude', () => {
   it('has valid structure', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -38,6 +38,11 @@ describe('agent registry', () => {
     expect(agent?.name).toBe('cursor')
   })
 
+  it('resolves Mistral Vibe by package alias', () => {
+    const agent = getAgentByLookupName('mistral-vibe')
+    expect(agent?.name).toBe('vibe')
+  })
+
   it('resolves Qoder by executable alias', () => {
     const agent = getAgentByLookupName('qodercli')
     expect(agent?.name).toBe('qoder')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,7 @@ import {
   getAgentByLookupName,
   getAgentByNameOrAlias,
   getAllAgents,
+  junie,
   inspectAgent,
   kilo,
   opencode,
@@ -104,6 +105,14 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('kilo')
   })
 
+  it('junie has correct structure', () => {
+    const agent = getAgentByNameOrAlias('junie')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('Junie CLI')
+    expect(agent!.packages?.npm).toBe('@jetbrains/junie')
+    expect(agent!.binaryName).toBe('junie')
+  })
+
   it('qoder has correct structure', () => {
     const agent = getAgentByNameOrAlias('qoder')
     expect(agent).toBeDefined()
@@ -119,6 +128,7 @@ describe('agent definitions', () => {
     expect(cursor.name).toBe('cursor')
     expect(droid.name).toBe('droid')
     expect(gemini.name).toBe('gemini')
+    expect(junie.name).toBe('junie')
     expect(kilo.name).toBe('kilo')
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -23,6 +23,13 @@ describe('agent registry', () => {
     expect(agents.length).toBeGreaterThanOrEqual(9)
   })
 
+  it('finds auggie by name', () => {
+    const agent = getAgentByNameOrAlias('auggie')
+    expect(agent).toBeDefined()
+    expect(agent!.name).toBe('auggie')
+    expect(agent!.binaryName).toBe('auggie')
+  })
+
   it('finds agent by name', () => {
     const agent = getAgentByNameOrAlias('claude')
     expect(agent).toBeDefined()

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  codebuddy,
   codex,
   copilot,
   createUpdatePlan,
@@ -43,6 +44,11 @@ describe('agent registry', () => {
     expect(agent?.name).toBe('vibe')
   })
 
+  it('resolves CodeBuddy by package-style alias', () => {
+    const agent = getAgentByLookupName('codebuddy-code')
+    expect(agent?.name).toBe('codebuddy')
+  })
+
   it('resolves Qoder by executable alias', () => {
     const agent = getAgentByLookupName('qodercli')
     expect(agent?.name).toBe('qoder')
@@ -65,6 +71,14 @@ describe('agent definitions', () => {
     expect(agent!.displayName).toBe('Codex CLI')
     expect(agent!.packages?.npm).toBe('@openai/codex')
     expect(agent!.binaryName).toBe('codex')
+  })
+
+  it('codebuddy has correct structure', () => {
+    const agent = getAgentByNameOrAlias('codebuddy')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('CodeBuddy Code')
+    expect(agent!.packages?.npm).toBe('@tencent-ai/codebuddy-code')
+    expect(agent!.binaryName).toBe('codebuddy')
   })
 
   it('opencode has correct structure', () => {
@@ -92,6 +106,7 @@ describe('agent definitions', () => {
   })
 
   it('re-exports all built-in agents from root index', () => {
+    expect(codebuddy.name).toBe('codebuddy')
     expect(codex.name).toBe('codex')
     expect(copilot.name).toBe('copilot')
     expect(cursor.name).toBe('cursor')

--- a/test/utils/version.test.ts
+++ b/test/utils/version.test.ts
@@ -73,6 +73,15 @@ describe('getInstalledVersion', () => {
     expect(version).toBe('0.118.0')
   })
 
+  it('extracts version from commit-suffixed output', async () => {
+    const { getInstalledVersion } = await import('../../src/utils/version')
+    mockSpawn.mockReturnValue(createMockProcess(0, '0.25.0 (commit b7668abc)\n'))
+    const version = await getInstalledVersion('auggie', {
+      command: ['auggie', '--version'],
+    })
+    expect(version).toBe('0.25.0')
+  })
+
   it('extracts version from multi-line output (first line)', async () => {
     const { getInstalledVersion } = await import('../../src/utils/version')
     mockSpawn.mockReturnValue(


### PR DESCRIPTION
## Summary

Batch four supported-agent additions into one `main` merge so Quantex lands the catalog, docs, tests, and OpenSpec deltas together with a single release cycle:

- CodeBuddy Code
- Auggie CLI
- Junie CLI
- Mistral Vibe

## Linked Artifacts

- Issue: #134
- ADR: not applicable
- OpenSpec: `add-codebuddy-cli-support`, `add-auggie-cli-support`, `add-junie-agent-support`, `add-mistral-vibe-agent`
- Discussion: not applicable

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- This PR supersedes #150, #151, and #152 so `main` only needs one merge and one release for these four agent additions.
- The branch preserves each original feature commit to keep the git history linear and easy to audit.
