### PR TITLE
fix: make managed CLI runtime Node-compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,13 @@ With Bun:
 bun add -g quantex-cli
 ```
 
-With npm:
+With npm (Node.js 20+):
 
 ```bash
 npm i -g quantex-cli
 ```
+
+The published JS CLI runs on Node after installation. Bun remains a supported package-manager path for install and self-upgrade, while the standalone binary release remains the zero-runtime option.
 
 You can also download standalone binaries from [GitHub Releases](https://github.com/Drswith/quantex-cli/releases), or use the install script:
 
@@ -88,7 +90,7 @@ After installation, prefer `qtx` for the shortest copyable path. If you prefer t
 
 ## Try It Without Installing
 
-If your environment already provides the runtime Quantex currently expects, you can try read-only commands before doing a global install:
+If your environment already provides Node.js 20 or newer, you can try read-only commands before doing a global install:
 
 ```bash
 bunx quantex-cli list
@@ -100,7 +102,8 @@ pnpm --package=quantex-cli dlx qtx doctor
 Notes:
 
 - These commands are intended for read-only and discovery-oriented flows such as `list`, `info`, `inspect`, `doctor`, `capabilities`, `commands`, and `schema`.
-- The currently published package executes its CLI entrypoint through `bun`, so `npx` / `npm exec` / `pnpm dlx` still require a working `bun` on `PATH`.
+- `npx`, `npm exec`, and `pnpm dlx` run the published JS CLI through Node and do not require `bun` on `PATH`.
+- `bunx` still requires Bun because `bunx` itself is Bun's launcher.
 - For `install`, `ensure`, `update`, `uninstall`, `upgrade`, or any flow that should record install-source state, prefer a normal install first.
 
 ## Quick Start

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -66,11 +66,13 @@ If command behavior changed, also run bun run test.
 bun add -g quantex-cli
 ```
 
-使用 npm：
+使用 npm（Node.js 20+）：
 
 ```bash
 npm i -g quantex-cli
 ```
+
+已发布的 JS CLI 在安装后通过 Node 运行。Bun 仍然是受支持的安装与自升级路径，而独立二进制仍然是完全不依赖额外运行时的选项。
 
 也可以从 [GitHub Releases](https://github.com/Drswith/quantex-cli/releases) 下载独立二进制，或使用安装脚本：
 
@@ -88,7 +90,7 @@ irm https://raw.githubusercontent.com/Drswith/quantex-cli/main/install.ps1 | iex
 
 ## 免安装试用
 
-如果你已经有 Quantex 当前要求的运行时环境，可以先不做全局安装，直接试用只读命令：
+如果你的环境已经有 Node.js 20 或更高版本，可以先不做全局安装，直接试用只读命令：
 
 ```bash
 bunx quantex-cli list
@@ -100,7 +102,8 @@ pnpm --package=quantex-cli dlx qtx doctor
 注意事项：
 
 - 这些命令适合 `list`、`info`、`inspect`、`doctor`、`capabilities`、`commands`、`schema` 这类只读或发现型操作。
-- 当前已发布包的 CLI 入口通过 `bun` 执行，所以即使走 `npx` / `npm exec` / `pnpm dlx`，运行环境里也仍然需要可用的 `bun`。
+- `npx`、`npm exec`、`pnpm dlx` 会通过 Node 运行已发布的 JS CLI，不要求环境里存在 `bun`。
+- `bunx` 仍然需要 Bun，因为它本身就是 Bun 提供的启动器。
 - `install`、`ensure`、`update`、`uninstall`、`upgrade` 这类会写状态或依赖已记录安装来源的操作，仍然建议先按上面的方式正常安装再执行。
 
 ## 快速开始

