### PR TITLE
feat(agents): add Devin for Terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | Crush | `qtx crush` | Charmbracelet's terminal AI coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
+| Devin for Terminal | `qtx devin` | Cognition's local coding agent CLI |
 | Droid | `qtx droid` | Factory AI software engineering agent CLI |
 | ForgeCode | `qtx forgecode` | Antinomy's AI coding assistant CLI |
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,6 +174,7 @@ qtx upgrade --channel beta
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | Crush | `qtx crush` | Charmbracelet 终端 AI 编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
+| Devin for Terminal | `qtx devin` | Cognition 本地编程 Agent CLI |
 | Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
 | ForgeCode | `qtx forgecode` | Antinomy AI 编程助手 CLI |
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |

--- a/openspec/changes/add-devin-cli-support/.openspec.yaml
+++ b/openspec/changes/add-devin-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-30

--- a/openspec/changes/add-devin-cli-support/design.md
+++ b/openspec/changes/add-devin-cli-support/design.md
@@ -1,0 +1,48 @@
+## Context
+
+Devin for Terminal is distributed through official install scripts for macOS/Linux/WSL and Windows, plus a Windsurf-bundled path that is enabled separately for enterprise users. The command reference documents a stable executable name (`devin`), a version subcommand (`devin version`, equivalent to `devin --version`), and a self-update command (`devin update`).
+
+Quantex already models script-installed agents that rely on `selfUpdate` instead of managed package updates. Devin support should fit that existing lifecycle catalog shape without adding special-case product logic for Windsurf-bundled installs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add Devin as a supported Quantex lifecycle agent with verified upstream metadata.
+- Preserve the official install scripts for each platform exactly as documented upstream.
+- Expose the documented version and self-update commands so Quantex update planning can handle unmanaged Devin installs.
+
+**Non-Goals:**
+
+- Model Windsurf-bundled enablement or enterprise entitlement checks as a separate install method.
+- Add managed npm, Bun, Homebrew, or winget metadata that is not documented upstream.
+- Add Devin-specific auth, setup, MCP, or session-management behavior beyond catalog metadata.
+
+## Decisions
+
+### 1. Use `devin` as both the canonical slug and executable name
+
+The upstream CLI command is `devin`, and it is specific enough to serve as both the Quantex agent slug and the executable identifier without aliases.
+
+### 2. Record only the official script installers
+
+Upstream quickstart documentation currently publishes shell and PowerShell installers, not managed package-manager installs. Quantex should keep only those official script methods in the catalog:
+
+- macOS/Linux: `curl -fsSL https://cli.devin.ai/install.sh | bash`
+- Windows: `irm https://static.devin.ai/cli/setup.ps1 | iex`
+
+This keeps install guidance aligned with vendor documentation and avoids inventing unsupported package-manager paths.
+
+### 3. Use the documented version and update commands
+
+The command reference explicitly documents `devin version` and `devin update`. Quantex should use `devin version` as the explicit version probe and expose `devin update` as the self-update command for unmanaged installs. This matches the current Quantex update strategy, where script-installed agents can still advertise a built-in updater.
+
+### 4. Treat the Windsurf-bundled path as out of scope for install metadata
+
+The Windsurf-bundled install is a product-bundled distribution path rather than a standalone CLI installer that Quantex can execute directly. Quantex should support the `devin` binary once present on PATH, but it should not model the Windsurf entitlement flow as a separate install method.
+
+## Risks / Trade-offs
+
+- [Users may expect managed package installs because other agents support npm or brew] -> Keep the catalog limited to the official script methods that Devin actually documents today.
+- [Bundled installs may update through the parent application instead of `devin update`] -> Use the documented self-update command for standalone installs and avoid claiming Windsurf-bundled update management in the catalog contract.
+- [The version command has two documented forms] -> Use the explicit `devin version` subcommand because it is listed in the command reference and explicitly documented as equivalent to `devin --version`.

