### PR TITLE
feat(agents): batch terminal agent support additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Agent | Run Command | Description |
 |-------|-------------|-------------|
 | Auggie CLI | `qtx auggie` | Augment's official terminal coding agent |
+| Autohand Code CLI | `qtx autohand` | Autohand's autonomous terminal coding agent CLI |
 | Amp | `qtx amp` | Sourcegraph's frontier AI coding agent CLI |
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
 | CodeBuddy Code | `qtx codebuddy` | Tencent's official AI coding assistant CLI |
@@ -184,6 +185,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |
 | Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |
 | Mistral Vibe | `qtx vibe` | Mistral's open-source CLI coding assistant |
+| OpenHands CLI | `qtx openhands` | OpenHands' open-source software development agent CLI |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |

--- a/README.md
+++ b/README.md
@@ -185,7 +185,6 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |
 | Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |
 | Mistral Vibe | `qtx vibe` | Mistral's open-source CLI coding assistant |
-| OpenHands CLI | `qtx openhands` | OpenHands' open-source software development agent CLI |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | Crush | `qtx crush` | Charmbracelet's terminal AI coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
+| Devin for Terminal | `qtx devin` | Cognition's local coding agent CLI |
 | Droid | `qtx droid` | Factory AI software engineering agent CLI |
 | ForgeCode | `qtx forgecode` | Antinomy's AI coding assistant CLI |
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |
 | Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |
 | Mistral Vibe | `qtx vibe` | Mistral's open-source CLI coding assistant |
+| OpenHands CLI | `qtx openhands` | OpenHands' open-source software development agent CLI |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,6 +168,7 @@ qtx upgrade --channel beta
 | Agent | 启动命令 | 描述 |
 |-------|----------|------|
 | Auggie CLI | `qtx auggie` | Augment 官方终端编程 Agent CLI |
+| Autohand Code CLI | `qtx autohand` | Autohand 官方自主终端编程 Agent CLI |
 | Amp | `qtx amp` | Sourcegraph 前沿 AI 编程 Agent CLI |
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
 | CodeBuddy Code | `qtx codebuddy` | 腾讯官方 AI 编程助手 CLI |
@@ -184,6 +185,7 @@ qtx upgrade --channel beta
 | Kimi Code | `qtx kimi` | Moonshot AI 编程助手 CLI |
 | Kiro CLI | `qtx kiro` | Amazon AI 编程 Agent CLI |
 | Mistral Vibe | `qtx vibe` | Mistral 开源终端编程助手 |
+| OpenHands CLI | `qtx openhands` | OpenHands 开源软件开发 Agent CLI |
 | OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
 | Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,6 +175,7 @@ qtx upgrade --channel beta
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | Crush | `qtx crush` | Charmbracelet 终端 AI 编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
+| Devin for Terminal | `qtx devin` | Cognition 本地编程 Agent CLI |
 | Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
 | ForgeCode | `qtx forgecode` | Antinomy AI 编程助手 CLI |
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |

--- a/openspec/changes/add-autohand-code-cli-support/.openspec.yaml
+++ b/openspec/changes/add-autohand-code-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-autohand-code-cli-support/design.md
+++ b/openspec/changes/add-autohand-code-cli-support/design.md
@@ -1,0 +1,39 @@
+# Design: Add Autohand Code CLI support
+
+## Decision
+
+Add Autohand Code CLI as a script-installed lifecycle agent on Windows, macOS, and Linux, using `autohand` as the canonical Quantex slug and executable name, `autohand-cli` as a package-style lookup alias, and `autohand --version` for version probing.
+
+## Agent Definition
+
+| Field | Value |
+|---|---|
+| name | `autohand` |
+| lookupAliases | `autohand-cli` |
+| displayName | `Autohand Code CLI` |
+| homepage | `https://autohand.ai/cli/` |
+| packages | `autohand-cli` |
+| binaryName | `autohand` |
+| selfUpdate | none |
+| versionProbe | `autohand --version` |
+
+## Install Methods
+
+| Platform | Method | Command |
+|---|---|---|
+| Windows | script | `iwr -useb https://autohand.ai/install.ps1 \| iex` |
+| macOS | script | `curl -fsSL https://autohand.ai/install.sh \| bash` |
+| Linux | script | `curl -fsSL https://autohand.ai/install.sh \| bash` |
+
+## Rationale
+
+- Upstream README and installer sources document the `autohand` executable, `autohand --version`, and official shell / PowerShell installers hosted at `autohand.ai`.
+- The published package metadata uses the npm package name `autohand-cli`, so adding it as package metadata and a lookup alias helps users resolve the agent with either the executable-oriented or package-oriented spelling.
+- Although Autohand is published on npm, the upstream user-facing install docs currently center the release-binary installer scripts instead of npm/bun flows. Quantex should not advertise managed install methods that the upstream product docs are not currently treating as the primary supported lifecycle path.
+- The upstream install scripts fetch the latest release assets, but the docs do not currently expose a dedicated `autohand update` subcommand. Quantex should therefore record manual/script update behavior rather than a self-update command.
+
+## Non-Goals
+
+- Model Autohand authentication, provider setup, skill authoring, or session management behavior in Quantex metadata
+- Add managed npm or bun install methods without explicit upstream install guidance
+- Expand Quantex's catalog schema to capture installer channels, release-asset naming, or bundled ripgrep behavior

