### PR TITLE
feat: add passive self-upgrade notice

### DIFF
--- a/openspec/changes/add-self-upgrade-notice/.openspec.yaml
+++ b/openspec/changes/add-self-upgrade-notice/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/add-self-upgrade-notice/design.md
+++ b/openspec/changes/add-self-upgrade-notice/design.md
@@ -1,0 +1,43 @@
+## Overview
+
+Add a post-command human reminder for outdated Quantex installs without changing command result payloads or forcing explicit update checks. The reminder should be best-effort, cheap on repeated invocations, and invisible to machine-facing modes.
+
+## Decisions
+
+- Hook the reminder into `executeCommandWithRuntime()` after the command result has been emitted and persisted for idempotency.
+- Limit the reminder to successful human-mode runtime commands.
+- Skip commands that already own self-upgrade messaging, specifically `upgrade` and `doctor`.
+- Reuse `inspectSelf()` for version resolution so the notice follows the same install-source and registry logic as explicit self-upgrade checks.
+- Store reminder throttle state in `state.json` under `self`, keyed by the last reminded target version and timestamp.
+
+## Reminder Rules
+
+- Only consider showing a reminder when:
+  - `outputMode === "human"`
+  - `quiet !== true`
+  - the command result is successful
+  - the action is not `upgrade` or `doctor`
+- Show a reminder only when `inspection.latestVersion` exists and differs from `inspection.currentVersion`.
+- If `inspection.canAutoUpdate` is true, suggest `quantex upgrade`.
+- If `inspection.canAutoUpdate` is false, suggest `quantex doctor` for source-specific remediation.
+- Suppress repeated reminders for the same target version until at least 24 hours have elapsed.
+- Show a new reminder immediately when a newer target version than the last reminded version appears.
+
+## State Shape
+
+Extend `state.self` with:
+
+- `updateNoticeVersion?: string`
+- `updateNoticeAt?: string`
+
+This keeps the throttle local to self-upgrade state and avoids introducing a separate persistence file.
+
+## Testing
+
+- Add state tests for persisting the update-notice markers.
+- Add runtime tests for:
+  - showing the reminder in human mode when outdated
+  - suppressing it in structured modes
+  - suppressing it for `upgrade` and `doctor`
+  - suppressing repeat reminders inside the throttle window
+  - re-showing when the available version changes

--- a/openspec/changes/add-self-upgrade-notice/proposal.md
+++ b/openspec/changes/add-self-upgrade-notice/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Implementation requested work-intake classification: this change modifies observable human CLI behavior for self-upgrade awareness, so it requires OpenSpec before file edits.
+
+Quantex can already tell a user whether a newer CLI version exists when they explicitly run `quantex upgrade --check` or `quantex doctor`, but users running older installs have no lightweight reminder during normal management flows. That leaves release adoption dependent on manual checking even when Quantex already knows how to detect a newer version.
+
+## What Changes
+
+- Add a human-mode self-upgrade notice that can appear after successful Quantex management commands when the current CLI version is behind the installable latest version.
+- Gate the notice so it does not affect JSON or NDJSON output, `--quiet`, or explicit self-upgrade and doctor flows that already surface upgrade state.
+- Persist lightweight reminder state so Quantex does not repeat the same notice on every command invocation.
+
+## Capabilities
+
+### New Capabilities
+
+- `self-upgrade-notice`: Human-mode reminder behavior for outdated Quantex installs, including throttling and output-mode gating.
+
+### Modified Capabilities
+
+- `self-upgrade`: Human-mode self-upgrade surfaces now include a passive reminder path outside explicit `upgrade` and `doctor` commands.
+
+## Impact
+
+- Affected code: `src/command-runtime.ts`, `src/self/`, `src/state/`, and related tests.
+- Affected specs: new `self-upgrade-notice` capability and a delta to `self-upgrade`.
+- No structured output, schema version, or command catalog changes are intended.