--- a/openspec/changes/add-devin-cli-support/proposal.md
+++ b/openspec/changes/add-devin-cli-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+This request changes the supported agent catalog, install metadata, and update behavior, so it requires an OpenSpec-backed change before implementation. Devin for Terminal now has official installation, version, and update documentation, but Quantex cannot yet install, inspect, or launch it as a first-class lifecycle agent.
+
+## What Changes
+
+- Add a Devin for Terminal agent definition with verified lifecycle metadata: canonical slug, display name, homepage, executable name, install methods, version probe, and self-update command.
+- Register Devin in the built-in agent catalog and root exports so existing lookup, install, ensure, inspect, resolve, exec, and update surfaces can use it.
+- Extend the agent-catalog contract with a Devin requirement that records the supported install scripts, version probe, and self-update behavior.
+- Refresh the product README supported-agent tables so the documented catalog matches the implemented CLI surface.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add Devin for Terminal as a supported lifecycle agent with verified install, version-probe, and update metadata.
+
+## Impact
+
+- `src/agents/definitions/devin.ts` - new Devin lifecycle metadata definition
+- `src/agents/index.ts` and `src/index.ts` - register and re-export Devin
+- `test/agents.test.ts` and `test/index.test.ts` - registry and export coverage
+- `openspec/specs/agent-catalog/spec.md` - add the Devin requirement
+- `README.md` and `README.zh-CN.md` - sync supported-agent tables with the current catalog

--- a/openspec/changes/add-devin-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-devin-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,31 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Devin for Terminal MUST be a supported lifecycle agent
+
+Quantex SHALL include Devin for Terminal in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Devin for Terminal
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `devin`
+- **THEN** Quantex returns a supported agent entry for Devin for Terminal
+- **AND** the entry identifies `devin` as the executable binary
+- **AND** the entry identifies `https://cli.devin.ai/` as the homepage
+
+#### Scenario: Installing Devin for Terminal through supported methods
+
+- **WHEN** Quantex renders or executes install options for Devin for Terminal
+- **THEN** the catalog includes the official macOS/Linux shell installer (`curl -fsSL https://cli.devin.ai/install.sh | bash`)
+- **AND** the catalog includes the official Windows PowerShell installer (`irm https://static.devin.ai/cli/setup.ps1 | iex`)
+- **AND** the catalog does not invent unsupported managed package metadata when upstream documentation does not publish it
+
+#### Scenario: Probing Devin for Terminal version
+
+- **WHEN** Quantex probes the installed version of Devin for Terminal
+- **THEN** it runs `devin version` and parses the output
+
+#### Scenario: Planning Devin for Terminal updates
+
+- **WHEN** Quantex plans an update for a Devin for Terminal installation that supports the built-in updater
+- **THEN** the catalog exposes `devin update` as the agent self-update command

--- a/openspec/changes/add-devin-cli-support/tasks.md
+++ b/openspec/changes/add-devin-cli-support/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Add Devin agent support
+
+## 1. OpenSpec and docs
+
+- [x] 1.1 Add the proposal, design, tasks, and `agent-catalog` spec delta for Devin support.
+- [x] 1.2 Update the static supported-agent tables in `README.md` and `README.zh-CN.md`.
+
+## 2. Catalog implementation
+
+- [x] 2.1 Create `src/agents/definitions/devin.ts` with verified lifecycle metadata.
+- [x] 2.2 Register and re-export Devin through `src/agents/index.ts` and `src/index.ts`.
+- [x] 2.3 Add test coverage for Devin install methods, version probe, self-update, and root exports.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.
+- [x] 3.6 Run `bun run memory:check`.

