### PR TITLE
feat(agents): add deepseek tui support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | Crush | `qtx crush` | Charmbracelet's terminal AI coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
+| DeepSeek TUI | `qtx deepseek` | DeepSeek's terminal-native coding agent |
 | Devin for Terminal | `qtx devin` | Cognition's local coding agent CLI |
 | Droid | `qtx droid` | Factory AI software engineering agent CLI |
 | ForgeCode | `qtx forgecode` | Antinomy's AI coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,6 +178,7 @@ qtx upgrade --channel beta
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | Crush | `qtx crush` | Charmbracelet 终端 AI 编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
+| DeepSeek TUI | `qtx deepseek` | DeepSeek 终端原生编程 Agent |
 | Devin for Terminal | `qtx devin` | Cognition 本地编程 Agent CLI |
 | Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
 | ForgeCode | `qtx forgecode` | Antinomy AI 编程助手 CLI |

--- a/openspec/changes/add-deepseek-tui-support/.openspec.yaml
+++ b/openspec/changes/add-deepseek-tui-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/add-deepseek-tui-support/design.md
+++ b/openspec/changes/add-deepseek-tui-support/design.md
@@ -1,0 +1,39 @@
+## Context
+
+DeepSeek TUI publishes an npm package (`deepseek-tui`) that downloads the platform-specific `deepseek` and `deepseek-tui` binaries from GitHub release artifacts during install. The upstream README documents `npm install -g deepseek-tui`, `deepseek --version`, and `deepseek update`, and it identifies `deepseek` as the primary user-facing dispatcher command.
+
+Quantex already models similar agents with one catalog entry that carries the lifecycle metadata needed by install, inspect, resolve, exec, and update planning. DeepSeek TUI should fit that existing catalog shape without requiring new package-manager or execution behaviors.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add DeepSeek TUI as a supported Quantex lifecycle agent with verified upstream metadata.
+- Use the primary `deepseek` binary as the canonical execution target while preserving `deepseek-tui` as a lookup alias.
+- Expose the documented npm install path and `deepseek update` self-update command.
+
+**Non-Goals:**
+
+- Add DeepSeek-specific runtime behaviors beyond catalog metadata.
+- Model source builds, direct GitHub release downloads, or cargo-based install flows in this change.
+- Introduce new install-method types or architecture-specific catalog branching.
+
+## Decisions
+
+### 1. Use `deepseek` as the canonical slug and executable, with `deepseek-tui` as a lookup alias
+
+The upstream package exposes both `deepseek` and `deepseek-tui`, but the README positions `deepseek` as the primary user entry point. Quantex should use `deepseek` as the canonical slug and executable name while accepting `deepseek-tui` as a stable lookup alias for users who identify the product by its package or companion binary name.
+
+### 2. Expose the documented npm managed install method on all supported platforms
+
+The verified install surface in upstream documentation is `npm install -g deepseek-tui`, and the npm package handles platform-specific binary download during `postinstall`. Quantex should therefore expose the npm managed install method on Windows, macOS, and Linux rather than inventing Bun, Homebrew, or script installers that upstream does not currently document as the primary packaged path.
+
+### 3. Record both version probe and self-update behavior on the `deepseek` dispatcher
+
+Upstream documents `deepseek --version` and `deepseek update` against the dispatcher binary, so Quantex should probe and update through `deepseek` rather than the companion `deepseek-tui` binary. This keeps lifecycle behavior aligned with the command users actually run.
+
+## Risks / Trade-offs
+
+- [The npm wrapper only supports selected OS/architecture combinations] -> Keep the catalog at the existing OS granularity and rely on upstream install-time validation for unsupported architectures.
+- [Users may expect cargo/source install guidance in Quantex] -> Keep the initial support minimal and verified; additional install channels can be added later if Quantex decides to model source-based flows explicitly.
+- [The alias could diverge if upstream changes branding] -> Limit the alias set to the currently shipped `deepseek-tui` binary and package name terminology.