--- a/openspec/changes/add-self-upgrade-notice/specs/self-upgrade-notice/spec.md
+++ b/openspec/changes/add-self-upgrade-notice/specs/self-upgrade-notice/spec.md
@@ -1,0 +1,74 @@
+# Self-Upgrade Notice Specification
+
+## Purpose
+
+Define the passive human-mode reminder behavior for outdated Quantex CLI installs.
+
+## ADDED Requirements
+
+### Requirement: Human-mode runtime commands MUST be able to remind about self updates
+
+Quantex SHALL be able to show a lightweight reminder after a successful human-mode runtime command when the installed CLI version is older than the installable latest version.
+
+#### Scenario: Successful human-mode command detects a newer Quantex version
+
+- GIVEN the user runs a Quantex management command that executes through the shared runtime
+- AND the command returns success in human output mode
+- AND Quantex resolves a newer `latestVersion` than `currentVersion`
+- WHEN post-command reminders are evaluated
+- THEN Quantex shows a short self-upgrade notice after the command output
+
+### Requirement: Self-upgrade reminders MUST stay out of machine-facing output
+
+Quantex SHALL not inject passive self-upgrade reminders into structured command surfaces.
+
+#### Scenario: JSON output mode
+
+- GIVEN the user runs a runtime command with `--json` or `--output json`
+- WHEN Quantex evaluates passive self-upgrade reminders
+- THEN it does not render a human reminder
+- AND the command result payload remains unchanged
+
+#### Scenario: NDJSON output mode
+
+- GIVEN the user runs a runtime command with `--output ndjson`
+- WHEN Quantex evaluates passive self-upgrade reminders
+- THEN it does not render a human reminder
+- AND no extra NDJSON events are emitted for the reminder
+
+### Requirement: Self-upgrade reminders MUST respect operator intent and command ownership
+
+Quantex SHALL suppress passive reminders when the current command already owns self-upgrade messaging or the operator asked for quieter output.
+
+#### Scenario: Quiet mode suppresses the reminder
+
+- GIVEN the user runs a runtime command in human mode with `--quiet`
+- WHEN Quantex evaluates passive self-upgrade reminders
+- THEN it does not render the reminder
+
+#### Scenario: Explicit self-upgrade command owns the messaging
+
+- GIVEN the user runs `quantex upgrade` or `quantex doctor`
+- WHEN Quantex evaluates passive self-upgrade reminders
+- THEN it does not render an additional post-command reminder
+
+### Requirement: Self-upgrade reminders MUST be throttled per target version
+
+Quantex SHALL remember when it last reminded the user about a specific target version so repeated command usage does not produce reminder spam.
+
+#### Scenario: Same target version was already reminded recently
+
+- GIVEN Quantex previously recorded a passive reminder for version `X`
+- AND less than 24 hours have elapsed since that reminder
+- AND the currently installable latest version is still `X`
+- WHEN Quantex evaluates passive self-upgrade reminders
+- THEN it suppresses the reminder
+
+#### Scenario: A newer target version becomes available
+
+- GIVEN Quantex previously recorded a passive reminder for version `X`
+- AND the currently installable latest version is now `Y`
+- AND `Y` is different from `X`
+- WHEN Quantex evaluates passive self-upgrade reminders
+- THEN it renders the reminder for `Y`
+- AND it refreshes the recorded reminder state

--- a/openspec/changes/add-self-upgrade-notice/specs/self-upgrade/spec.md
+++ b/openspec/changes/add-self-upgrade-notice/specs/self-upgrade/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Self-upgrade MUST expose recovery guidance
+
+The self-upgrade system SHALL provide recovery hints when automatic upgrade is unavailable or fails, and SHALL support a passive reminder path for outdated installs during other human-mode runtime commands.
+
+#### Scenario: Human runtime command reminds about auto-updatable install
+
+- GIVEN the user runs a successful human-mode runtime command other than `quantex upgrade` or `quantex doctor`
+- AND Quantex detects that `latestVersion` is newer than `currentVersion`
+- AND the current install source supports auto-update
+- WHEN Quantex renders the passive reminder
+- THEN it suggests running `quantex upgrade`
+
+#### Scenario: Human runtime command reminds about manual remediation path
+
+- GIVEN the user runs a successful human-mode runtime command other than `quantex upgrade` or `quantex doctor`
+- AND Quantex detects that `latestVersion` is newer than `currentVersion`
+- AND the current install source does not support auto-update
+- WHEN Quantex renders the passive reminder
+- THEN it points the user toward `quantex doctor` for source-specific next steps

--- a/openspec/changes/add-self-upgrade-notice/tasks.md
+++ b/openspec/changes/add-self-upgrade-notice/tasks.md
@@ -15,4 +15,4 @@
 
 ## 4. Delivery
 
-- [ ] 4.1 Review git state, commit the change, push the branch, and open a PR with a validated body file.
+- [x] 4.1 Review git state, commit the change, push the branch, and open a PR with a validated body file.

