### PR TITLE
docs(readme): clarify deepseek third-party wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
 | Crush | `qtx crush` | Charmbracelet's terminal AI coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
-| DeepSeek TUI | `qtx deepseek` | DeepSeek's terminal-native coding agent |
+| DeepSeek TUI | `qtx deepseek` | Third-party terminal-native coding agent for DeepSeek |
 | Devin for Terminal | `qtx devin` | Cognition's local coding agent CLI |
 | Droid | `qtx droid` | Factory AI software engineering agent CLI |
 | ForgeCode | `qtx forgecode` | Antinomy's AI coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -178,7 +178,7 @@ qtx upgrade --channel beta
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
 | Crush | `qtx crush` | Charmbracelet 终端 AI 编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
-| DeepSeek TUI | `qtx deepseek` | DeepSeek 终端原生编程 Agent |
+| DeepSeek TUI | `qtx deepseek` | 面向 DeepSeek 的第三方终端原生编程 Agent |
 | Devin for Terminal | `qtx devin` | Cognition 本地编程 Agent CLI |
 | Droid | `qtx droid` | Factory AI 软件工程 Agent CLI |
 | ForgeCode | `qtx forgecode` | Antinomy AI 编程助手 CLI |


### PR DESCRIPTION
## Summary

Restore the intended DeepSeek TUI README copy in English and Chinese to explicitly describe it as a third-party terminal-native coding agent for DeepSeek.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `add-deepseek-tui-support`
- Discussion:

## Validation

- [ ] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [x] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [x] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [ ] Working tree was clean after commit.
- [ ] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This PR supersedes #172 by carrying only the intended README wording change on top of the current `origin/main`, without reintroducing stale release-version or changelog state.
