### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,3 +146,13 @@ bun run release:artifacts
 - self binary upgrade 已包含 checksum、lock、verify、`.bak` rollback 与 Windows 延迟替换
 - 全局 dual-mode surface 当前还包括 `--yes`、`--quiet`、`--color`、`--log-level`、`--dry-run`、`--refresh`、`--no-cache`
 - 结构化 `meta` 当前可附带 `fetchedAt`、`staleAfter`、`source`
+
+## Cursor Cloud specific instructions
+
+- 运行时为 Bun v1.3.11，通过 `~/.bun/bin` 提供。Cloud VM 启动脚本已配置 `bun install`。
+- 这是一个纯 CLI 项目，无需启动后台服务、数据库或 Docker。
+- 开发模式运行：`bun run dev` （等价于 `bun run src/cli.ts`），后接 CLI 参数，如 `bun run dev -- list`。
+- 验证命令参考 AGENTS.md 的 Validation 节；核心四件套：`bun run lint`、`bun run format:check`、`bun run typecheck`、`bun run test`。
+- `bun run build` 产出 `dist/`；`bun run build:bin` 产出平台二进制。
+- lint 由 `oxlint` 提供，format 由 `oxfmt` 提供；不要引入 eslint 或 prettier。
+- Cloud VM 中 npm 和 brew 不可用；`capabilities` 输出会显示 `npm: not-found`、`brew: not-found`，这属于正常环境限制。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add Cursor Cloud specific instructions section to AGENTS.md for future cloud agents. This documents the Cloud VM environment specifics including Bun runtime path, available tooling, validation commands, and known environment limitations (npm/brew not available).

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: N/A (no behavior/contract change; documentation-only)
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [x] Not run, explained below

All validation commands pass. Tests also pass (380/380). No behavior changes — docs-only.

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [x] Not needed

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Full validation log captured at `/opt/cursor/artifacts/dev_environment_validation.log`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-071ec106-1449-49db-adbe-ea6c5edc6b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-071ec106-1449-49db-adbe-ea6c5edc6b28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