--- a/openspec/changes/add-deepseek-tui-support/proposal.md
+++ b/openspec/changes/add-deepseek-tui-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+This request changes the supported agent catalog, install metadata, and version-probe behavior, so it requires an OpenSpec-backed change before implementation. DeepSeek TUI is now distributed through an npm wrapper around upstream release artifacts, but Quantex cannot currently install, inspect, or launch it as a first-class lifecycle agent.
+
+## What Changes
+
+- Add a DeepSeek TUI agent definition with verified lifecycle metadata: canonical slug, lookup alias, display name, homepage, npm package metadata, executable name, install method, version probe, and self-update command.
+- Register DeepSeek TUI in the runtime agent catalog and root exports so lookup, inspection, resolution, and execution surfaces can use it.
+- Extend the agent-catalog contract with a DeepSeek TUI requirement that records the supported lookup names, npm install path, version probe, and self-update command.
+- Refresh the product README agent tables so the documented supported-agent list matches the implemented catalog after adding DeepSeek TUI.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add DeepSeek TUI as a supported lifecycle agent with verified install, version-probe, and self-update metadata.
+
+## Impact
+
+- `src/agents/definitions/deepseek.ts` - new DeepSeek TUI catalog entry
+- `src/agents/index.ts` and `src/index.ts` - register and re-export DeepSeek TUI
+- `test/agents.test.ts` and `test/index.test.ts` - verify DeepSeek TUI metadata and exports
+- `openspec/specs/agent-catalog/spec.md` - add the DeepSeek TUI requirement
+- `README.md` and `README.zh-CN.md` - sync supported-agent tables with the implemented catalog

--- a/openspec/changes/add-deepseek-tui-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-deepseek-tui-support/specs/agent-catalog/spec.md
@@ -1,0 +1,30 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: DeepSeek TUI MUST be a supported lifecycle agent
+
+Quantex SHALL include DeepSeek TUI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up DeepSeek TUI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `deepseek` or the alias `deepseek-tui`
+- **THEN** Quantex returns a supported agent entry for DeepSeek TUI
+- **AND** the entry identifies `deepseek` as the executable binary
+- **AND** the entry identifies `deepseek-tui` as its npm package metadata
+- **AND** the entry identifies `https://github.com/Hmbown/DeepSeek-TUI` as the homepage
+
+#### Scenario: Installing DeepSeek TUI through supported methods
+
+- **WHEN** Quantex renders or executes install options for DeepSeek TUI
+- **THEN** the catalog includes the npm-compatible managed install method on Windows, macOS, and Linux
+
+#### Scenario: Probing DeepSeek TUI version
+
+- **WHEN** Quantex probes the installed version of DeepSeek TUI
+- **THEN** it runs `deepseek --version` and parses the output
+
+#### Scenario: Planning DeepSeek TUI updates
+
+- **WHEN** Quantex plans an update for a DeepSeek TUI installation that supports self-update
+- **THEN** the catalog exposes `deepseek update` as the agent self-update command

--- a/openspec/changes/add-deepseek-tui-support/tasks.md
+++ b/openspec/changes/add-deepseek-tui-support/tasks.md
@@ -1,0 +1,18 @@
+## 1. Catalog Support
+
+- [x] 1.1 Add `src/agents/definitions/deepseek.ts` with verified DeepSeek TUI lifecycle metadata.
+- [x] 1.2 Register DeepSeek TUI in `src/agents/index.ts` and `src/index.ts`.
+- [x] 1.3 Add the DeepSeek TUI requirement to `openspec/specs/agent-catalog/spec.md`.
+
+## 2. Tests And Docs
+
+- [x] 2.1 Add or update automated tests for DeepSeek TUI metadata, lookup aliases, and root exports.
+- [x] 2.2 Sync `README.md` and `README.zh-CN.md` supported-agent tables with the implemented catalog.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.