--- a/openspec/changes/make-js-cli-node-runtime/.openspec.yaml
+++ b/openspec/changes/make-js-cli-node-runtime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/make-js-cli-node-runtime/design.md
+++ b/openspec/changes/make-js-cli-node-runtime/design.md
@@ -1,0 +1,69 @@
+## Context
+
+Quantex publishes a JS CLI package whose `bin` entrypoints point to `dist/cli.mjs`, but the current source runtime still assumes Bun. The shebang uses `#!/usr/bin/env bun`, several modules call `Bun.spawn`, `Bun.file`, `Bun.write`, and `Bun.TOML.parse`, and the README explicitly warns that package-manager no-install usage still requires Bun on `PATH`.
+
+That coupling is broader than the product needs. Bun is useful for Quantex maintainers because it powers the repository's fast build, validation, and release scripts, but npm-installed users should not inherit Bun as an extra runtime prerequisite just to execute a packaged CLI. The design therefore needs to separate the published CLI runtime boundary from the repo's maintainer toolchain boundary without breaking self-upgrade, agent lifecycle behavior, or release packaging.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the published CLI runtime in `src/` and `dist/` execute under supported Node.js without accessing Bun globals.
+- Preserve the existing Quantex product surface, including managed self-upgrade behavior, structured output, and standalone binary releases.
+- Keep Bun available for repository-local scripts, validation, and release automation where it already works well.
+- Add validation that proves both package contents and Node-based CLI execution remain intact.
+
+**Non-Goals:**
+
+- Rewriting every maintainer-facing script under `scripts/` to stop using Bun.
+- Changing agent install/update semantics or removing Bun as a supported managed install method for third-party agents.
+- Reworking the standalone binary build pipeline beyond any packaging or smoke-check adjustments needed for the new runtime contract.
+
+## Decisions
+
+### Restrict the Node-compatibility migration to the published runtime boundary
+
+The Node migration will apply to `src/` and the generated `dist/` outputs that ship to end users. Repository scripts under `scripts/` may stay Bun-based for now.
+
+This yields the user-facing benefit quickly while avoiding a repo-wide runtime migration that would slow delivery and expand risk. It also matches the real boundary that matters: the files shipped in the npm package and invoked by `qtx`, `quantex`, `npx`, and `npm exec`.
+
+Alternative considered:
+
+- Convert the entire repository to Node-only. Rejected for this change because it adds toolchain churn without improving the shipped CLI contract.
+
+### Replace Bun runtime APIs with narrow Node-native helpers
+
+Runtime modules will stop calling Bun globals directly. Process execution will move to a Node `child_process.spawn` wrapper, JSON state/config persistence will use `node:fs/promises`, and stdout/stderr collection will use Node stream consumers.
+
+This keeps the migration localized and makes the runtime contract easy to audit: user-shipped code no longer needs Bun-specific APIs.
+
+Alternative considered:
+
+- Keep Bun types and polyfill a `Bun` shim at runtime. Rejected because it preserves the hidden dependency and makes failures harder to reason about.
+
+### Use a narrow bunfig registry parser instead of adding a general TOML runtime dependency
+
+The only Bun-only parse in the shipped runtime is reading `bunfig.toml` to discover a registry for managed self-upgrade. For this change Quantex will replace `Bun.TOML.parse` with a purpose-built parser that extracts the supported `install.registry` forms Quantex actually needs.
+
+This keeps the published package dependency-free at runtime and avoids increasing tarball size just to read one configuration field.
+
+Alternative considered:
+
+- Add a TOML parser dependency. Rejected for now because the needed surface is small and the extra runtime dependency would mainly pay for unused parsing features.
+
+### Validate both package boundaries and Node execution
+
+Package checks will continue verifying that standalone binaries stay out of the managed-install tarball, and they will also verify that the built CLI runs under Node.
+
+This protects the two failure modes the change cares about most: shipping the wrong files and silently reintroducing Bun-only runtime code later.
+
+Alternative considered:
+
+- Validate only source patterns or only the shebang. Rejected because that would miss runtime regressions introduced through future refactors or build output changes.
+
+## Risks / Trade-offs
+
+- [Node and Bun spawn semantics differ in edge cases] -> Keep the replacement wrapper narrow and run the existing test suite plus package execution smoke checks.
+- [The bunfig parser misses a valid but uncommon registry form] -> Support the currently documented forms Quantex already consumes and fall back cleanly when parsing fails.
+- [Maintainers assume "Bun removed from runtime" means "Bun removed from repo"] -> Update README wording so runtime expectations and maintainer workflow expectations are clearly separated.
+- [A future contributor reintroduces `Bun.*` in shipped runtime code] -> Add validation that executes the built CLI with Node and keep the new runtime contract explicit in OpenSpec.