--- a/openspec/changes/add-self-upgrade-notice/tasks.md
+++ b/openspec/changes/add-self-upgrade-notice/tasks.md
@@ -1,0 +1,18 @@
+## 1. OpenSpec
+
+- [x] 1.1 Finalize the proposal, design, and spec deltas for passive self-upgrade reminders.
+
+## 2. Implementation
+
+- [x] 2.1 Extend self state to persist passive self-upgrade reminder throttle metadata.
+- [x] 2.2 Add a self-upgrade notice helper that evaluates output mode, command ownership, upgrade availability, and throttle state.
+- [x] 2.3 Invoke the passive self-upgrade notice from the shared runtime without changing structured command results.
+
+## 3. Validation
+
+- [x] 3.1 Add or update tests for state persistence and runtime reminder behavior.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.
+
+## 4. Delivery
+
+- [ ] 4.1 Review git state, commit the change, push the branch, and open a PR with a validated body file.

--- a/src/command-runtime.ts
+++ b/src/command-runtime.ts
@@ -3,6 +3,7 @@ import process from 'node:process'
 import { cancelCliContextOperations, getCliContext } from './cli-context'
 import { loadIdempotencyRecord, saveIdempotencyRecord } from './idempotency'
 import { createErrorResult, emitCommandEvent, emitCommandResult } from './output'