--- a/src/agents/definitions/deepseek.ts
+++ b/src/agents/definitions/deepseek.ts
@@ -1,0 +1,24 @@
+import type { AgentDefinition } from '../types'
+import { npmInstall } from '../methods'
+
+export const deepseek: AgentDefinition = {
+  name: 'deepseek',
+  lookupAliases: ['deepseek-tui'],
+  displayName: 'DeepSeek TUI',
+  homepage: 'https://github.com/Hmbown/DeepSeek-TUI',
+  packages: {
+    npm: 'deepseek-tui',
+  },
+  binaryName: 'deepseek',
+  selfUpdate: {
+    command: ['deepseek', 'update'],
+  },
+  versionProbe: {
+    command: ['deepseek', '--version'],
+  },
+  platforms: {
+    windows: [npmInstall()],
+    macos: [npmInstall()],
+    linux: [npmInstall()],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -8,6 +8,7 @@ import { codex } from './definitions/codex'
 import { copilot } from './definitions/copilot'
 import { crush } from './definitions/crush'
 import { cursor } from './definitions/cursor'
+import { deepseek } from './definitions/deepseek'
 import { devin } from './definitions/devin'
 import { droid } from './definitions/droid'
 import { forgecode } from './definitions/forgecode'
@@ -34,6 +35,7 @@ const agents: AgentDefinition[] = [
   copilot,
   crush,
   cursor,
+  deepseek,
   devin,
   droid,
   forgecode,
@@ -73,6 +75,7 @@ export {
   copilot,
   crush,
   cursor,
+  deepseek,
   devin,
   droid,
   forgecode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   codebuddy,
   codex,
   copilot,
+  deepseek,
   cursor,
   devin,
   droid,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -8,6 +8,7 @@ import { codebuddy } from '../src/agents/definitions/codebuddy'
 import { codex } from '../src/agents/definitions/codex'
 import { copilot } from '../src/agents/definitions/copilot'
 import { cursor } from '../src/agents/definitions/cursor'
+import { deepseek } from '../src/agents/definitions/deepseek'
 import { devin } from '../src/agents/definitions/devin'
 import { droid } from '../src/agents/definitions/droid'
 import { gemini } from '../src/agents/definitions/gemini'
@@ -384,6 +385,31 @@ describe('junie', () => {
     expect(
       junie.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'jetbrains-junie/junie/junie'),
     ).toBeDefined()
+  })
+})
+
+describe('deepseek', () => {
+  it('is registered for lookup by canonical name and package alias', () => {
+    expect(getAgentByNameOrAlias('deepseek')).toBe(deepseek)
+    expect(getAgentByNameOrAlias('deepseek-tui')).toBe(deepseek)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(deepseek)
+    expect(deepseek.name).toBe('deepseek')
+    expect(deepseek.lookupAliases).toEqual(['deepseek-tui'])
+    expect(deepseek.displayName).toBe('DeepSeek TUI')
+    expect(deepseek.packages?.npm).toBe('deepseek-tui')
+    expect(deepseek.binaryName).toBe('deepseek')
+    expect(deepseek.homepage).toBe('https://github.com/Hmbown/DeepSeek-TUI')
+    expect(deepseek.selfUpdate?.command).toEqual(['deepseek', 'update'])
+    expect(deepseek.versionProbe?.command).toEqual(['deepseek', '--version'])
+  })
+
+  it('exposes npm install on all supported platforms', () => {
+    expect(deepseek.platforms.windows!.find(m => m.type === 'npm')).toBeDefined()
+    expect(deepseek.platforms.macos!.find(m => m.type === 'npm')).toBeDefined()
+    expect(deepseek.platforms.linux!.find(m => m.type === 'npm')).toBeDefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -5,6 +5,7 @@ import {
   codex,
   copilot,
   createUpdatePlan,
+  deepseek,
   cursor,
   devin,
   droid,
@@ -158,6 +159,14 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('junie')
   })
 
+  it('deepseek has correct structure', () => {
+    const agent = getAgentByNameOrAlias('deepseek')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('DeepSeek TUI')
+    expect(agent!.packages?.npm).toBe('deepseek-tui')
+    expect(agent!.binaryName).toBe('deepseek')
+  })
+
   it('qoder has correct structure', () => {
     const agent = getAgentByNameOrAlias('qoder')
     expect(agent).toBeDefined()
@@ -171,6 +180,7 @@ describe('agent definitions', () => {
     expect(codebuddy.name).toBe('codebuddy')
     expect(codex.name).toBe('codex')
     expect(copilot.name).toBe('copilot')
+    expect(deepseek.name).toBe('deepseek')
     expect(cursor.name).toBe('cursor')
     expect(devin.name).toBe('devin')
     expect(droid.name).toBe('droid')


### PR DESCRIPTION
## Summary

Add DeepSeek TUI to the supported agent catalog and document the new support in the product README and OpenSpec change set.

## Linked Artifacts

- Issue: #134
- ADR:
- OpenSpec: `add-deepseek-tui-support`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [ ] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This branch is a clean cherry-pick of the existing DeepSeek support work onto the latest `origin/main` so the merge can stay linear and avoid carrying the stale local branch history.