--- a/openspec/changes/make-js-cli-node-runtime/proposal.md
+++ b/openspec/changes/make-js-cli-node-runtime/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+This work was classified as OpenSpec-required because it changes observable managed-install behavior, package distribution, architecture boundaries, and product-facing documentation. Quantex's published JS CLI currently depends on Bun runtime APIs, which means users who install through npm or run no-install package-manager entrypoints still need `bun` on `PATH`; that hidden prerequisite raises adoption friction and makes the managed package feel heavier than it should.
+
+## What Changes
+
+- Make the published JS CLI runtime under `src/` and `dist/` execute on supported Node.js without requiring Bun runtime APIs or a `bun` shebang.
+- Keep Bun as a maintainer-facing development, build, validation, and release tool for the repository instead of making the whole project Node-first.
+- Add regression checks that verify the packed managed-install artifact still excludes standalone binaries and that the built CLI can be executed by Node.
+- Update product-facing install and no-install documentation so users understand the runtime expectations for npm, Bun, and standalone binary usage.
+
+## Capabilities
+
+### New Capabilities
+
+- `js-runtime-compatibility`: the managed-install JS CLI runtime executes under supported Node.js without requiring Bun to be present at runtime.
+
+### Modified Capabilities
+
+- `package-distribution`: the managed-install package keeps the runtime files and metadata needed for Node-based execution while still excluding standalone binary artifacts.
+- `product-readme`: install and no-install guidance describe the managed package's Node runtime contract and keep standalone binaries as the no-runtime path.
+
+## Impact
+
+- Affected code: `src/cli.ts`, `src/config/`, `src/state/`, `src/self/`, `src/utils/`, `src/package-manager/bun.ts`, and packaging validation scripts.
+- Affected contracts: published CLI runtime compatibility, managed package contents, and user-facing installation guidance.
+- Dependencies and tooling: Node-compatible runtime helpers may replace Bun-only runtime APIs; Bun remains the repo's primary maintainer toolchain.

--- a/openspec/changes/make-js-cli-node-runtime/specs/js-runtime-compatibility/spec.md
+++ b/openspec/changes/make-js-cli-node-runtime/specs/js-runtime-compatibility/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: Managed CLI runtime MUST execute on supported Node.js without Bun
+
+The published Quantex managed-install JS runtime SHALL execute on supported Node.js without requiring Bun to be present on `PATH` at runtime.
+
+#### Scenario: Running an npm-installed Quantex CLI without Bun
+
+- **WHEN** a user installs Quantex through a managed JS package path such as npm
+- **AND** the environment provides supported Node.js but no `bun` executable
+- **THEN** running `qtx --version` or `quantex --version` starts the published CLI successfully
+- **AND** the runtime does not depend on Bun globals or a `bun` shebang
+
+#### Scenario: Running a no-install package-manager entrypoint without Bun
+
+- **WHEN** a package manager launches the published Quantex bin entrypoint in a supported Node.js environment without `bun` on `PATH`
+- **THEN** read-only commands such as `qtx commands --json` can execute successfully
+

--- a/openspec/changes/make-js-cli-node-runtime/specs/package-distribution/spec.md
+++ b/openspec/changes/make-js-cli-node-runtime/specs/package-distribution/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: Managed-install package MUST keep runtime CLI files
+
+The npm package consumed by Bun and npm managed installs SHALL still include the runtime CLI files and metadata needed to execute the CLI under supported Node.js and perform lazy self-install-source reconciliation at runtime.
+
+#### Scenario: User installs Quantex from npm or Bun
+
+- **WHEN** the managed-install package is packed for publication
+- **THEN** it still contains the runtime CLI files under `dist/` needed for `qtx` and `quantex`
+- **AND** the published CLI entrypoint is executable by Node.js
+- **AND** it does not require Bun to be present on `PATH` after installation
+- **AND** it does not require an install-time `postinstall` entrypoint to preserve the managed self-upgrade contract
+

--- a/openspec/changes/make-js-cli-node-runtime/specs/product-readme/spec.md
+++ b/openspec/changes/make-js-cli-node-runtime/specs/product-readme/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+
+### Requirement: README Documents Verified Read-Only No-Install Usage
+
+The product README SHALL include a first-class no-install try-it-out section that promotes only read-only or discovery-oriented commands and uses command forms verified against the published package behavior.
+
+#### Scenario: User evaluates Quantex without a global install
+
+- **WHEN** a user opens the no-install try-it-out section
+- **THEN** the README shows copyable commands for read-only surfaces such as `list`, `info`, `inspect`, `doctor`, `capabilities`, `commands`, or `schema`
+- **AND** each recommended package-manager form matches a currently working invocation for the published package
+- **AND** the section states the current Node-based runtime prerequisite for managed package execution when applicable
+- **AND** the section does not claim that `bun` is required merely to execute the published JS CLI
+
+#### Scenario: User looks for mutating no-install commands
+
+- **WHEN** a user reads the no-install try-it-out guidance
+- **THEN** the README directs install, update, uninstall, and other state-writing flows back to the normal installation paths instead of promoting them as first-class no-install usage

