### PR TITLE
feat(agents): add OpenHands CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |
 | Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |
 | Mistral Vibe | `qtx vibe` | Mistral's open-source CLI coding assistant |
+| OpenHands CLI | `qtx openhands` | OpenHands' open-source software development agent CLI |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -184,6 +184,7 @@ qtx upgrade --channel beta
 | Kimi Code | `qtx kimi` | Moonshot AI 编程助手 CLI |
 | Kiro CLI | `qtx kiro` | Amazon AI 编程 Agent CLI |
 | Mistral Vibe | `qtx vibe` | Mistral 开源终端编程助手 |
+| OpenHands CLI | `qtx openhands` | OpenHands 开源软件开发 Agent CLI |
 | OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
 | Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |

--- a/openspec/changes/add-openhands-cli-support/.openspec.yaml
+++ b/openspec/changes/add-openhands-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-openhands-cli-support/design.md
+++ b/openspec/changes/add-openhands-cli-support/design.md
@@ -1,0 +1,48 @@
+# Design: Add OpenHands CLI support
+
+## Context
+
+OpenHands is a Python-based CLI distributed through an official `uv` install flow plus an official shell installer for macOS and Linux. Its executable command is `openhands`. The OpenHands docs also state that native Windows CLI usage is not officially supported and should run inside WSL, so Quantex should not advertise a native Windows install path.
+
+Autohand is already supported in this repository as a different product with a different executable (`autohand`). This change must add OpenHands alongside Autohand rather than renaming, aliasing, or otherwise mutating the existing Autohand entry.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add OpenHands as a distinct supported lifecycle agent.
+- Preserve the existing Autohand definition unchanged.
+- Record only upstream-documented lifecycle metadata for install, version probing, and update guidance.
+
+**Non-Goals:**
+
+- Adding a first-class `uv` managed install type in this change.
+- Advertising native Windows CLI support when upstream docs require WSL.
+- Changing Autohand naming, aliases, or install behavior.
+
+## Decisions
+
+- Use `openhands` as both the canonical Quantex slug and executable name because the upstream CLI command is stable and product-specific.
+- Do not add lookup aliases until upstream publishes a stable alternative CLI name worth resolving.
+- Model `uv tool install openhands --python 3.12` as an unmanaged `binary` install method on macOS and Linux.
+- Model `curl -fsSL https://install.openhands.dev/install.sh | sh` as an unmanaged `script` install method on macOS and Linux.
+- Omit `windows` platform metadata because upstream CLI docs explicitly direct Windows users to run the CLI from WSL rather than native PowerShell or Command Prompt.
+- Use `openhands --version` as the version probe because the official CLI reference documents `-v` / `--version`.
+- Record `uv tool upgrade openhands --python 3.12` as the self-update command because the official install docs publish that upgrade path.
+
+## Risks / Trade-offs
+
+- [Managed lifecycle gap] `uv` installs remain modeled as unmanaged commands, so Quantex will not gain first-class managed latest-version lookup for OpenHands in this change.
+- [Platform expectation] Some Windows users may expect a native entry. Omitting a native Windows install path is more accurate than implying support that upstream does not document.
+- [Catalog confusion] OpenHands and Autohand are similarly named but different products. Separate canonical slugs and no shared aliases prevent lookup collisions.
+
+## Migration Plan
+
+- Add the `openhands` agent definition and register it in the catalog and root exports.
+- Add tests that verify OpenHands lookup, install methods, version probing, and the absence of native Windows platform metadata.
+- Update supported-agent tables so OpenHands and Autohand are both listed as distinct supported agents.
+- Validate with lint, format check, typecheck, tests, and OpenSpec validation.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/add-openhands-cli-support/proposal.md
+++ b/openspec/changes/add-openhands-cli-support/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+OpenHands is a separate upstream project from the already supported Autohand CLI. Quantex should support `openhands` as its own lifecycle agent so users can install, inspect, resolve, and run it without colliding with the existing `autohand` catalog entry.
+
+This request requires OpenSpec because it adds supported agent catalog metadata and updates product-facing supported-agent documentation.
+
+## What Changes
+
+- Add a supported `openhands` catalog entry with verified install methods, version probing, and update metadata from the official OpenHands CLI docs.
+- Register the new agent in the runtime registry and root exports without changing the existing `autohand` entry.
+- Add test coverage for OpenHands lookup, install metadata, and version probing.
+- Update supported-agent documentation to list OpenHands separately from Autohand.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-catalog`: add OpenHands CLI as a supported lifecycle agent with official install methods, version probing, and documented update guidance
+
+## Impact
+
+- `src/agents/definitions/openhands.ts` - new OpenHands lifecycle metadata definition
+- `src/agents/index.ts` and `src/index.ts` - register and re-export OpenHands
+- `test/agents.test.ts` and `test/index.test.ts` - cover OpenHands lookup and metadata
+- `README.md` and `README.zh-CN.md` - add OpenHands to supported-agent tables
+- `openspec/changes/add-openhands-cli-support/specs/agent-catalog/spec.md` - record the catalog contract delta

--- a/openspec/changes/add-openhands-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-openhands-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: OpenHands CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include OpenHands CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up OpenHands CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `openhands`
+- **THEN** Quantex returns a supported agent entry for OpenHands CLI
+- **AND** the entry identifies `openhands` as the executable binary
+- **AND** the entry identifies `https://docs.openhands.dev/openhands/usage/cli/installation` as the homepage
+
+#### Scenario: Installing OpenHands CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for OpenHands CLI
+- **THEN** macOS and Linux include the official `uv` install command option (`uv tool install openhands --python 3.12`)
+- **AND** macOS and Linux include the official install script option (`curl -fsSL https://install.openhands.dev/install.sh | sh`)
+- **AND** the catalog does not advertise a native Windows install method because upstream CLI docs require Windows users to run inside WSL
+
+#### Scenario: Probing OpenHands CLI version
+
+- **WHEN** Quantex probes the installed version of OpenHands CLI
+- **THEN** it runs `openhands --version` and parses the output
+
+#### Scenario: Planning OpenHands CLI updates
+
+- **WHEN** Quantex plans an update for an OpenHands CLI installation
+- **THEN** the catalog exposes `uv tool upgrade openhands --python 3.12` as the documented update command