+import { maybeRenderSelfUpdateNotice } from './self/update-notice'
 import { pc } from './utils/color'
 
 interface ExecuteCommandOptions<T> {
@@ -19,7 +20,7 @@ export async function executeCommandWithRuntime<T>(options: ExecuteCommandOption
 
   if (timeoutMs === undefined)
     return withSignalCancellation(options, () =>
-      options.run().then(result => storeIdempotentResult(options.action, options.target, result)),
+      options.run().then(result => finalizeSuccessfulRun(options.action, options.target, result)),
     )
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined
@@ -63,13 +64,32 @@ export async function executeCommandWithRuntime<T>(options: ExecuteCommandOption
 
     return await withSignalCancellation(options, () =>
       Promise.race([
-        options.run().then(result => storeIdempotentResult(options.action, options.target, result)),
+        options.run().then(result => finalizeSuccessfulRun(options.action, options.target, result)),
         timeoutPromise,
       ]),
     )
   } finally {
     if (timeoutId) clearTimeout(timeoutId)
   }
+}
+
+async function finalizeSuccessfulRun<T>(
+  action: string,
+  target: CommandTarget | undefined,
+  result: CommandResult<T>,
+): Promise<CommandResult<T>> {
+  const storedResult = await storeIdempotentResult(action, target, result)
+
+  try {
+    await maybeRenderSelfUpdateNotice({
+      action,
+      ok: storedResult.ok,
+    })
+  } catch {
+    // Passive reminders must never fail the primary command path.
+  }
+
+  return storedResult
 }
 
 function renderTimeoutHuman(result: Pick<CommandResult, 'error'>): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ export {
   saveState,
   setInstalledAgentState,
   setSelfInstallSource,
+  setSelfUpdateNoticeState,
 } from './state'
 export type { InstalledAgentState, QuantexState, SelfState } from './state'
 export { getPlatform, isBinaryInPath, isBunAvailable, isNpmAvailable } from './utils/detect'

--- a/src/self/update-notice.ts
+++ b/src/self/update-notice.ts
@@ -1,0 +1,50 @@
+import { getCliContext } from '../cli-context'
+import { getSelfState, setSelfUpdateNoticeState } from '../state'
+import { pc } from '../utils/color'
+import { printInfo } from '../utils/user-output'
+import { inspectSelf } from './index'
+
+const UPDATE_NOTICE_THROTTLE_MS = 24 * 60 * 60 * 1000
+const SELF_UPGRADE_NOTICE_SKIPPED_ACTIONS = new Set(['doctor', 'upgrade'])
+
+export async function maybeRenderSelfUpdateNotice(options: { action: string; ok: boolean }): Promise<void> {
+  if (!options.ok || SELF_UPGRADE_NOTICE_SKIPPED_ACTIONS.has(options.action)) return
+
+  const context = getCliContext()
+  if (context.outputMode !== 'human' || context.quiet) return
+
+  const inspection = await inspectSelf()
+  if (!inspection.latestVersion || inspection.latestVersion === inspection.currentVersion) return
+
+  const selfState = await getSelfState()
+  const now = Date.now()
+
+  if (
+    shouldSuppressUpdateNotice(selfState.updateNoticeVersion, selfState.updateNoticeAt, inspection.latestVersion, now)
+  )
+    return
+
+  const nextStep = inspection.canAutoUpdate
+    ? 'Run `quantex upgrade`.'
+    : 'Run `quantex doctor` for source-specific update steps.'
+  printInfo(
+    pc.yellow(
+      `Quantex CLI ${inspection.latestVersion} is available (current ${inspection.currentVersion}). ${nextStep}`,
+    ),
+  )
+  await setSelfUpdateNoticeState(inspection.latestVersion, new Date(now).toISOString())
+}
+
+export function shouldSuppressUpdateNotice(
+  lastVersion: string | undefined,
+  lastAt: string | undefined,
+  nextVersion: string,
+  now: number,
+): boolean {
+  if (!lastVersion || !lastAt || lastVersion !== nextVersion) return false
+
+  const lastTimestamp = Date.parse(lastAt)
+  if (Number.isNaN(lastTimestamp)) return false
+
+  return now - lastTimestamp < UPDATE_NOTICE_THROTTLE_MS
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -8,5 +8,6 @@ export {
   saveState,
   setInstalledAgentState,
   setSelfInstallSource,
+  setSelfUpdateNoticeState,
 } from './state/index'
 export type { InstalledAgentState, QuantexState, SelfState } from './state/index'

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -15,6 +15,8 @@ export interface InstalledAgentState {
 
 export interface SelfState {
   installSource?: SelfInstallSource
+  updateNoticeAt?: string
+  updateNoticeVersion?: string
 }
 
 export interface QuantexState {
@@ -80,12 +82,23 @@ export async function setSelfInstallSource(installSource: SelfInstallSource): Pr
   })
 }
 
+export async function setSelfUpdateNoticeState(updateNoticeVersion: string, updateNoticeAt: string): Promise<void> {
+  await mutateState(state => {
+    state.self.updateNoticeVersion = updateNoticeVersion
+    state.self.updateNoticeAt = updateNoticeAt
+  })
+}
+
 async function readState(): Promise<QuantexState> {
   try {
     const data = JSON.parse(await readFile(getStateFilePath(), 'utf8')) as Partial<QuantexState>
     return {
       installedAgents: data.installedAgents ?? {},
-      self: data.self ?? {},
+      self: {
+        installSource: data.self?.installSource,
+        updateNoticeAt: data.self?.updateNoticeAt,
+        updateNoticeVersion: data.self?.updateNoticeVersion,
+      },
     }
   } catch {
     return { ...defaultState }

--- a/test/command-runtime.test.ts
+++ b/test/command-runtime.test.ts
@@ -6,6 +6,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setCliContext } from '../src/cli-context'
 import { executeCommandWithRuntime } from '../src/command-runtime'
 import { createSuccessResult } from '../src/output'
+import * as selfModule from '../src/self'
+import { saveState } from '../src/state'
+
+const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelf')
 
 describe('executeCommandWithRuntime', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
@@ -20,6 +24,8 @@ describe('executeCommandWithRuntime', () => {
 
   afterEach(() => {
     logSpy.mockRestore()
+    inspectSelfSpy.mockReset()
+    vi.useRealTimers()
     if (originalHome === undefined) delete process.env.HOME
     else process.env.HOME = originalHome
     rmSync(tempHome, { force: true, recursive: true })
@@ -159,5 +165,180 @@ describe('executeCommandWithRuntime', () => {
     expect(cancelledEvent.data.signal).toBe('SIGTERM')
     expect(result.ok).toBe(false)
     expect(result.error?.code).toBe('CANCELLED')
+  })
+
+  it('shows a passive self-update notice after a successful human-mode command', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T08:00:00.000Z'))
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: '/tmp/quantex',
+      installSource: 'npm',
+      latestVersion: '1.1.0',
+      packageRoot: '/tmp/quantex',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    setCliContext({
+      interactive: true,
+      outputMode: 'human',
+      runId: 'human-run-id',
+    })
+
+    const result = await executeCommandWithRuntime({
+      action: 'list',
+      run: async () =>
+        createSuccessResult({
+          action: 'list',
+          data: { agents: [] },
+          target: {
+            kind: 'system',
+            name: 'agents',
+          },
+        }),
+      target: {
+        kind: 'system',
+        name: 'agents',
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Quantex CLI 1.1.0 is available'))
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Run `quantex upgrade`.'))
+    stdoutWriteSpy.mockRestore()
+  })
+
+  it('suppresses the passive notice in structured output modes', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: '/tmp/quantex',
+      installSource: 'npm',
+      latestVersion: '1.1.0',
+      packageRoot: '/tmp/quantex',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'json-run-id',
+    })
+
+    await executeCommandWithRuntime({
+      action: 'list',
+      run: async () =>
+        createSuccessResult({
+          action: 'list',
+          data: { agents: [] },
+          target: {
+            kind: 'system',
+            name: 'agents',
+          },
+        }),
+      target: {
+        kind: 'system',
+        name: 'agents',
+      },
+    })
+
+    expect(inspectSelfSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).not.toHaveBeenCalledWith(expect.stringContaining('Quantex CLI 1.1.0 is available'))
+    stdoutWriteSpy.mockRestore()
+  })
+
+  it('suppresses repeated reminders for the same target version inside the throttle window', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T08:00:00.000Z'))
+    await saveState({
+      installedAgents: {},
+      self: {
+        updateNoticeAt: '2026-05-01T00:00:00.000Z',
+        updateNoticeVersion: '1.1.0',
+      },
+    })
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: '/tmp/quantex',
+      installSource: 'npm',
+      latestVersion: '1.1.0',
+      packageRoot: '/tmp/quantex',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    setCliContext({
+      interactive: true,
+      outputMode: 'human',
+      runId: 'human-run-id',
+    })
+
+    await executeCommandWithRuntime({
+      action: 'list',
+      run: async () =>
+        createSuccessResult({
+          action: 'list',
+          data: { agents: [] },
+          target: {
+            kind: 'system',
+            name: 'agents',
+          },
+        }),
+      target: {
+        kind: 'system',
+        name: 'agents',
+      },
+    })
+
+    expect(stdoutWriteSpy).not.toHaveBeenCalledWith(expect.stringContaining('Quantex CLI 1.1.0 is available'))
+    stdoutWriteSpy.mockRestore()
+  })
+
+  it('skips passive reminders for doctor because that command owns self-upgrade messaging', async () => {
+    const stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: '/tmp/quantex',
+      installSource: 'npm',
+      latestVersion: '1.1.0',
+      packageRoot: '/tmp/quantex',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    setCliContext({
+      interactive: true,
+      outputMode: 'human',
+      runId: 'doctor-run-id',
+    })
+
+    await executeCommandWithRuntime({
+      action: 'doctor',
+      run: async () =>
+        createSuccessResult({
+          action: 'doctor',
+          data: { issues: [] },
+          target: {
+            kind: 'system',
+            name: 'doctor',
+          },
+        }),
+      target: {
+        kind: 'system',
+        name: 'doctor',
+      },
+    })
+
+    expect(inspectSelfSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).not.toHaveBeenCalledWith(expect.stringContaining('Quantex CLI 1.1.0 is available'))
+    stdoutWriteSpy.mockRestore()
   })
 })

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -10,6 +10,7 @@ import {
   loadState,
   saveState,
   setSelfInstallSource,
+  setSelfUpdateNoticeState,
 } from '../src/state'
 import { acquireResourceLock } from '../src/utils/lock'
 
@@ -64,6 +65,24 @@ describe('state helpers', () => {
 
     const writtenState = JSON.parse(readFileSync(getStateFilePath(), 'utf8'))
     expect(writtenState.self?.installSource).toBe('binary')
+  })
+
+  it('persists self update notice throttle metadata', async () => {
+    await saveState({
+      installedAgents: {},
+      self: {},
+    })
+
+    await setSelfUpdateNoticeState('1.2.0', '2026-05-01T00:00:00.000Z')
+
+    expect(await getSelfState()).toEqual({
+      updateNoticeAt: '2026-05-01T00:00:00.000Z',
+      updateNoticeVersion: '1.2.0',
+    })
+
+    const writtenState = JSON.parse(readFileSync(getStateFilePath(), 'utf8'))
+    expect(writtenState.self?.updateNoticeVersion).toBe('1.2.0')
+    expect(writtenState.self?.updateNoticeAt).toBe('2026-05-01T00:00:00.000Z')
   })
 
   it('rejects writes while the state lock is already held', async () => {


### PR DESCRIPTION
## Summary

Add a passive human-mode self-upgrade reminder so users on older Quantex installs get a lightweight prompt during normal management commands instead of needing to remember `quantex upgrade --check` or `quantex doctor`.

The runtime now checks for outdated self versions after successful human-mode commands, suppresses the notice for structured output and self-owned upgrade flows, and throttles repeats for the same target version through persisted self state.

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `add-self-upgrade-notice`
- Discussion: none

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Reviewers should focus on the runtime gating and throttle behavior: the reminder must stay out of JSON/NDJSON contracts and avoid repeating the same target version inside the 24-hour window.
