### PR TITLE
ci(release): harden release-please baseline handling

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -21,10 +21,17 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository validation logic
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Validate Release PR scope
         uses: actions/github-script@v7
         with:
           script: |
+            const { validateReleasePrPolicy } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/release-pr-policy.js`)
             const pullRequest = context.payload.pull_request
             const baseBranch = pullRequest.base.ref
             const headBranch = pullRequest.head.ref
@@ -36,26 +43,6 @@ jobs:
               return
             }
 
-            const expectedHeadBranch = `release-please--branches--${baseBranch}--components--quantex-cli`
-            if (headBranch !== expectedHeadBranch) {
-              core.setFailed(`Unexpected release-please branch "${headBranch}". Expected "${expectedHeadBranch}".`)
-              return
-            }
-
-            const titlePattern = baseBranch === 'beta'
-              ? /^chore: release \d+\.\d+\.\d+-beta(?:\.\d+)?$/
-              : /^chore: release \d+\.\d+\.\d+$/
-
-            if (!titlePattern.test(title)) {
-              core.setFailed(`Release PR title "${title}" does not match the expected ${baseBranch} release pattern.`)
-              return
-            }
-
-            if (!body.includes('This PR was generated with [Release Please]')) {
-              core.setFailed('Release PR body does not include the release-please generated marker.')
-              return
-            }
-
             const files = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -63,29 +50,25 @@ jobs:
               per_page: 100,
             })
 
-            const changedFiles = files.map(file => file.filename).sort()
-            const allowedFiles = new Set([
-              '.release-please-manifest.json',
-              'CHANGELOG.md',
-              'package.json',
-              'src/generated/build-meta.ts',
-            ])
-            const requiredFiles = new Set([
-              '.release-please-manifest.json',
-              'package.json',
-              'src/generated/build-meta.ts',
-            ])
+            const packageJson = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'package.json',
+              ref: baseBranch,
+            })
 
-            const unexpectedFiles = changedFiles.filter(fileName => !allowedFiles.has(fileName))
-            if (unexpectedFiles.length > 0) {
-              core.setFailed(`Release PR changes unexpected files: ${unexpectedFiles.join(', ')}`)
-              return
-            }
+            const basePackageJson = JSON.parse(Buffer.from(packageJson.data.content, 'base64').toString('utf8'))
+            const issues = validateReleasePrPolicy({
+              baseBranch,
+              baseVersion: basePackageJson.version,
+              body,
+              changedFiles: files.map(file => file.filename),
+              headBranch,
+              title,
+            })
 
-            const missingFiles = [...requiredFiles].filter(fileName => !changedFiles.includes(fileName))
-            if (missingFiles.length > 0) {
-              core.setFailed(`Release PR is missing required version files: ${missingFiles.join(', ')}`)
-              return
+            if (issues.length > 0) {
+              core.setFailed(issues.join('\n'))
             }
 
       - name: Create release bot token

--- a/openspec/changes/harden-release-please-baseline/.openspec.yaml
+++ b/openspec/changes/harden-release-please-baseline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/harden-release-please-baseline/design.md
+++ b/openspec/changes/harden-release-please-baseline/design.md
@@ -1,0 +1,43 @@
+## Context
+
+Release-please already owns version-file updates, changelog generation, and the split between Release PR creation and GitHub Release publication. Quantex wraps that with two repository-specific layers:
+
+- `release.yml` decides when release-please should run.
+- `release-pr-automerge.yml` validates generated Release PRs before enabling bot auto-merge.
+
+The duplicate `0.13.0` incident shows that only validating title shape and changed-file scope is not enough. If release-please computes from stale state, Quantex will currently auto-merge that bad Release PR.
+
+## Goals
+
+- Let release-please use current release state instead of a stale manual baseline override.
+- Reject generated Release PRs that do not advance the version on `main` or `beta`.
+- Keep the fix narrow: do not replace release-please or add manual release orchestration.
+
+## Non-Goals
+
+- Rebuild release-please state in custom repository scripts.
+- Change the release trigger taxonomy for normal docs/process PRs.
+- Alter published tag naming, npm tags, or artifact publication behavior.
+
+## Decisions
+
+### 1. Remove the stale `last-release-sha` override
+
+`last-release-sha` is an escape hatch, not a steady-state source of truth. Keeping a hard-coded April 24 SHA after multiple successful releases lets release-please anchor future planning to history that predates the current published version. Removing that override returns baseline selection to the current manifest, tags, and release-please's native logic.
+
+### 2. Validate version monotonicity in Release PR automerge
+
+Auto-merge should only be enabled for generated Release PRs that advance the version on the base branch. The validator can read the current `package.json` version from the PR base ref and compare it against the semantic version parsed from the Release PR title. If the generated version is less than or equal to the base-branch version, the workflow should fail and leave the PR unmerged.
+
+This guard blocks duplicate release PRs even if release-please regresses for another reason in the future.
+
+### 3. Keep validation inside the dedicated Release PR workflow
+
+The monotonic-version check belongs with the existing release branch validator because it depends on generated Release PR state, base-branch version files, and automerge policy. It should remain separate from normal contributor PR body governance.
+
+## Risks and Mitigations
+
+- Risk: removing `last-release-sha` could expose other release-please state drift.
+  - Mitigation: the monotonic-version check still blocks obviously bad duplicate versions from being auto-merged.
+- Risk: version comparison could mis-handle beta releases.
+  - Mitigation: parse stable and prerelease numeric segments explicitly and compare them deterministically.

--- a/openspec/changes/harden-release-please-baseline/proposal.md
+++ b/openspec/changes/harden-release-please-baseline/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Implementation requested work-intake classification: this change modifies release workflow governance and durable release metadata handling, so it requires OpenSpec before file edits.
+
+Quantex's release automation produced a duplicate `chore: release 0.13.0` PR after `feat(agents): add deepseek tui support` merged to `main`. The duplicate Release PR re-summarized old history and prevented the newly merged feature from advancing to a new version. The evidence points to two workflow weaknesses:
+
+- `release-please-config.json` still carries a stale `last-release-sha` override from April 24, 2026, so release-please can anchor changelog and version planning to an outdated baseline.
+- Release PR automerge currently validates branch, title, and changed-file scope, but it does not reject a generated Release PR whose proposed version fails to advance beyond the current base-branch version.
+
+## What Changes
+
+- Remove the stale manifest-level release baseline override so release-please can derive the next release from the current manifest and tags instead of an outdated pinned SHA.
+- Harden Release PR validation so automerge fails when a generated release PR proposes a version that is not strictly greater than the current version on the protected base branch.
+- Document the baseline and monotonic-version requirements in the release workflow specification.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `release-workflow`: release-please baseline selection and generated Release PR validation for protected branches.
+- `release-governance`: dedicated Release PR validation now enforces version advancement instead of only shape and file-scope checks.
+
+## Impact
+
+- Affected code: `release-please-config.json`, `.github/workflows/release-pr-automerge.yml`, and any shared validation helpers needed by that workflow.
+- Affected specs: `openspec/specs/release-workflow/spec.md` and `openspec/specs/release-governance/spec.md`.
+- Release output should resume producing the next version after release-worthy merges instead of duplicating an already published version.

--- a/openspec/changes/harden-release-please-baseline/specs/release-governance/spec.md
+++ b/openspec/changes/harden-release-please-baseline/specs/release-governance/spec.md
@@ -1,0 +1,11 @@
+## MODIFIED Requirements
+### Requirement: Release PRs Keep Dedicated Validation
+
+Release-please generated Release PRs SHALL remain governed by the dedicated Release PR validator instead of the product-impacting release-intent check.
+
+#### Scenario: Release-please PR opens
+
+- **WHEN** a pull request comes from a release-please branch
+- **THEN** PR Governance does not require product-impacting release intent for the version-file changes
+- **AND** Release PR Automerge validates the release branch, title, generated marker, and changed file scope
+- **AND** it rejects a generated Release PR whose proposed semantic version is less than or equal to the current version on the protected base branch

--- a/openspec/changes/harden-release-please-baseline/specs/release-workflow/spec.md
+++ b/openspec/changes/harden-release-please-baseline/specs/release-workflow/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+### Requirement: Release Workflow Skips Non-release Pushes
+
+The Release workflow SHALL evaluate release relevance only after merge-gating CI has completed successfully for a protected-branch push, and it SHALL skip release-please for pushes that cannot create a release.
+
+#### Scenario: release-worthy merge reaches main
+
+- **WHEN** merge-gating CI completes successfully for a push to `main`
+- **AND** the pushed commit has a release-worthy conventional commit title such as `feat:`, `fix:`, or `perf:`
+- **THEN** the Release workflow MUST invoke release-please in Release PR mode
+- **AND** the release-please action version MUST be pinned to a repository-verified tag
+- **AND** it MUST skip GitHub Release creation in that invocation
+- **AND** it MUST derive the next release from the current manifest and published release state instead of a stale repository-pinned baseline override
+

--- a/openspec/changes/harden-release-please-baseline/tasks.md
+++ b/openspec/changes/harden-release-please-baseline/tasks.md
@@ -1,0 +1,17 @@
+## 1. OpenSpec
+
+- [x] 1.1 Finalize the proposal, design, and spec deltas for release baseline hardening.
+
+## 2. Implementation
+
+- [x] 2.1 Remove the stale `last-release-sha` override from `release-please-config.json`.
+- [x] 2.2 Extend Release PR automerge validation to reject non-advancing release versions against the base branch.
+
+## 3. Validation
+
+- [x] 3.1 Add or update automated tests or locally executable validation for the new release-version guard.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.
+
+## 4. Delivery
+
+- [ ] 4.1 Review git state, commit the change, push the branch, and open a PR with a validated body file.

--- a/openspec/changes/harden-release-please-baseline/tasks.md
+++ b/openspec/changes/harden-release-please-baseline/tasks.md
@@ -14,4 +14,4 @@
 
 ## 4. Delivery
 
-- [ ] 4.1 Review git state, commit the change, push the branch, and open a PR with a validated body file.
+- [x] 4.1 Review git state, commit the change, push the branch, and open a PR with a validated body file.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "last-release-sha": "fcda8f1e3c95f5cf28d5db7a56df900dd8a4060d",
   "packages": {
     ".": {
       "release-type": "node",

--- a/scripts/release-pr-policy.d.ts
+++ b/scripts/release-pr-policy.d.ts
@@ -1,0 +1,12 @@
+export interface ReleasePrPolicyInput {
+  baseBranch: string
+  baseVersion: string
+  body: string
+  changedFiles: string[]
+  headBranch: string
+  title: string
+}
+
+export function compareReleaseVersions(leftRaw: string, rightRaw: string): number
+
+export function validateReleasePrPolicy(input: ReleasePrPolicyInput): string[]

--- a/scripts/release-pr-policy.js
+++ b/scripts/release-pr-policy.js
@@ -1,0 +1,168 @@
+import { readFileSync } from 'node:fs'
+import process from 'node:process'
+
+const stableTitlePattern = /^chore: release (\d+\.\d+\.\d+)$/
+const betaTitlePattern = /^chore: release (\d+\.\d+\.\d+-beta(?:\.\d+)?)$/
+const generatedMarker = 'This PR was generated with [Release Please]'
+
+const allowedFiles = new Set([
+  '.release-please-manifest.json',
+  'CHANGELOG.md',
+  'package.json',
+  'src/generated/build-meta.ts',
+])
+
+const requiredFiles = new Set(['.release-please-manifest.json', 'package.json', 'src/generated/build-meta.ts'])
+
+export function validateReleasePrPolicy(input) {
+  const issues = []
+  const baseBranch = input.baseBranch || ''
+  const headBranch = input.headBranch || ''
+  const title = input.title || ''
+  const body = input.body || ''
+  const changedFiles = [...(input.changedFiles || [])].sort()
+  const baseVersion = input.baseVersion || ''
+
+  const expectedHeadBranch = `release-please--branches--${baseBranch}--components--quantex-cli`
+  if (headBranch !== expectedHeadBranch) {
+    issues.push(`Unexpected release-please branch "${headBranch}". Expected "${expectedHeadBranch}".`)
+  }
+
+  const titlePattern = baseBranch === 'beta' ? betaTitlePattern : stableTitlePattern
+  const versionMatch = title.match(titlePattern)
+  if (!versionMatch) {
+    issues.push(`Release PR title "${title}" does not match the expected ${baseBranch} release pattern.`)
+  }
+
+  if (!body.includes(generatedMarker)) {
+    issues.push('Release PR body does not include the release-please generated marker.')
+  }
+
+  const unexpectedFiles = changedFiles.filter(fileName => !allowedFiles.has(fileName))
+  if (unexpectedFiles.length > 0) {
+    issues.push(`Release PR changes unexpected files: ${unexpectedFiles.join(', ')}`)
+  }
+
+  const missingFiles = [...requiredFiles].filter(fileName => !changedFiles.includes(fileName))
+  if (missingFiles.length > 0) {
+    issues.push(`Release PR is missing required version files: ${missingFiles.join(', ')}`)
+  }
+
+  if (versionMatch && baseVersion) {
+    const proposedVersion = versionMatch[1]
+    if (compareReleaseVersions(proposedVersion, baseVersion) <= 0) {
+      issues.push(
+        `Release PR version "${proposedVersion}" must be greater than the current ${baseBranch} version "${baseVersion}".`,
+      )
+    }
+  }
+
+  return issues
+}
+
+export function compareReleaseVersions(leftRaw, rightRaw) {
+  const left = parseReleaseVersion(leftRaw)
+  const right = parseReleaseVersion(rightRaw)
+
+  if (left.major !== right.major) return left.major - right.major
+  if (left.minor !== right.minor) return left.minor - right.minor
+  if (left.patch !== right.patch) return left.patch - right.patch
+
+  if (left.prerelease === null && right.prerelease === null) return 0
+  if (left.prerelease === null) return 1
+  if (right.prerelease === null) return -1
+
+  if (left.prerelease.tag !== right.prerelease.tag) {
+    return left.prerelease.tag.localeCompare(right.prerelease.tag)
+  }
+
+  return left.prerelease.number - right.prerelease.number
+}
+
+export function parseReleaseVersion(rawValue) {
+  const match = rawValue.match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+)(?:\.(\d+))?)?$/)
+  if (!match) {
+    throw new Error(`Invalid release version: ${rawValue}`)
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4]
+      ? {
+          tag: match[4],
+          number: Number(match[5] ?? '0'),
+        }
+      : null,
+  }
+}
+
+if (import.meta.main) {
+  const options = parseArgs(process.argv.slice(2))
+  const body = options.bodyFile ? readFileSync(options.bodyFile, 'utf8') : process.env.PR_BODY || ''
+  const changedFiles = options.changedFilesJson
+    ? parseChangedFiles(options.changedFilesJson)
+    : process.env.CHANGED_FILES_JSON
+      ? parseChangedFiles(process.env.CHANGED_FILES_JSON)
+      : []
+
+  const issues = validateReleasePrPolicy({
+    baseBranch: options.baseBranch ?? process.env.PR_BASE_BRANCH ?? '',
+    baseVersion: options.baseVersion ?? process.env.PR_BASE_VERSION ?? '',
+    body,
+    changedFiles,
+    headBranch: options.headBranch ?? process.env.PR_HEAD_BRANCH ?? '',
+    title: options.title ?? process.env.PR_TITLE ?? '',
+  })
+
+  if (issues.length > 0) {
+    console.error('Release PR policy check failed:\n')
+    for (const issue of issues) console.error(`- ${issue}`)
+    process.exit(1)
+  }
+
+  console.log('Release PR policy check passed.')
+}
+
+function parseArgs(args) {
+  const options = {}
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    const nextValue = args[index + 1]
+
+    if (arg === '--base-branch' && nextValue) {
+      options.baseBranch = nextValue
+      index += 1
+    } else if (arg === '--base-version' && nextValue) {
+      options.baseVersion = nextValue
+      index += 1
+    } else if (arg === '--body-file' && nextValue) {
+      options.bodyFile = nextValue
+      index += 1
+    } else if (arg === '--changed-files-json' && nextValue) {
+      options.changedFilesJson = nextValue
+      index += 1
+    } else if (arg === '--head-branch' && nextValue) {
+      options.headBranch = nextValue
+      index += 1
+    } else if (arg === '--title' && nextValue) {
+      options.title = nextValue
+      index += 1
+    } else {
+      throw new Error(`Unknown or incomplete argument: ${arg}`)
+    }
+  }
+
+  return options
+}
+
+function parseChangedFiles(rawValue) {
+  const parsedValue = JSON.parse(rawValue)
+  if (!Array.isArray(parsedValue) || parsedValue.some(value => typeof value !== 'string')) {
+    throw new Error('Changed files must be a JSON array of file paths.')
+  }
+
+  return parsedValue
+}

--- a/test/release-pr-policy.test.ts
+++ b/test/release-pr-policy.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { compareReleaseVersions, validateReleasePrPolicy } from '../scripts/release-pr-policy.js'
+
+const validBody = `## Summary
+
+- materialize the next Quantex release version in source-controlled files
+
+---
+This PR was generated with [Release Please](https://github.com/googleapis/release-please).
+`
+
+const validChangedFiles = [
+  '.release-please-manifest.json',
+  'CHANGELOG.md',
+  'package.json',
+  'src/generated/build-meta.ts',
+]
+
+describe('release PR policy', () => {
+  it('accepts a valid stable release PR', () => {
+    expect(
+      validateReleasePrPolicy({
+        baseBranch: 'main',
+        baseVersion: '0.13.0',
+        body: validBody,
+        changedFiles: validChangedFiles,
+        headBranch: 'release-please--branches--main--components--quantex-cli',
+        title: 'chore: release 0.14.0',
+      }),
+    ).toEqual([])
+  })
+
+  it('rejects a duplicate stable release version', () => {
+    const issues = validateReleasePrPolicy({
+      baseBranch: 'main',
+      baseVersion: '0.13.0',
+      body: validBody,
+      changedFiles: validChangedFiles,
+      headBranch: 'release-please--branches--main--components--quantex-cli',
+      title: 'chore: release 0.13.0',
+    })
+
+    expect(issues.join('\n')).toContain('must be greater than the current main version "0.13.0"')
+  })
+
+  it('rejects unexpected file scope', () => {
+    const issues = validateReleasePrPolicy({
+      baseBranch: 'main',
+      baseVersion: '0.13.0',
+      body: validBody,
+      changedFiles: [...validChangedFiles, 'README.md'],
+      headBranch: 'release-please--branches--main--components--quantex-cli',
+      title: 'chore: release 0.14.0',
+    })
+
+    expect(issues.join('\n')).toContain('Release PR changes unexpected files: README.md')
+  })
+
+  it('compares stable releases after beta prereleases', () => {
+    expect(compareReleaseVersions('0.14.0', '0.14.0-beta.2')).toBeGreaterThan(0)
+    expect(compareReleaseVersions('0.14.0-beta.3', '0.14.0-beta.2')).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary

Harden release-please baseline handling by removing the stale repository-pinned release anchor and rejecting generated Release PRs that do not advance the protected branch version.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `harden-release-please-baseline`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- This branch reapplies the release workflow hardening work onto the restored `main` after the release-line rollback.
- It removes the stale `last-release-sha` override from `release-please-config.json`.
- It adds a dedicated policy check so generated Release PRs must advance the protected branch version before automerge can proceed.