--- a/openspec/changes/add-openhands-cli-support/tasks.md
+++ b/openspec/changes/add-openhands-cli-support/tasks.md
@@ -1,0 +1,15 @@
+## 1. OpenSpec And Docs
+
+- [x] 1.1 Write the proposal, design, tasks, and agent-catalog delta for OpenHands CLI support
+- [x] 1.2 Update supported-agent documentation to list OpenHands separately from Autohand
+
+## 2. Catalog Implementation
+
+- [x] 2.1 Add `src/agents/definitions/openhands.ts` with verified lifecycle metadata
+- [x] 2.2 Register and re-export OpenHands without changing the existing Autohand entry
+- [x] 2.3 Add tests covering OpenHands lookup, version probing, and official install methods
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, and `bun run typecheck`
+- [x] 3.2 Run `bun run test` and `bun run openspec:validate`

--- a/src/agents/definitions/openhands.ts
+++ b/src/agents/definitions/openhands.ts
@@ -1,0 +1,25 @@
+import type { AgentDefinition } from '../types'
+import { binaryInstall, scriptInstall } from '../methods'
+
+export const openhands: AgentDefinition = {
+  name: 'openhands',
+  displayName: 'OpenHands CLI',
+  homepage: 'https://docs.openhands.dev/openhands/usage/cli/installation',
+  binaryName: 'openhands',
+  selfUpdate: {
+    command: ['uv', 'tool', 'upgrade', 'openhands', '--python', '3.12'],
+  },
+  versionProbe: {
+    command: ['openhands', '--version'],
+  },
+  platforms: {
+    macos: [
+      binaryInstall('uv tool install openhands --python 3.12'),
+      scriptInstall('curl -fsSL https://install.openhands.dev/install.sh | sh'),
+    ],
+    linux: [
+      binaryInstall('uv tool install openhands --python 3.12'),
+      scriptInstall('curl -fsSL https://install.openhands.dev/install.sh | sh'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -16,6 +16,7 @@ import { kilo } from './definitions/kilo'
 import { kimi } from './definitions/kimi'
 import { kiro } from './definitions/kiro'
 import { opencode } from './definitions/opencode'
+import { openhands } from './definitions/openhands'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
@@ -38,6 +39,7 @@ const agents: AgentDefinition[] = [
   kilo,
   kimi,
   kiro,
+  openhands,
   opencode,
   pi,
   qoder,
@@ -74,6 +76,7 @@ export {
   kilo,
   kimi,
   kiro,
+  openhands,
   opencode,
   pi,
   qoder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
   getAllAgents,
   junie,
   kilo,
+  openhands,
   opencode,
   pi,
   qoder,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -12,6 +12,7 @@ import { gemini } from '../src/agents/definitions/gemini'
 import { junie } from '../src/agents/definitions/junie'
 import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
+import { openhands } from '../src/agents/definitions/openhands'
 import { pi } from '../src/agents/definitions/pi'
 import { qoder } from '../src/agents/definitions/qoder'
 import { qwen } from '../src/agents/definitions/qwen'
@@ -352,6 +353,38 @@ describe('opencode', () => {
       opencode.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'anomalyco/tap/opencode'),
     ).toBeDefined()
     expect(opencode.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('openhands', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('openhands')).toBe(openhands)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(openhands)
+    expect(openhands.name).toBe('openhands')
+    expect(openhands.lookupAliases).toBeUndefined()
+    expect(openhands.displayName).toBe('OpenHands CLI')
+    expect(openhands.binaryName).toBe('openhands')
+    expect(openhands.homepage).toBe('https://docs.openhands.dev/openhands/usage/cli/installation')
+    expect(openhands.selfUpdate?.command).toEqual(['uv', 'tool', 'upgrade', 'openhands', '--python', '3.12'])
+    expect(openhands.versionProbe?.command).toEqual(['openhands', '--version'])
+  })
+
+  it('supports official uv and install-script methods on macOS and Linux only', () => {
+    for (const methods of [openhands.platforms.macos, openhands.platforms.linux]) {
+      expect(
+        methods!.find(m => m.type === 'binary' && m.command === 'uv tool install openhands --python 3.12'),
+      ).toBeDefined()
+      expect(
+        methods!.find(
+          m => m.type === 'script' && m.command === 'curl -fsSL https://install.openhands.dev/install.sh | sh',
+        ),
+      ).toBeDefined()
+    }
+
+    expect(openhands.platforms.windows).toBeUndefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -13,6 +13,7 @@ import {
   junie,
   inspectAgent,
   kilo,
+  openhands,
   opencode,
   pi,
   qoder,
@@ -50,6 +51,13 @@ describe('agent registry', () => {
   it('resolves Mistral Vibe by package alias', () => {
     const agent = getAgentByLookupName('mistral-vibe')
     expect(agent?.name).toBe('vibe')
+  })
+
+  it('finds OpenHands by name', () => {
+    const agent = getAgentByNameOrAlias('openhands')
+    expect(agent).toBeDefined()
+    expect(agent!.name).toBe('openhands')
+    expect(agent!.binaryName).toBe('openhands')
   })
 
   it('resolves CodeBuddy by package-style alias', () => {
@@ -97,6 +105,14 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('opencode')
   })
 
+  it('openhands has correct structure', () => {
+    const agent = getAgentByNameOrAlias('openhands')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('OpenHands CLI')
+    expect(agent!.binaryName).toBe('openhands')
+    expect(agent!.homepage).toBe('https://docs.openhands.dev/openhands/usage/cli/installation')
+  })
+
   it('kilo has correct structure', () => {
     const agent = getAgentByNameOrAlias('kilo')
     expect(agent).toBeDefined()
@@ -130,6 +146,7 @@ describe('agent definitions', () => {
     expect(gemini.name).toBe('gemini')
     expect(junie.name).toBe('junie')
     expect(kilo.name).toBe('kilo')
+    expect(openhands.name).toBe('openhands')
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')
     expect(qoder.name).toBe('qoder')


### PR DESCRIPTION
## Summary

Add OpenHands CLI as a separate supported Quantex agent without changing the existing Autohand entry. This wires OpenHands into the agent catalog, root exports, tests, product-facing supported-agent tables, and a dedicated OpenSpec change.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/add-openhands-cli-support/`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- [ ] Release: not applicable - docs/process/test-only change
- [ ] Release: patch - bug fix
- [x] Release: minor - user-facing feature
- [ ] Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- OpenHands is added as `openhands` and intentionally kept separate from the existing `autohand` support.
- Native Windows install metadata is not advertised because the official OpenHands CLI docs currently direct Windows users to run the CLI inside WSL.