--- a/openspec/changes/add-autohand-code-cli-support/proposal.md
+++ b/openspec/changes/add-autohand-code-cli-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+This request requires OpenSpec because it changes supported agent catalog metadata and product-facing supported-agent documentation. Autohand Code CLI now publishes official cross-platform installer scripts, release binaries, and a stable `autohand` executable, but Quantex cannot currently install, inspect, or resolve it as a first-class lifecycle agent.
+
+## What Changes
+
+- Add an Autohand Code CLI agent definition with verified lifecycle metadata for lookup, installation, and version probing
+- Register Autohand in the supported agent catalog so lifecycle commands can resolve `autohand`
+- Update product-facing supported-agent tables to include Autohand and keep the catalog list in sync
+- Add an OpenSpec delta for the Autohand agent-catalog contract
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: add Autohand Code CLI as a supported lifecycle agent with canonical lookup, script installer metadata, and version-probe requirements
+
+## Impact
+
+- `src/agents/definitions/autohand.ts` - new lifecycle metadata definition
+- `src/agents/index.ts` and `src/index.ts` - register and re-export Autohand
+- `test/agents.test.ts` and `test/index.test.ts` - cover lookup, exports, and installer metadata
+- `README.md` and `README.zh-CN.md` - include Autohand in supported-agent tables
+- `openspec/changes/add-autohand-code-cli-support/specs/agent-catalog/spec.md` - record the catalog contract delta

--- a/openspec/changes/add-autohand-code-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-autohand-code-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,31 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Autohand Code CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Autohand Code CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, and stable identification.
+
+#### Scenario: Looking up Autohand Code CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `autohand` or the alias `autohand-cli`
+- **THEN** Quantex returns a supported agent entry for Autohand Code CLI
+- **AND** the entry identifies `autohand` as the executable binary
+- **AND** the entry identifies `autohand-cli` as its npm package metadata
+- **AND** the entry identifies `https://autohand.ai/cli/` as the homepage
+
+#### Scenario: Installing Autohand Code CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Autohand Code CLI
+- **THEN** macOS and Linux include the official shell installer option (`curl -fsSL https://autohand.ai/install.sh | bash`)
+- **AND** Windows includes the official PowerShell installer option (`iwr -useb https://autohand.ai/install.ps1 | iex`)
+
+#### Scenario: Probing Autohand Code CLI version
+
+- **WHEN** Quantex probes the installed version of Autohand Code CLI
+- **THEN** it runs `autohand --version` and parses the output
+
+#### Scenario: Planning Autohand Code CLI updates
+
+- **WHEN** Quantex plans an update for an Autohand Code CLI installation
+- **THEN** the catalog does not expose a self-update command because upstream documentation currently points users to installer scripts and release assets rather than a dedicated `autohand update` subcommand

--- a/openspec/changes/add-autohand-code-cli-support/tasks.md
+++ b/openspec/changes/add-autohand-code-cli-support/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Add Autohand Code CLI support
+
+## 1. OpenSpec
+
+- [x] 1.1 Add the OpenSpec proposal, design, tasks, and agent-catalog delta for Autohand Code CLI support
+
+## 2. Implementation
+
+- [x] 2.1 Create `src/agents/definitions/autohand.ts` with verified lifecycle metadata and register it in the exported agent catalog
+- [x] 2.2 Add tests covering Autohand lookup, exports, version probe metadata, and official installer commands
+- [x] 2.3 Update product-facing supported-agent tables to include Autohand and keep the catalog list synchronized
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`

--- a/openspec/changes/add-devin-cli-support/.openspec.yaml
+++ b/openspec/changes/add-devin-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-devin-cli-support/design.md
+++ b/openspec/changes/add-devin-cli-support/design.md
@@ -1,0 +1,48 @@
+## Context
+
+Devin for Terminal is distributed through official install scripts for macOS/Linux/WSL and Windows, plus a Windsurf-bundled path that is enabled separately for enterprise users. The command reference documents a stable executable name (`devin`), a version subcommand (`devin version`, equivalent to `devin --version`), and a self-update command (`devin update`).
+
+Quantex already models script-installed agents that rely on `selfUpdate` instead of managed package updates. Devin support should fit that existing lifecycle catalog shape without adding special-case product logic for Windsurf-bundled installs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add Devin as a supported Quantex lifecycle agent with verified upstream metadata.
+- Preserve the official install scripts for each platform exactly as documented upstream.
+- Expose the documented version and self-update commands so Quantex update planning can handle unmanaged Devin installs.
+
+**Non-Goals:**
+
+- Model Windsurf-bundled enablement or enterprise entitlement checks as a separate install method.
+- Add managed npm, Bun, Homebrew, or winget metadata that is not documented upstream.
+- Add Devin-specific auth, setup, MCP, or session-management behavior beyond catalog metadata.
+
+## Decisions
+
+### 1. Use `devin` as both the canonical slug and executable name
+
+The upstream CLI command is `devin`, and it is specific enough to serve as both the Quantex agent slug and the executable identifier without aliases.
+
+### 2. Record only the official script installers
+
+Upstream quickstart documentation currently publishes shell and PowerShell installers, not managed package-manager installs. Quantex should keep only those official script methods in the catalog:
+
+- macOS/Linux: `curl -fsSL https://cli.devin.ai/install.sh | bash`
+- Windows: `irm https://static.devin.ai/cli/setup.ps1 | iex`
+
+This keeps install guidance aligned with vendor documentation and avoids inventing unsupported package-manager paths.
+
+### 3. Use the documented version and update commands
+
+The command reference explicitly documents `devin version` and `devin update`. Quantex should use `devin version` as the explicit version probe and expose `devin update` as the self-update command for unmanaged installs. This matches the current Quantex update strategy, where script-installed agents can still advertise a built-in updater.
+
+### 4. Treat the Windsurf-bundled path as out of scope for install metadata
+
+The Windsurf-bundled install is a product-bundled distribution path rather than a standalone CLI installer that Quantex can execute directly. Quantex should support the `devin` binary once present on PATH, but it should not model the Windsurf entitlement flow as a separate install method.
+
+## Risks / Trade-offs
+
+- [Users may expect managed package installs because other agents support npm or brew] -> Keep the catalog limited to the official script methods that Devin actually documents today.
+- [Bundled installs may update through the parent application instead of `devin update`] -> Use the documented self-update command for standalone installs and avoid claiming Windsurf-bundled update management in the catalog contract.
+- [The version command has two documented forms] -> Use the explicit `devin version` subcommand because it is listed in the command reference and explicitly documented as equivalent to `devin --version`.