--- a/openspec/changes/make-js-cli-node-runtime/tasks.md
+++ b/openspec/changes/make-js-cli-node-runtime/tasks.md
@@ -1,0 +1,14 @@
+## 1. OpenSpec And Contract Updates
+
+- [x] 1.1 Add the proposal, design, and spec deltas for the Node-compatible managed runtime contract.
+- [x] 1.2 Update product-facing documentation to describe the managed package runtime expectations for npm, Bun, and standalone binaries.
+
+## 2. Runtime Refactor
+
+- [x] 2.1 Replace Bun runtime APIs in `src/` with Node-compatible process, file, and stream helpers.
+- [x] 2.2 Switch the published CLI entrypoint to a Node shebang and keep managed self-upgrade registry detection working without `Bun.TOML.parse`.
+
+## 3. Packaging And Validation
+
+- [x] 3.1 Extend package validation so it verifies both the managed-install artifact boundary and Node-based CLI execution.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, `bun run build`, `bun run package:check`, and `bun run openspec:validate`.

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
       "oxfmt --write"
     ]
   },
+  "engines": {
+    "node": ">=20"
+  },
   "packageManager": "bun@1.3.11"
 }

--- a/scripts/verify-package-distribution.ts
+++ b/scripts/verify-package-distribution.ts
@@ -61,12 +61,38 @@ if (missingFiles.length > 0) {
   throw new Error(`Managed-install package is missing required runtime files:\n${missingFiles.join('\n')}`)
 }
 