--- a/src/agents/definitions/devin.ts
+++ b/src/agents/definitions/devin.ts
@@ -1,0 +1,20 @@
+import type { AgentDefinition } from '../types'
+import { scriptInstall } from '../methods'
+
+export const devin: AgentDefinition = {
+  name: 'devin',
+  displayName: 'Devin for Terminal',
+  homepage: 'https://cli.devin.ai/',
+  binaryName: 'devin',
+  selfUpdate: {
+    command: ['devin', 'update'],
+  },
+  versionProbe: {
+    command: ['devin', 'version'],
+  },
+  platforms: {
+    windows: [scriptInstall('irm https://static.devin.ai/cli/setup.ps1 | iex')],
+    macos: [scriptInstall('curl -fsSL https://cli.devin.ai/install.sh | bash')],
+    linux: [scriptInstall('curl -fsSL https://cli.devin.ai/install.sh | bash')],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -7,6 +7,7 @@ import { codex } from './definitions/codex'
 import { copilot } from './definitions/copilot'
 import { crush } from './definitions/crush'
 import { cursor } from './definitions/cursor'
+import { devin } from './definitions/devin'
 import { droid } from './definitions/droid'
 import { forgecode } from './definitions/forgecode'
 import { gemini } from './definitions/gemini'
@@ -30,6 +31,7 @@ const agents: AgentDefinition[] = [
   copilot,
   crush,
   cursor,
+  devin,
   droid,
   forgecode,
   gemini,
@@ -66,6 +68,7 @@ export {
   copilot,
   crush,
   cursor,
+  devin,
   droid,
   forgecode,
   gemini,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   codex,
   copilot,
   cursor,
+  devin,
   droid,
   gemini,
   getAgentByLookupName,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -7,6 +7,7 @@ import { codebuddy } from '../src/agents/definitions/codebuddy'
 import { codex } from '../src/agents/definitions/codex'
 import { copilot } from '../src/agents/definitions/copilot'
 import { cursor } from '../src/agents/definitions/cursor'
+import { devin } from '../src/agents/definitions/devin'
 import { droid } from '../src/agents/definitions/droid'
 import { gemini } from '../src/agents/definitions/gemini'
 import { junie } from '../src/agents/definitions/junie'
@@ -233,6 +234,35 @@ describe('cursor', () => {
     expect(cursor.platforms.macos!.find(m => (m.command ?? '').includes('cursor.com/install'))).toBeDefined()
     expect(cursor.platforms.linux!.find(m => (m.command ?? '').includes('cursor.com/install'))).toBeDefined()
     expect(cursor.platforms.windows!.find(m => (m.command ?? '').includes('cursor.com/install'))).toBeDefined()
+  })
+})
+
+describe('devin', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('devin')).toBe(devin)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(devin)
+    expect(devin.name).toBe('devin')
+    expect(devin.lookupAliases).toBeUndefined()
+    expect(devin.displayName).toBe('Devin for Terminal')
+    expect(devin.binaryName).toBe('devin')
+    expect(devin.homepage).toBe('https://cli.devin.ai/')
+    expect(devin.selfUpdate?.command).toEqual(['devin', 'update'])
+    expect(devin.versionProbe?.command).toEqual(['devin', 'version'])
+  })
+
+  it('exposes the official script installers per platform', () => {
+    expect(
+      devin.platforms.windows!.find(m => m.type === 'script' && m.command.includes('static.devin.ai/cli/setup.ps1')),
+    ).toBeDefined()
+    expect(
+      devin.platforms.macos!.find(m => m.type === 'script' && m.command.includes('cli.devin.ai/install.sh')),
+    ).toBeDefined()
+    expect(
+      devin.platforms.linux!.find(m => m.type === 'script' && m.command.includes('cli.devin.ai/install.sh')),
+    ).toBeDefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,7 @@ import {
   copilot,
   createUpdatePlan,
   cursor,
+  devin,
   droid,
   gemini,
   getAgentByLookupName,
@@ -89,6 +90,13 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('codebuddy')
   })
 
+  it('devin has correct structure', () => {
+    const agent = getAgentByNameOrAlias('devin')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('Devin for Terminal')
+    expect(agent!.binaryName).toBe('devin')
+  })
+
   it('opencode has correct structure', () => {
     const agent = getAgentByNameOrAlias('opencode')
     expect(agent).toBeDefined()
@@ -126,6 +134,7 @@ describe('agent definitions', () => {
     expect(codex.name).toBe('codex')
     expect(copilot.name).toBe('copilot')
     expect(cursor.name).toBe('cursor')
+    expect(devin.name).toBe('devin')
     expect(droid.name).toBe('droid')
     expect(gemini.name).toBe('gemini')
     expect(junie.name).toBe('junie')


### PR DESCRIPTION
## Summary

Add Devin for Terminal as a supported Quantex lifecycle agent so users can install, inspect, resolve, execute, and update it through the built-in catalog. This also records the upstream install/version/update contract in OpenSpec and keeps the public supported-agent tables aligned with the implemented surface.

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `openspec/changes/add-devin-cli-support/`
- Discussion: https://cli.devin.ai/docs

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Reviewers should pay extra attention to whether the documented Devin install and update commands remain the preferred upstream path, since this change intentionally avoids inventing unsupported managed package metadata.