--- a/openspec/changes/add-devin-cli-support/proposal.md
+++ b/openspec/changes/add-devin-cli-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+This request changes the supported agent catalog, install metadata, and update behavior, so it requires an OpenSpec-backed change before implementation. Devin for Terminal now has official installation, version, and update documentation, but Quantex cannot yet install, inspect, or launch it as a first-class lifecycle agent.
+
+## What Changes
+
+- Add a Devin for Terminal agent definition with verified lifecycle metadata: canonical slug, display name, homepage, executable name, install methods, version probe, and self-update command.
+- Register Devin in the built-in agent catalog and root exports so existing lookup, install, ensure, inspect, resolve, exec, and update surfaces can use it.
+- Extend the agent-catalog contract with a Devin requirement that records the supported install scripts, version probe, and self-update behavior.
+- Refresh the product README supported-agent tables so the documented catalog matches the implemented CLI surface.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add Devin for Terminal as a supported lifecycle agent with verified install, version-probe, and update metadata.
+
+## Impact
+
+- `src/agents/definitions/devin.ts` - new Devin lifecycle metadata definition
+- `src/agents/index.ts` and `src/index.ts` - register and re-export Devin
+- `test/agents.test.ts` and `test/index.test.ts` - registry and export coverage
+- `openspec/specs/agent-catalog/spec.md` - add the Devin requirement
+- `README.md` and `README.zh-CN.md` - sync supported-agent tables with the current catalog

--- a/openspec/changes/add-devin-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-devin-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,31 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Devin for Terminal MUST be a supported lifecycle agent
+
+Quantex SHALL include Devin for Terminal in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Devin for Terminal
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `devin`
+- **THEN** Quantex returns a supported agent entry for Devin for Terminal
+- **AND** the entry identifies `devin` as the executable binary
+- **AND** the entry identifies `https://cli.devin.ai/` as the homepage
+
+#### Scenario: Installing Devin for Terminal through supported methods
+
+- **WHEN** Quantex renders or executes install options for Devin for Terminal
+- **THEN** the catalog includes the official macOS/Linux shell installer (`curl -fsSL https://cli.devin.ai/install.sh | bash`)
+- **AND** the catalog includes the official Windows PowerShell installer (`irm https://static.devin.ai/cli/setup.ps1 | iex`)
+- **AND** the catalog does not invent unsupported managed package metadata when upstream documentation does not publish it
+
+#### Scenario: Probing Devin for Terminal version
+
+- **WHEN** Quantex probes the installed version of Devin for Terminal
+- **THEN** it runs `devin version` and parses the output
+
+#### Scenario: Planning Devin for Terminal updates
+
+- **WHEN** Quantex plans an update for a Devin for Terminal installation that supports the built-in updater
+- **THEN** the catalog exposes `devin update` as the agent self-update command

--- a/openspec/changes/add-devin-cli-support/tasks.md
+++ b/openspec/changes/add-devin-cli-support/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Add Devin agent support
+
+## 1. OpenSpec and docs
+
+- [x] 1.1 Add the proposal, design, tasks, and `agent-catalog` spec delta for Devin support.
+- [x] 1.2 Update the static supported-agent tables in `README.md` and `README.zh-CN.md`.
+
+## 2. Catalog implementation
+
+- [x] 2.1 Create `src/agents/definitions/devin.ts` with verified lifecycle metadata.
+- [x] 2.2 Register and re-export Devin through `src/agents/index.ts` and `src/index.ts`.
+- [x] 2.3 Add test coverage for Devin install methods, version probe, self-update, and root exports.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.
+- [x] 3.6 Run `bun run memory:check`.