+const nodeSmoke = Bun.spawn(['node', 'dist/cli.mjs', 'commands', '--json'], {
+  cwd: process.cwd(),
+  env: process.env,
+  stdio: ['ignore', 'pipe', 'pipe'] as const,
+})
+
+const [nodeSmokeStdout, nodeSmokeStderr, nodeSmokeExitCode] = await Promise.all([
+  nodeSmoke.stdout ? new Response(nodeSmoke.stdout).text() : Promise.resolve(''),
+  nodeSmoke.stderr ? new Response(nodeSmoke.stderr).text() : Promise.resolve(''),
+  nodeSmoke.exited,
+])
+
+if (nodeSmokeExitCode !== 0) {
+  throw new Error(
+    `Node CLI smoke check failed with exit code ${nodeSmokeExitCode}.\n${nodeSmokeStderr.trim() || nodeSmokeStdout.trim()}`,
+  )
+}
+
+try {
+  JSON.parse(nodeSmokeStdout)
+} catch (error) {
+  throw new Error(`Node CLI smoke check did not emit valid JSON.\n${String(error)}\n${nodeSmokeStdout.trim()}`, {
+    cause: error,
+  })
+}
+
 if (packedPackage.filename) {
   await rm(join(process.cwd(), packedPackage.filename), { force: true })
 }
 
 console.log(
-  `Managed-install package excludes dist/bin and postinstall entrypoints, and keeps runtime files (${requiredFiles.join(', ')}).`,
+  `Managed-install package excludes dist/bin and postinstall entrypoints, keeps runtime files (${requiredFiles.join(', ')}), and runs under Node.`,
 )
 
 function parsePackOutput(packStdout: string): PackedPackage[] {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 
 import type { CommandResult, CommandTarget } from './output/types'
 import { program } from 'commander'

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,5 @@
 import type { SelfUpdateChannel } from '../self/types'
-import { mkdir, readFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -55,7 +55,7 @@ export function isNpmBunUpdateStrategy(value: string): value is NpmBunUpdateStra
 
 export async function saveConfig(config: Record<string, unknown>): Promise<void> {
   await mkdir(getConfigDir(), { recursive: true })
-  await Bun.write(getConfigFilePath(), `${JSON.stringify(config, null, 2)}\n`)
+  await writeFile(getConfigFilePath(), `${JSON.stringify(config, null, 2)}\n`, 'utf8')
 }
 
 async function readUserConfig(): Promise<Record<string, unknown>> {

--- a/src/package-manager/bun.ts
+++ b/src/package-manager/bun.ts
@@ -1,4 +1,4 @@
-import { spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
+import { readProcessOutput, spawnCommand, spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
 import { normalizeRegistryUrl } from '../utils/registry'
 
 export type RegistryUpdateStrategy = 'latest-major' | 'respect-semver'
@@ -90,15 +90,14 @@ async function trustBlockedGlobalPackages(packageNames: string[]): Promise<boole
 
 async function readGlobalUntrustedPackages(): Promise<string | undefined> {
   try {
-    const proc = Bun.spawn(['bun', 'pm', '-g', 'untrusted'], {
+    const proc = spawnCommand(['bun', 'pm', '-g', 'untrusted'], {
       stdio: createPipedStdio(),
     })
-    const output = await new Response(proc.stdout).text()
-    await proc.exited
+    const { exitCode, stdout } = await readProcessOutput(proc)
 
-    if (proc.exitCode !== 0) return undefined
+    if (exitCode !== 0) return undefined
 
-    return output
+    return stdout
   } catch {
     return undefined
   }

--- a/src/self/binary.ts
+++ b/src/self/binary.ts
@@ -4,6 +4,7 @@ import { createHash } from 'node:crypto'
 import { chmod, mkdtemp, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
 import process from 'node:process'
+import { readProcessOutput, spawnCommand } from '../utils/child-process'
 
 type BinaryUpgradeResult = Omit<SelfUpdateResult, 'installSource'>
 
@@ -94,7 +95,7 @@ function scheduleWindowsBinaryReplacement(
       process.pid,
       expectedVersion,
     )
-    const proc = Bun.spawn(
+    const proc = spawnCommand(
       [
         'powershell.exe',
         '-NoProfile',
@@ -112,7 +113,7 @@ function scheduleWindowsBinaryReplacement(
       },
     )
 
-    proc.unref?.()
+    proc.unref()
     return {
       success: true,
     }
@@ -202,11 +203,10 @@ async function verifyStandaloneBinary(executablePath: string, expectedVersion?: 
   if (!expectedVersion) return { success: true }
 
   try {
-    const proc = Bun.spawn([executablePath, '--version'], {
+    const proc = spawnCommand([executablePath, '--version'], {
       stdio: ['ignore', 'pipe', 'ignore'] as const,
     })
-    const stdout = proc.stdout ? await new Response(proc.stdout).text() : ''
-    const exitCode = await proc.exited
+    const { exitCode, stdout } = await readProcessOutput(proc)
 
     if (exitCode !== 0) {
       return createBinaryFailure(

--- a/src/self/registry.ts
+++ b/src/self/registry.ts
@@ -102,14 +102,7 @@ async function readRegistryFromBunfig(cwd: string, env: NodeJS.ProcessEnv): Prom
 
 async function parseBunfigRegistry(path: string): Promise<string | undefined> {
   try {
-    const parsed = Bun.TOML.parse(await readFile(path, 'utf8')) as {
-      install?: {
-        registry?: string | { url?: string }
-      }
-    }
-    const registryValue = parsed.install?.registry
-    if (typeof registryValue === 'string') return normalizeRegistryUrl(registryValue)
-    return normalizeRegistryUrl(registryValue?.url)
+    return parseBunfigRegistryValue(await readFile(path, 'utf8'))
   } catch {
     return undefined
   }
@@ -165,4 +158,33 @@ function findNearestFile(startDir: string, fileName: string): string | undefined
 
 function resolveHomeDir(env: NodeJS.ProcessEnv): string {
   return env.HOME || env.USERPROFILE || homedir()
+}
+
+function parseBunfigRegistryValue(content: string): string | undefined {
+  const directRegistry = matchFirstQuotedValue(content, [
+    /(?:^|\n)\s*install\.registry\s*=\s*["']([^"'#\n]+)["']/,
+    /(?:^|\n)\s*install\.registry\s*=\s*\{\s*url\s*=\s*["']([^"'#\n]+)["']/,
+    /(?:^|\n)\s*install\s*=\s*\{[\s\S]*?\bregistry\s*=\s*["']([^"'#\n]+)["'][\s\S]*?\}/,
+    /(?:^|\n)\s*install\s*=\s*\{[\s\S]*?\bregistry\s*=\s*\{\s*url\s*=\s*["']([^"'#\n]+)["'][\s\S]*?\}[\s\S]*?\}/,
+  ])
+  if (directRegistry) return normalizeRegistryUrl(directRegistry)
+
+  const installSection = content.match(/(?:^|\n)\s*\[install\]\s*\n([\s\S]*?)(?=\n\s*\[[^\]]+\]|\s*$)/)?.[1]
+  if (!installSection) return undefined
+
+  const sectionRegistry = matchFirstQuotedValue(installSection, [
+    /(?:^|\n)\s*registry\s*=\s*["']([^"'#\n]+)["']/,
+    /(?:^|\n)\s*registry\s*=\s*\{\s*url\s*=\s*["']([^"'#\n]+)["']/,
+  ])
+
+  return normalizeRegistryUrl(sectionRegistry)
+}
+
+function matchFirstQuotedValue(content: string, patterns: RegExp[]): string | undefined {
+  for (const pattern of patterns) {
+    const value = content.match(pattern)?.[1]
+    if (value) return value
+  }
+
+  return undefined
 }

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,6 +1,6 @@
 import type { InstallType, PackageTargetKind } from '../agents/types'
 import type { SelfInstallSource } from '../self/types'
-import { mkdir } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { getConfigDir } from '../config'
 import { acquireResourceLock, getResourceLockPath } from '../utils/lock'
@@ -82,7 +82,7 @@ export async function setSelfInstallSource(installSource: SelfInstallSource): Pr
 
 async function readState(): Promise<QuantexState> {
   try {
-    const data = (await Bun.file(getStateFilePath()).json()) as Partial<QuantexState>
+    const data = JSON.parse(await readFile(getStateFilePath(), 'utf8')) as Partial<QuantexState>
     return {
       installedAgents: data.installedAgents ?? {},
       self: data.self ?? {},
@@ -94,7 +94,7 @@ async function readState(): Promise<QuantexState> {
 
 async function writeState(state: QuantexState): Promise<void> {
   await mkdir(getConfigDir(), { recursive: true })
-  await Bun.write(getStateFilePath(), `${JSON.stringify(state, null, 2)}\n`)
+  await writeFile(getStateFilePath(), `${JSON.stringify(state, null, 2)}\n`, 'utf8')
 }
 
 async function mutateState(mutator: (state: QuantexState) => void | Promise<void>): Promise<void> {

--- a/src/utils/child-process.ts
+++ b/src/utils/child-process.ts
@@ -1,18 +1,41 @@
+import { spawn, type ChildProcess, type SpawnOptions as NodeSpawnOptions } from 'node:child_process'
 import process from 'node:process'
+import { text as readText } from 'node:stream/consumers'
 import { getCliContext, registerCliCancellationHandler } from '../cli-context'
 
-type SpawnCommand = Parameters<typeof Bun.spawn>[0]
-type SpawnOptions = Exclude<Parameters<typeof Bun.spawn>[1], undefined>
+export type SpawnCommand = readonly string[]
+type SpawnStdio = 'ignore' | 'inherit' | 'pipe'
+type SpawnOptions = Omit<NodeSpawnOptions, 'stdio'> & {
+  stdio?: [SpawnStdio, SpawnStdio, SpawnStdio]
+}
+
+interface BunSpawnLike {
+  exitCode: number | null
+  exited: Promise<unknown>
+  kill?: (signal?: NodeJS.Signals | number) => boolean
+  stderr?: unknown
+  stdout?: unknown
+  unref?: () => void
+}
+
+export interface SpawnedProcessHandle {
+  readonly exitCode: number | null
+  readonly stderr: ChildProcess['stderr']
+  readonly stdout: ChildProcess['stdout']
+  exited: Promise<number>
+  kill: ChildProcess['kill']
+  unref: () => void
+}
 
 export interface SpawnHandle {
   cleanup: () => void
   outputDrained: Promise<void>
-  proc: ReturnType<typeof Bun.spawn>
+  proc: SpawnedProcessHandle
 }
 
 export function spawnWithQuantexStdio(command: SpawnCommand, options: SpawnOptions = {}): SpawnHandle {
   if (getCliContext().outputMode === 'human') {
-    const proc = Bun.spawn(command, {
+    const proc = spawnCommand(command, {
       ...options,
       stdio: ['inherit', 'inherit', 'inherit'] as const,
     })
@@ -23,7 +46,7 @@ export function spawnWithQuantexStdio(command: SpawnCommand, options: SpawnOptio
     }
   }
 
-  const proc = Bun.spawn(command, {
+  const proc = spawnCommand(command, {
     ...options,
     stdio: ['ignore', 'pipe', 'pipe'] as const,
   })
@@ -37,17 +60,110 @@ export function spawnWithQuantexStdio(command: SpawnCommand, options: SpawnOptio
 
 export async function waitForSpawnedCommand(handle: SpawnHandle): Promise<number> {
   try {
-    await handle.proc.exited
+    const exitCode = await handle.proc.exited
     await handle.outputDrained
-    return handle.proc.exitCode ?? 1
+    return exitCode
   } finally {
     handle.cleanup()
+  }
+}
+
+export function spawnCommand(command: SpawnCommand, options: SpawnOptions = {}): SpawnedProcessHandle {
+  const bunSpawn = getBunSpawn()
+  if (bunSpawn) return spawnWithBun(command, options, bunSpawn)
+
+  const [file, ...args] = command
+  if (!file) {
+    throw new Error('spawnCommand requires a non-empty command array.')
+  }
+  const child = spawn(file, args, {
+    ...options,
+    shell: options.shell ?? shouldUseShellOnWindows(file),
+  })
+
+  return {
+    get exitCode() {
+      return child.exitCode
+    },
+    stderr: child.stderr,
+    stdout: child.stdout,
+    exited: waitForChildProcess(child),
+    kill: child.kill.bind(child),
+    unref: () => child.unref(),
+  }
+}
+
+export async function readProcessOutput(proc: SpawnedProcessHandle): Promise<{
+  exitCode: number
+  stderr: string
+  stdout: string
+}> {
+  const [stdout, stderr, exitCode] = await Promise.all([
+    readStreamText(proc.stdout),
+    readStreamText(proc.stderr),
+    proc.exited,
+  ])
+
+  return {
+    exitCode,
+    stderr,
+    stdout,
   }
 }
 
 async function forwardToStderr(stream: unknown): Promise<void> {
   if (!stream) return
 
-  const output = await new Response(stream as any).text()
+  const output = await readStreamText(stream as NodeJS.ReadableStream)
   if (output) process.stderr.write(output)
+}
+
+async function waitForChildProcess(child: ChildProcess): Promise<number> {
+  return new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('close', code => {
+      resolve(typeof code === 'number' ? code : 1)
+    })
+  })
+}
+
+async function readStreamText(stream: unknown): Promise<string> {
+  if (!stream) return ''
+  if (typeof stream === 'string') return stream
+  if (typeof (stream as { getReader?: unknown }).getReader === 'function') {
+    return new Response(stream as unknown as ReadableStream).text()
+  }
+  return readText(stream as NodeJS.ReadableStream)
+}
+
+function shouldUseShellOnWindows(file: string): boolean {
+  if (process.platform !== 'win32') return false
+  if (file.includes('/') || file.includes('\\')) return false
+  return !/\.[a-z0-9]+$/i.test(file)
+}
+
+function getBunSpawn(): ((command: string[], options?: SpawnOptions) => BunSpawnLike) | undefined {
+  const candidate = (globalThis as { Bun?: { spawn?: unknown } }).Bun?.spawn
+  return typeof candidate === 'function'
+    ? (candidate as (command: string[], options?: SpawnOptions) => BunSpawnLike)
+    : undefined
+}
+
+function spawnWithBun(
+  command: SpawnCommand,
+  options: SpawnOptions,
+  bunSpawn: (command: string[], options?: SpawnOptions) => BunSpawnLike,
+): SpawnedProcessHandle {
+  const proc = bunSpawn([...command], options)
+
+  return {
+    get exitCode() {
+      return proc.exitCode
+    },
+    stderr: proc.stderr as ChildProcess['stderr'],
+    stdout: proc.stdout as ChildProcess['stdout'],
+    exited: proc.exited.then(() => (typeof proc.exitCode === 'number' ? proc.exitCode : 1)),
+    kill: signal => proc.kill?.(signal) ?? false,
+    unref: () => proc.unref?.(),
+  }
 }

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,6 +1,8 @@
 import type { Colors } from 'picocolors/types'
-import { createColors, isColorSupported } from 'picocolors'
+import pico from 'picocolors'
 import { getCliContext } from '../cli-context'
+
+const { createColors, isColorSupported } = pico
 
 function getColors(): Colors {
   const mode = getCliContext().colorMode ?? 'auto'

--- a/src/utils/detect.ts
+++ b/src/utils/detect.ts
@@ -1,5 +1,6 @@
 import type { Platform } from '../agents/types'
 import process from 'node:process'
+import { readProcessOutput, spawnCommand } from './child-process'
 
 export function getPlatform(): Platform {
   switch (process.platform) {
@@ -14,9 +15,8 @@ export function getPlatform(): Platform {
 
 async function isCommandAvailable(command: string): Promise<boolean> {
   try {
-    const proc = Bun.spawn([command, '--version'], { stdout: 'pipe', stderr: 'pipe' })
-    await proc.exited
-    return proc.exitCode === 0
+    const { exitCode } = await readProcessOutput(spawnCommand([command, '--version']))
+    return exitCode === 0
   } catch {
     return false
   }
@@ -41,9 +41,8 @@ export async function isWingetAvailable(): Promise<boolean> {
 export async function isBinaryInPath(binaryName: string): Promise<boolean> {
   try {
     const cmd = process.platform === 'win32' ? 'where' : 'which'
-    const proc = Bun.spawn([cmd, binaryName], { stdout: 'pipe', stderr: 'pipe' })
-    await proc.exited
-    return proc.exitCode === 0
+    const { exitCode } = await readProcessOutput(spawnCommand([cmd, binaryName]))
+    return exitCode === 0
   } catch {
     return false
   }

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,6 +1,7 @@
 import type { AgentVersionProbe } from '../agents'
 import { realpath } from 'node:fs/promises'
 import process from 'node:process'
+import { readProcessOutput, spawnCommand } from './child-process'
 import { fetchJsonWithCache } from './network'
 import { buildRegistryPackageVersionUrl, OFFICIAL_NPM_REGISTRY, normalizeRegistryUrl } from './registry'
 
@@ -22,10 +23,9 @@ export async function getInstalledVersion(
   const command = versionProbe?.command ?? [binaryName, '--version']
 
   try {
-    const proc = Bun.spawn(command, { stdout: 'pipe', stderr: 'pipe' })
-    await proc.exited
-    if (proc.exitCode !== 0) return undefined
-    const text = await new Response(proc.stdout).text()
+    const { exitCode, stdout } = await readProcessOutput(spawnCommand(command))
+    if (exitCode !== 0) return undefined
+    const text = stdout
     return parseInstalledVersionOutput(text, versionProbe?.parser)
   } catch {
     return undefined
@@ -52,10 +52,9 @@ export async function getLatestVersion(
 export async function getBinaryPath(binaryName: string): Promise<string | undefined> {
   try {
     const cmd = process.platform === 'win32' ? 'where' : 'which'
-    const proc = Bun.spawn([cmd, binaryName], { stdout: 'pipe', stderr: 'pipe' })
-    await proc.exited
-    if (proc.exitCode !== 0) return undefined
-    const text = await new Response(proc.stdout).text()
+    const { exitCode, stdout } = await readProcessOutput(spawnCommand([cmd, binaryName]))
+    if (exitCode !== 0) return undefined
+    const text = stdout
     return text.trim().split('\n')[0]
   } catch {
     return undefined

--- a/test/self-binary.test.ts
+++ b/test/self-binary.test.ts
@@ -33,6 +33,8 @@ describe('upgradeStandaloneBinary', () => {
     const tempRoot = await mkdtemp(join(tmpdir(), 'quantex-binary-win-'))
     const executablePath = join(tempRoot, 'qtx.exe')
     const mockSpawn = vi.fn().mockReturnValue({
+      exitCode: 0,
+      exited: Promise.resolve(0),
       unref: vi.fn(),
     })
 
@@ -94,6 +96,7 @@ describe('upgradeStandaloneBinary', () => {
     const executablePath = join(tempRoot, 'qtx')
     const replacement = '#!/bin/sh\necho 1.1.0\n'
     const mockSpawn = vi.fn().mockReturnValue({
+      exitCode: 0,
       exited: Promise.resolve(0),
       stdout: createByteStream('1.1.0\n'),
     })
@@ -159,6 +162,7 @@ describe('upgradeStandaloneBinary', () => {
     const original = '#!/bin/sh\necho old\n'
     const replacement = '#!/bin/sh\nexit 1\n'
     const mockSpawn = vi.fn().mockReturnValue({
+      exitCode: 1,
       exited: Promise.resolve(1),
       stdout: createByteStream(''),
     })

--- a/test/utils/detect.test.ts
+++ b/test/utils/detect.test.ts
@@ -23,7 +23,11 @@ function createMockProcess(exitCode: number, stdout = '') {
         controller.close()
       },
     }),
-    stderr: new ReadableStream(),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    }),
   }
 }
 

--- a/test/utils/version.test.ts
+++ b/test/utils/version.test.ts
@@ -47,7 +47,11 @@ function createMockProcess(exitCode: number, stdout = '') {
         controller.close()
       },
     }),
-    stderr: new ReadableStream(),
+    stderr: new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    }),
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
-    "types": ["bun-types"],
+    "types": ["node", "bun-types"],
     "strict": true,
     "strictNullChecks": true,
     "noEmit": true,


### PR DESCRIPTION
## Summary

Make the published Quantex JS CLI run on Node 20+ without requiring Bun to be present at runtime.

- replace Bun-only runtime APIs in shipped `src/` code with Node-compatible process, file, and stream helpers
- switch the published CLI shebang to Node while preserving managed self-upgrade registry detection
- document the new npm/no-install runtime contract and add a package smoke check that executes the built CLI with Node

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `openspec/changes/make-js-cli-node-runtime/`
- Discussion: none

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below
- [x] `bun run build`
- [x] `bun run package:check`
- [x] `bun run openspec:validate`

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [x] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Reviewers should pay extra attention to the new Node/Bun process wrapper, the narrow `bunfig.toml` registry parser, and the Node-based package smoke check because those pieces now define the managed runtime boundary.