--- a/openspec/changes/add-openhands-cli-support/.openspec.yaml
+++ b/openspec/changes/add-openhands-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-openhands-cli-support/design.md
+++ b/openspec/changes/add-openhands-cli-support/design.md
@@ -1,0 +1,48 @@
+# Design: Add OpenHands CLI support
+
+## Context
+
+OpenHands is a Python-based CLI distributed through an official `uv` install flow plus an official shell installer for macOS and Linux. Its executable command is `openhands`. The OpenHands docs also state that native Windows CLI usage is not officially supported and should run inside WSL, so Quantex should not advertise a native Windows install path.
+
+Autohand is already supported in this repository as a different product with a different executable (`autohand`). This change must add OpenHands alongside Autohand rather than renaming, aliasing, or otherwise mutating the existing Autohand entry.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add OpenHands as a distinct supported lifecycle agent.
+- Preserve the existing Autohand definition unchanged.
+- Record only upstream-documented lifecycle metadata for install, version probing, and update guidance.
+
+**Non-Goals:**
+
+- Adding a first-class `uv` managed install type in this change.
+- Advertising native Windows CLI support when upstream docs require WSL.
+- Changing Autohand naming, aliases, or install behavior.
+
+## Decisions
+
+- Use `openhands` as both the canonical Quantex slug and executable name because the upstream CLI command is stable and product-specific.
+- Do not add lookup aliases until upstream publishes a stable alternative CLI name worth resolving.
+- Model `uv tool install openhands --python 3.12` as an unmanaged `binary` install method on macOS and Linux.
+- Model `curl -fsSL https://install.openhands.dev/install.sh | sh` as an unmanaged `script` install method on macOS and Linux.
+- Omit `windows` platform metadata because upstream CLI docs explicitly direct Windows users to run the CLI from WSL rather than native PowerShell or Command Prompt.
+- Use `openhands --version` as the version probe because the official CLI reference documents `-v` / `--version`.
+- Record `uv tool upgrade openhands --python 3.12` as the self-update command because the official install docs publish that upgrade path.
+
+## Risks / Trade-offs
+
+- [Managed lifecycle gap] `uv` installs remain modeled as unmanaged commands, so Quantex will not gain first-class managed latest-version lookup for OpenHands in this change.
+- [Platform expectation] Some Windows users may expect a native entry. Omitting a native Windows install path is more accurate than implying support that upstream does not document.
+- [Catalog confusion] OpenHands and Autohand are similarly named but different products. Separate canonical slugs and no shared aliases prevent lookup collisions.
+
+## Migration Plan
+
+- Add the `openhands` agent definition and register it in the catalog and root exports.
+- Add tests that verify OpenHands lookup, install methods, version probing, and the absence of native Windows platform metadata.
+- Update supported-agent tables so OpenHands and Autohand are both listed as distinct supported agents.
+- Validate with lint, format check, typecheck, tests, and OpenSpec validation.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/add-openhands-cli-support/proposal.md
+++ b/openspec/changes/add-openhands-cli-support/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+OpenHands is a separate upstream project from the already supported Autohand CLI. Quantex should support `openhands` as its own lifecycle agent so users can install, inspect, resolve, and run it without colliding with the existing `autohand` catalog entry.
+
+This request requires OpenSpec because it adds supported agent catalog metadata and updates product-facing supported-agent documentation.
+
+## What Changes
+
+- Add a supported `openhands` catalog entry with verified install methods, version probing, and update metadata from the official OpenHands CLI docs.
+- Register the new agent in the runtime registry and root exports without changing the existing `autohand` entry.
+- Add test coverage for OpenHands lookup, install metadata, and version probing.
+- Update supported-agent documentation to list OpenHands separately from Autohand.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-catalog`: add OpenHands CLI as a supported lifecycle agent with official install methods, version probing, and documented update guidance
+
+## Impact
+
+- `src/agents/definitions/openhands.ts` - new OpenHands lifecycle metadata definition
+- `src/agents/index.ts` and `src/index.ts` - register and re-export OpenHands
+- `test/agents.test.ts` and `test/index.test.ts` - cover OpenHands lookup and metadata
+- `README.md` and `README.zh-CN.md` - add OpenHands to supported-agent tables
+- `openspec/changes/add-openhands-cli-support/specs/agent-catalog/spec.md` - record the catalog contract delta

--- a/openspec/changes/add-openhands-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-openhands-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: OpenHands CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include OpenHands CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up OpenHands CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `openhands`
+- **THEN** Quantex returns a supported agent entry for OpenHands CLI
+- **AND** the entry identifies `openhands` as the executable binary
+- **AND** the entry identifies `https://docs.openhands.dev/openhands/usage/cli/installation` as the homepage
+
+#### Scenario: Installing OpenHands CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for OpenHands CLI
+- **THEN** macOS and Linux include the official `uv` install command option (`uv tool install openhands --python 3.12`)
+- **AND** macOS and Linux include the official install script option (`curl -fsSL https://install.openhands.dev/install.sh | sh`)
+- **AND** the catalog does not advertise a native Windows install method because upstream CLI docs require Windows users to run inside WSL
+
+#### Scenario: Probing OpenHands CLI version
+
+- **WHEN** Quantex probes the installed version of OpenHands CLI
+- **THEN** it runs `openhands --version` and parses the output
+
+#### Scenario: Planning OpenHands CLI updates
+
+- **WHEN** Quantex plans an update for an OpenHands CLI installation
+- **THEN** the catalog exposes `uv tool upgrade openhands --python 3.12` as the documented update command

--- a/openspec/changes/add-openhands-cli-support/tasks.md
+++ b/openspec/changes/add-openhands-cli-support/tasks.md
@@ -1,0 +1,15 @@
+## 1. OpenSpec And Docs
+
+- [x] 1.1 Write the proposal, design, tasks, and agent-catalog delta for OpenHands CLI support
+- [x] 1.2 Update supported-agent documentation to list OpenHands separately from Autohand
+
+## 2. Catalog Implementation
+
+- [x] 2.1 Add `src/agents/definitions/openhands.ts` with verified lifecycle metadata
+- [x] 2.2 Register and re-export OpenHands without changing the existing Autohand entry
+- [x] 2.3 Add tests covering OpenHands lookup, version probing, and official install methods
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, and `bun run typecheck`
+- [x] 3.2 Run `bun run test` and `bun run openspec:validate`

--- a/src/agents/definitions/autohand.ts
+++ b/src/agents/definitions/autohand.ts
@@ -1,0 +1,21 @@
+import type { AgentDefinition } from '../types'
+import { scriptInstall } from '../methods'
+
+export const autohand: AgentDefinition = {
+  name: 'autohand',
+  lookupAliases: ['autohand-cli'],
+  displayName: 'Autohand Code CLI',
+  homepage: 'https://autohand.ai/cli/',
+  packages: {
+    npm: 'autohand-cli',
+  },
+  binaryName: 'autohand',
+  versionProbe: {
+    command: ['autohand', '--version'],
+  },
+  platforms: {
+    windows: [scriptInstall('iwr -useb https://autohand.ai/install.ps1 | iex')],
+    macos: [scriptInstall('curl -fsSL https://autohand.ai/install.sh | bash')],
+    linux: [scriptInstall('curl -fsSL https://autohand.ai/install.sh | bash')],
+  },
+}

--- a/src/agents/definitions/devin.ts
+++ b/src/agents/definitions/devin.ts
@@ -1,0 +1,20 @@
+import type { AgentDefinition } from '../types'
+import { scriptInstall } from '../methods'
+
+export const devin: AgentDefinition = {
+  name: 'devin',
+  displayName: 'Devin for Terminal',
+  homepage: 'https://cli.devin.ai/',
+  binaryName: 'devin',
+  selfUpdate: {
+    command: ['devin', 'update'],
+  },
+  versionProbe: {
+    command: ['devin', 'version'],
+  },
+  platforms: {
+    windows: [scriptInstall('irm https://static.devin.ai/cli/setup.ps1 | iex')],
+    macos: [scriptInstall('curl -fsSL https://cli.devin.ai/install.sh | bash')],
+    linux: [scriptInstall('curl -fsSL https://cli.devin.ai/install.sh | bash')],
+  },
+}

--- a/src/agents/definitions/openhands.ts
+++ b/src/agents/definitions/openhands.ts
@@ -1,0 +1,25 @@
+import type { AgentDefinition } from '../types'
+import { binaryInstall, scriptInstall } from '../methods'
+
+export const openhands: AgentDefinition = {
+  name: 'openhands',
+  displayName: 'OpenHands CLI',
+  homepage: 'https://docs.openhands.dev/openhands/usage/cli/installation',
+  binaryName: 'openhands',
+  selfUpdate: {
+    command: ['uv', 'tool', 'upgrade', 'openhands', '--python', '3.12'],
+  },
+  versionProbe: {
+    command: ['openhands', '--version'],
+  },
+  platforms: {
+    macos: [
+      binaryInstall('uv tool install openhands --python 3.12'),
+      scriptInstall('curl -fsSL https://install.openhands.dev/install.sh | sh'),
+    ],
+    linux: [
+      binaryInstall('uv tool install openhands --python 3.12'),
+      scriptInstall('curl -fsSL https://install.openhands.dev/install.sh | sh'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -17,7 +17,6 @@ import { kilo } from './definitions/kilo'
 import { kimi } from './definitions/kimi'
 import { kiro } from './definitions/kiro'
 import { opencode } from './definitions/opencode'
-import { openhands } from './definitions/openhands'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
@@ -41,7 +40,6 @@ const agents: AgentDefinition[] = [
   kilo,
   kimi,
   kiro,
-  openhands,
   opencode,
   pi,
   qoder,
@@ -79,7 +77,6 @@ export {
   kilo,
   kimi,
   kiro,
-  openhands,
   opencode,
   pi,
   qoder,

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -17,6 +17,7 @@ import { kilo } from './definitions/kilo'
 import { kimi } from './definitions/kimi'
 import { kiro } from './definitions/kiro'
 import { opencode } from './definitions/opencode'
+import { openhands } from './definitions/openhands'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
@@ -40,6 +41,7 @@ const agents: AgentDefinition[] = [
   kilo,
   kimi,
   kiro,
+  openhands,
   opencode,
   pi,
   qoder,
@@ -77,6 +79,7 @@ export {
   kilo,
   kimi,
   kiro,
+  openhands,
   opencode,
   pi,
   qoder,

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -1,6 +1,7 @@
 import type { AgentDefinition } from './types'
 import { amp } from './definitions/amp'
 import { auggie } from './definitions/auggie'
+import { autohand } from './definitions/autohand'
 import { claude } from './definitions/claude'
 import { codebuddy } from './definitions/codebuddy'
 import { codex } from './definitions/codex'
@@ -16,6 +17,7 @@ import { kilo } from './definitions/kilo'
 import { kimi } from './definitions/kimi'
 import { kiro } from './definitions/kiro'
 import { opencode } from './definitions/opencode'
+import { openhands } from './definitions/openhands'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
@@ -23,6 +25,7 @@ import { vibe } from './definitions/vibe'
 
 const agents: AgentDefinition[] = [
   auggie,
+  autohand,
   amp,
   claude,
   codebuddy,
@@ -38,6 +41,7 @@ const agents: AgentDefinition[] = [
   kilo,
   kimi,
   kiro,
+  openhands,
   opencode,
   pi,
   qoder,
@@ -59,6 +63,7 @@ export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined
 
 export {
   auggie,
+  autohand,
   amp,
   claude,
   codebuddy,
@@ -74,6 +79,7 @@ export {
   kilo,
   kimi,
   kiro,
+  openhands,
   opencode,
   pi,
   qoder,

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -8,6 +8,7 @@ import { codex } from './definitions/codex'
 import { copilot } from './definitions/copilot'
 import { crush } from './definitions/crush'
 import { cursor } from './definitions/cursor'
+import { devin } from './definitions/devin'
 import { droid } from './definitions/droid'
 import { forgecode } from './definitions/forgecode'
 import { gemini } from './definitions/gemini'
@@ -33,6 +34,7 @@ const agents: AgentDefinition[] = [
   copilot,
   crush,
   cursor,
+  devin,
   droid,
   forgecode,
   gemini,
@@ -71,6 +73,7 @@ export {
   copilot,
   crush,
   cursor,
+  devin,
   droid,
   forgecode,
   gemini,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export {
   codex,
   copilot,
   cursor,
+  devin,
   droid,
   gemini,
   getAgentByLookupName,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,6 @@ export {
   getAllAgents,
   junie,
   kilo,
-  openhands,
   opencode,
   pi,
   qoder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
   getAllAgents,
   junie,
   kilo,
+  openhands,
   opencode,
   pi,
   qoder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export {
 } from './agent-update'
 export type { AgentUpdateContext, AgentUpdateProvider, AgentUpdateStrategy } from './agent-update'
 export {
+  autohand,
   claude,
   codebuddy,
   codex,
@@ -20,6 +21,7 @@ export {
   getAllAgents,
   junie,
   kilo,
+  openhands,
   opencode,
   pi,
   qoder,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -13,6 +13,7 @@ import { gemini } from '../src/agents/definitions/gemini'
 import { junie } from '../src/agents/definitions/junie'
 import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
+import { openhands } from '../src/agents/definitions/openhands'
 import { pi } from '../src/agents/definitions/pi'
 import { qoder } from '../src/agents/definitions/qoder'
 import { qwen } from '../src/agents/definitions/qwen'
@@ -384,6 +385,38 @@ describe('opencode', () => {
       opencode.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'anomalyco/tap/opencode'),
     ).toBeDefined()
     expect(opencode.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('openhands', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('openhands')).toBe(openhands)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(openhands)
+    expect(openhands.name).toBe('openhands')
+    expect(openhands.lookupAliases).toBeUndefined()
+    expect(openhands.displayName).toBe('OpenHands CLI')
+    expect(openhands.binaryName).toBe('openhands')
+    expect(openhands.homepage).toBe('https://docs.openhands.dev/openhands/usage/cli/installation')
+    expect(openhands.selfUpdate?.command).toEqual(['uv', 'tool', 'upgrade', 'openhands', '--python', '3.12'])
+    expect(openhands.versionProbe?.command).toEqual(['openhands', '--version'])
+  })
+
+  it('supports official uv and install-script methods on macOS and Linux only', () => {
+    for (const methods of [openhands.platforms.macos, openhands.platforms.linux]) {
+      expect(
+        methods!.find(m => m.type === 'binary' && m.command === 'uv tool install openhands --python 3.12'),
+      ).toBeDefined()
+      expect(
+        methods!.find(
+          m => m.type === 'script' && m.command === 'curl -fsSL https://install.openhands.dev/install.sh | sh',
+        ),
+      ).toBeDefined()
+    }
+
+    expect(openhands.platforms.windows).toBeUndefined()
   })
 })
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -8,6 +8,7 @@ import { codebuddy } from '../src/agents/definitions/codebuddy'
 import { codex } from '../src/agents/definitions/codex'
 import { copilot } from '../src/agents/definitions/copilot'
 import { cursor } from '../src/agents/definitions/cursor'
+import { devin } from '../src/agents/definitions/devin'
 import { droid } from '../src/agents/definitions/droid'
 import { gemini } from '../src/agents/definitions/gemini'
 import { junie } from '../src/agents/definitions/junie'
@@ -266,6 +267,35 @@ describe('cursor', () => {
     expect(cursor.platforms.macos!.find(m => (m.command ?? '').includes('cursor.com/install'))).toBeDefined()
     expect(cursor.platforms.linux!.find(m => (m.command ?? '').includes('cursor.com/install'))).toBeDefined()
     expect(cursor.platforms.windows!.find(m => (m.command ?? '').includes('cursor.com/install'))).toBeDefined()
+  })
+})
+
+describe('devin', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('devin')).toBe(devin)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(devin)
+    expect(devin.name).toBe('devin')
+    expect(devin.lookupAliases).toBeUndefined()
+    expect(devin.displayName).toBe('Devin for Terminal')
+    expect(devin.binaryName).toBe('devin')
+    expect(devin.homepage).toBe('https://cli.devin.ai/')
+    expect(devin.selfUpdate?.command).toEqual(['devin', 'update'])
+    expect(devin.versionProbe?.command).toEqual(['devin', 'version'])
+  })
+
+  it('exposes the official script installers per platform', () => {
+    expect(
+      devin.platforms.windows!.find(m => m.type === 'script' && m.command.includes('static.devin.ai/cli/setup.ps1')),
+    ).toBeDefined()
+    expect(
+      devin.platforms.macos!.find(m => m.type === 'script' && m.command.includes('cli.devin.ai/install.sh')),
+    ).toBeDefined()
+    expect(
+      devin.platforms.linux!.find(m => m.type === 'script' && m.command.includes('cli.devin.ai/install.sh')),
+    ).toBeDefined()
   })
 })
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -13,7 +13,6 @@ import { gemini } from '../src/agents/definitions/gemini'
 import { junie } from '../src/agents/definitions/junie'
 import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
-import { openhands } from '../src/agents/definitions/openhands'
 import { pi } from '../src/agents/definitions/pi'
 import { qoder } from '../src/agents/definitions/qoder'
 import { qwen } from '../src/agents/definitions/qwen'
@@ -385,38 +384,6 @@ describe('opencode', () => {
       opencode.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'anomalyco/tap/opencode'),
     ).toBeDefined()
     expect(opencode.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
-  })
-})
-
-describe('openhands', () => {
-  it('is registered for lookup by canonical name', () => {
-    expect(getAgentByNameOrAlias('openhands')).toBe(openhands)
-  })
-
-  it('has valid structure', () => {
-    validateAgent(openhands)
-    expect(openhands.name).toBe('openhands')
-    expect(openhands.lookupAliases).toBeUndefined()
-    expect(openhands.displayName).toBe('OpenHands CLI')
-    expect(openhands.binaryName).toBe('openhands')
-    expect(openhands.homepage).toBe('https://docs.openhands.dev/openhands/usage/cli/installation')
-    expect(openhands.selfUpdate?.command).toEqual(['uv', 'tool', 'upgrade', 'openhands', '--python', '3.12'])
-    expect(openhands.versionProbe?.command).toEqual(['openhands', '--version'])
-  })
-
-  it('supports official uv and install-script methods on macOS and Linux only', () => {
-    for (const methods of [openhands.platforms.macos, openhands.platforms.linux]) {
-      expect(
-        methods!.find(m => m.type === 'binary' && m.command === 'uv tool install openhands --python 3.12'),
-      ).toBeDefined()
-      expect(
-        methods!.find(
-          m => m.type === 'script' && m.command === 'curl -fsSL https://install.openhands.dev/install.sh | sh',
-        ),
-      ).toBeDefined()
-    }
-
-    expect(openhands.platforms.windows).toBeUndefined()
   })
 })
 

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -2,6 +2,7 @@ import type { AgentDefinition } from '../src/agents/types'
 import { describe, expect, it } from 'vitest'
 import { getAgentByLookupName, getAgentByNameOrAlias, getAllAgents } from '../src/agents'
 import { auggie } from '../src/agents/definitions/auggie'
+import { autohand } from '../src/agents/definitions/autohand'
 import { claude } from '../src/agents/definitions/claude'
 import { codebuddy } from '../src/agents/definitions/codebuddy'
 import { codex } from '../src/agents/definitions/codex'
@@ -12,6 +13,7 @@ import { gemini } from '../src/agents/definitions/gemini'
 import { junie } from '../src/agents/definitions/junie'
 import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
+import { openhands } from '../src/agents/definitions/openhands'
 import { pi } from '../src/agents/definitions/pi'
 import { qoder } from '../src/agents/definitions/qoder'
 import { qwen } from '../src/agents/definitions/qwen'
@@ -93,6 +95,37 @@ describe('auggie', () => {
     expect(auggie.platforms.linux!.find(m => m.type === 'bun')).toBeDefined()
     expect(auggie.platforms.linux!.find(m => m.type === 'npm')).toBeDefined()
     expect(auggie.platforms.windows).toBeUndefined()
+  })
+})
+
+describe('autohand', () => {
+  it('is registered for lookup by canonical name and package-style alias', () => {
+    expect(getAgentByNameOrAlias('autohand')).toBe(autohand)
+    expect(getAgentByLookupName('autohand-cli')).toBe(autohand)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(autohand)
+    expect(autohand.name).toBe('autohand')
+    expect(autohand.lookupAliases).toEqual(['autohand-cli'])
+    expect(autohand.displayName).toBe('Autohand Code CLI')
+    expect(autohand.packages?.npm).toBe('autohand-cli')
+    expect(autohand.binaryName).toBe('autohand')
+    expect(autohand.homepage).toBe('https://autohand.ai/cli/')
+    expect(autohand.selfUpdate).toBeUndefined()
+    expect(autohand.versionProbe?.command).toEqual(['autohand', '--version'])
+  })
+
+  it('supports official script installers on all platforms', () => {
+    expect(
+      autohand.platforms.windows!.find(m => m.type === 'script' && m.command.includes('autohand.ai/install.ps1')),
+    ).toBeDefined()
+    expect(
+      autohand.platforms.macos!.find(m => m.type === 'script' && m.command.includes('autohand.ai/install.sh')),
+    ).toBeDefined()
+    expect(
+      autohand.platforms.linux!.find(m => m.type === 'script' && m.command.includes('autohand.ai/install.sh')),
+    ).toBeDefined()
   })
 })
 
@@ -352,6 +385,38 @@ describe('opencode', () => {
       opencode.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'anomalyco/tap/opencode'),
     ).toBeDefined()
     expect(opencode.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('openhands', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('openhands')).toBe(openhands)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(openhands)
+    expect(openhands.name).toBe('openhands')
+    expect(openhands.lookupAliases).toBeUndefined()
+    expect(openhands.displayName).toBe('OpenHands CLI')
+    expect(openhands.binaryName).toBe('openhands')
+    expect(openhands.homepage).toBe('https://docs.openhands.dev/openhands/usage/cli/installation')
+    expect(openhands.selfUpdate?.command).toEqual(['uv', 'tool', 'upgrade', 'openhands', '--python', '3.12'])
+    expect(openhands.versionProbe?.command).toEqual(['openhands', '--version'])
+  })
+
+  it('supports official uv and install-script methods on macOS and Linux only', () => {
+    for (const methods of [openhands.platforms.macos, openhands.platforms.linux]) {
+      expect(
+        methods!.find(m => m.type === 'binary' && m.command === 'uv tool install openhands --python 3.12'),
+      ).toBeDefined()
+      expect(
+        methods!.find(
+          m => m.type === 'script' && m.command === 'curl -fsSL https://install.openhands.dev/install.sh | sh',
+        ),
+      ).toBeDefined()
+    }
+
+    expect(openhands.platforms.windows).toBeUndefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  autohand,
   codebuddy,
   codex,
   copilot,
@@ -13,6 +14,7 @@ import {
   junie,
   inspectAgent,
   kilo,
+  openhands,
   opencode,
   pi,
   qoder,
@@ -29,6 +31,13 @@ describe('agent registry', () => {
     expect(agent).toBeDefined()
     expect(agent!.name).toBe('auggie')
     expect(agent!.binaryName).toBe('auggie')
+  })
+
+  it('finds autohand by name', () => {
+    const agent = getAgentByNameOrAlias('autohand')
+    expect(agent).toBeDefined()
+    expect(agent!.name).toBe('autohand')
+    expect(agent!.binaryName).toBe('autohand')
   })
 
   it('finds agent by name', () => {
@@ -52,9 +61,21 @@ describe('agent registry', () => {
     expect(agent?.name).toBe('vibe')
   })
 
+  it('finds OpenHands by name', () => {
+    const agent = getAgentByNameOrAlias('openhands')
+    expect(agent).toBeDefined()
+    expect(agent!.name).toBe('openhands')
+    expect(agent!.binaryName).toBe('openhands')
+  })
+
   it('resolves CodeBuddy by package-style alias', () => {
     const agent = getAgentByLookupName('codebuddy-code')
     expect(agent?.name).toBe('codebuddy')
+  })
+
+  it('resolves Autohand by package-style alias', () => {
+    const agent = getAgentByLookupName('autohand-cli')
+    expect(agent?.name).toBe('autohand')
   })
 
   it('resolves Qoder by executable alias', () => {
@@ -89,12 +110,28 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('codebuddy')
   })
 
+  it('autohand has correct structure', () => {
+    const agent = getAgentByNameOrAlias('autohand')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('Autohand Code CLI')
+    expect(agent!.packages?.npm).toBe('autohand-cli')
+    expect(agent!.binaryName).toBe('autohand')
+  })
+
   it('opencode has correct structure', () => {
     const agent = getAgentByNameOrAlias('opencode')
     expect(agent).toBeDefined()
     expect(agent!.displayName).toBe('OpenCode')
     expect(agent!.packages?.npm).toBe('opencode-ai')
     expect(agent!.binaryName).toBe('opencode')
+  })
+
+  it('openhands has correct structure', () => {
+    const agent = getAgentByNameOrAlias('openhands')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('OpenHands CLI')
+    expect(agent!.binaryName).toBe('openhands')
+    expect(agent!.homepage).toBe('https://docs.openhands.dev/openhands/usage/cli/installation')
   })
 
   it('kilo has correct structure', () => {
@@ -122,6 +159,7 @@ describe('agent definitions', () => {
   })
 
   it('re-exports all built-in agents from root index', () => {
+    expect(autohand.name).toBe('autohand')
     expect(codebuddy.name).toBe('codebuddy')
     expect(codex.name).toBe('codex')
     expect(copilot.name).toBe('copilot')
@@ -130,6 +168,7 @@ describe('agent definitions', () => {
     expect(gemini.name).toBe('gemini')
     expect(junie.name).toBe('junie')
     expect(kilo.name).toBe('kilo')
+    expect(openhands.name).toBe('openhands')
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')
     expect(qoder.name).toBe('qoder')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,6 +14,7 @@ import {
   junie,
   inspectAgent,
   kilo,
+  openhands,
   opencode,
   pi,
   qoder,
@@ -58,6 +59,13 @@ describe('agent registry', () => {
   it('resolves Mistral Vibe by package alias', () => {
     const agent = getAgentByLookupName('mistral-vibe')
     expect(agent?.name).toBe('vibe')
+  })
+
+  it('finds OpenHands by name', () => {
+    const agent = getAgentByNameOrAlias('openhands')
+    expect(agent).toBeDefined()
+    expect(agent!.name).toBe('openhands')
+    expect(agent!.binaryName).toBe('openhands')
   })
 
   it('resolves CodeBuddy by package-style alias', () => {
@@ -118,6 +126,14 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('opencode')
   })
 
+  it('openhands has correct structure', () => {
+    const agent = getAgentByNameOrAlias('openhands')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('OpenHands CLI')
+    expect(agent!.binaryName).toBe('openhands')
+    expect(agent!.homepage).toBe('https://docs.openhands.dev/openhands/usage/cli/installation')
+  })
+
   it('kilo has correct structure', () => {
     const agent = getAgentByNameOrAlias('kilo')
     expect(agent).toBeDefined()
@@ -152,6 +168,7 @@ describe('agent definitions', () => {
     expect(gemini.name).toBe('gemini')
     expect(junie.name).toBe('junie')
     expect(kilo.name).toBe('kilo')
+    expect(openhands.name).toBe('openhands')
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')
     expect(qoder.name).toBe('qoder')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,6 +6,7 @@ import {
   copilot,
   createUpdatePlan,
   cursor,
+  devin,
   droid,
   gemini,
   getAgentByLookupName,
@@ -118,6 +119,13 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('autohand')
   })
 
+  it('devin has correct structure', () => {
+    const agent = getAgentByNameOrAlias('devin')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('Devin for Terminal')
+    expect(agent!.binaryName).toBe('devin')
+  })
+
   it('opencode has correct structure', () => {
     const agent = getAgentByNameOrAlias('opencode')
     expect(agent).toBeDefined()
@@ -164,6 +172,7 @@ describe('agent definitions', () => {
     expect(codex.name).toBe('codex')
     expect(copilot.name).toBe('copilot')
     expect(cursor.name).toBe('cursor')
+    expect(devin.name).toBe('devin')
     expect(droid.name).toBe('droid')
     expect(gemini.name).toBe('gemini')
     expect(junie.name).toBe('junie')

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,7 +14,6 @@ import {
   junie,
   inspectAgent,
   kilo,
-  openhands,
   opencode,
   pi,
   qoder,
@@ -59,13 +58,6 @@ describe('agent registry', () => {
   it('resolves Mistral Vibe by package alias', () => {
     const agent = getAgentByLookupName('mistral-vibe')
     expect(agent?.name).toBe('vibe')
-  })
-
-  it('finds OpenHands by name', () => {
-    const agent = getAgentByNameOrAlias('openhands')
-    expect(agent).toBeDefined()
-    expect(agent!.name).toBe('openhands')
-    expect(agent!.binaryName).toBe('openhands')
   })
 
   it('resolves CodeBuddy by package-style alias', () => {
@@ -126,14 +118,6 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('opencode')
   })
 
-  it('openhands has correct structure', () => {
-    const agent = getAgentByNameOrAlias('openhands')
-    expect(agent).toBeDefined()
-    expect(agent!.displayName).toBe('OpenHands CLI')
-    expect(agent!.binaryName).toBe('openhands')
-    expect(agent!.homepage).toBe('https://docs.openhands.dev/openhands/usage/cli/installation')
-  })
-
   it('kilo has correct structure', () => {
     const agent = getAgentByNameOrAlias('kilo')
     expect(agent).toBeDefined()
@@ -168,7 +152,6 @@ describe('agent definitions', () => {
     expect(gemini.name).toBe('gemini')
     expect(junie.name).toBe('junie')
     expect(kilo.name).toBe('kilo')
-    expect(openhands.name).toBe('openhands')
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')
     expect(qoder.name).toBe('qoder')


### PR DESCRIPTION
## Summary

Batch three supported-agent additions into one `main` merge so Quantex lands the catalog, docs, tests, and OpenSpec deltas together with a single release cycle:

- Autohand Code CLI
- OpenHands CLI
- Devin for Terminal

## Linked Artifacts

- Issue: #134
- ADR: not applicable
- OpenSpec: `add-autohand-code-cli-support`, `add-openhands-cli-support`, `add-devin-cli-support`
- Discussion: not applicable

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- This PR supersedes #157 and #158 so these three agent additions only need one merge and one release cycle on `main`.
- OpenHands is intentionally kept separate from Autohand; both agents remain first-class catalog entries with their own install and probe metadata.
