### PR TITLE
ci(governance): block co-authored-by trailers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,51 @@ jobs:
         with:
           bun-version: 1.3.11
 
+      - name: List commits for trailer policy
+        id: commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            async function listCommits() {
+              if (context.eventName === 'pull_request') {
+                const commits = await github.paginate(github.rest.pulls.listCommits, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  per_page: 100,
+                })
+
+                return commits.map(commit => ({
+                  message: commit.commit.message,
+                  sha: commit.sha,
+                }))
+              }
+
+              if (context.eventName === 'push') {
+                const before = context.payload.before
+                const after = context.payload.after || context.sha
+
+                if (!before || /^0+$/.test(before))
+                  return []
+
+                const { data } = await github.rest.repos.compareCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  base: before,
+                  head: after,
+                })
+
+                return (data.commits ?? []).map(commit => ({
+                  message: commit.commit.message,
+                  sha: commit.sha,
+                }))
+              }
+
+              return []
+            }
+
+            core.setOutput('commits_json', JSON.stringify(await listCommits()))
+
       - uses: actions/cache@v4
         with:
           path: |
@@ -110,6 +155,10 @@ jobs:
             ${{ runner.os }}-bun-
 
       - run: bun install --frozen-lockfile --ignore-scripts --no-progress
+      - name: Validate commit trailer policy
+        env:
+          COMMITS_JSON: ${{ steps.commits.outputs.commits_json }}
+        run: bun run scripts/commit-trailer-policy.ts
       - run: bun run memory:check
       - run: bun run openspec:validate
       - run: bun run lint

--- a/openspec/changes/block-coauthored-by-trailers/.openspec.yaml
+++ b/openspec/changes/block-coauthored-by-trailers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-04

--- a/openspec/changes/block-coauthored-by-trailers/design.md
+++ b/openspec/changes/block-coauthored-by-trailers/design.md
@@ -1,0 +1,22 @@
+## Overview
+
+CI should reject prohibited `Co-authored-by:` trailers using the same repository-owned pattern already used for PR body policy and release PR policy:
+
+- GitHub Actions gathers event-specific metadata.
+- A local repository script evaluates policy.
+- Tests cover the script and a lightweight workflow wiring assertion.
+
+## Design
+
+1. Add `scripts/commit-trailer-policy.ts` as the single source of truth for prohibited trailer detection.
+2. Feed the script a JSON array of commit objects with `sha` and `message` fields.
+3. In `.github/workflows/ci.yml`, collect commits from:
+   - `pull_request`: `pulls.listCommits`
+   - `push`: `repos.compareCommits`
+4. Run the trailer policy inside the required `lint` job so branch protection cannot bypass the result by ignoring a non-required check.
+
+## Rejected Alternatives
+
+- `pre-commit`: cannot inspect the final commit message.
+- `pre-push` only: useful as ergonomics, but still locally bypassable and later than necessary.
+- A standalone non-required CI job: would not guarantee merge protection while the branch rules only require `lint`, `classify`, and test-matrix checks.

--- a/openspec/changes/block-coauthored-by-trailers/proposal.md
+++ b/openspec/changes/block-coauthored-by-trailers/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+This change modifies repository merge governance for commit metadata, so it requires OpenSpec before implementation.
+
+Quantex previously accepted merged history containing `Co-authored-by` trailers that did not match the project's intended authorship policy. The repository currently has no remote enforcement for this metadata, so local tool defaults, IDE integrations, or bot-generated commits can introduce trailers that are only discovered after merge. That makes history cleanup expensive and can break release lineage when remediation requires force-pushing protected branches.
+
+## What Changes
+
+- Add a CI-governed repository script that rejects new commits containing `Co-authored-by:` trailers.
+- Run that script for both pull requests and protected-branch pushes using the commits reported by GitHub for the event payload.
+- Document the new commit-metadata governance rule in the release-governance specification.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `release-governance`: protected-branch CI now enforces repository commit metadata policy for new commits.
+
+## Impact
+
+- Affected code: `scripts/`, `test/`, and `.github/workflows/ci.yml`.
+- Affected specs: `openspec/specs/release-governance/spec.md`.
+- New pull requests and protected-branch pushes will fail before merge or release if their newly introduced commits contain `Co-authored-by:` trailers.

--- a/openspec/changes/block-coauthored-by-trailers/specs/release-governance/spec.md
+++ b/openspec/changes/block-coauthored-by-trailers/specs/release-governance/spec.md
@@ -1,0 +1,18 @@
+## MODIFIED Requirements
+### Requirement: Protected-branch CI MUST reject prohibited co-author trailers in new commits
+
+Repository CI SHALL reject newly introduced commits on pull requests and protected-branch pushes when their commit messages contain `Co-authored-by:` trailers.
+
+#### Scenario: Pull request introduces co-author trailer
+
+- **WHEN** CI evaluates the commits introduced by a pull request targeting a protected branch
+- **AND** any of those commit messages contains a `Co-authored-by:` trailer
+- **THEN** CI fails before merge
+- **AND** it reports the offending commit SHA and trailer line
+
+#### Scenario: Protected-branch push introduces co-author trailer
+
+- **WHEN** CI evaluates the commits introduced by a direct push to a protected branch
+- **AND** any of those commit messages contains a `Co-authored-by:` trailer
+- **THEN** CI fails before downstream release automation treats the push as releasable history
+- **AND** it reports the offending commit SHA and trailer line

--- a/openspec/changes/block-coauthored-by-trailers/tasks.md
+++ b/openspec/changes/block-coauthored-by-trailers/tasks.md
@@ -1,0 +1,17 @@
+## 1. OpenSpec
+
+- [x] 1.1 Finalize the proposal and spec delta for CI commit-trailer governance.
+
+## 2. Implementation
+
+- [x] 2.1 Add a repository script that rejects `Co-authored-by:` trailers in newly introduced commits.
+- [x] 2.2 Wire the script into CI for both pull_request and push events.
+
+## 3. Validation
+
+- [x] 3.1 Add or update automated tests for the commit-trailer policy script.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.
+
+## 4. Delivery
+
+- [x] 4.1 Review git state and prepare the branch for commit, push, and PR delivery.

--- a/scripts/commit-trailer-policy.ts
+++ b/scripts/commit-trailer-policy.ts
@@ -1,0 +1,84 @@
+import process from 'node:process'
+
+export interface CommitMetadata {
+  message: string
+  sha: string
+}
+
+export interface CommitTrailerPolicyInput {
+  commits: CommitMetadata[]
+}
+
+const prohibitedTrailerPattern = /^co-authored-by:\s*/i
+
+export function validateCommitTrailerPolicy(input: CommitTrailerPolicyInput): string[] {
+  const issues: string[] = []
+
+  for (const commit of input.commits) {
+    const sha = commit.sha || '<unknown>'
+    const message = commit.message || ''
+    const offendingLines = message
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => prohibitedTrailerPattern.test(line))
+
+    for (const line of offendingLines) {
+      issues.push(`Commit ${sha.slice(0, 12)} contains prohibited trailer: ${line}`)
+    }
+  }
+
+  return issues
+}
+
+if (import.meta.main) {
+  const commits = parseCommits(process.argv.slice(2), process.env.COMMITS_JSON)
+  const issues = validateCommitTrailerPolicy({ commits })
+
+  if (issues.length > 0) {
+    console.error('Commit trailer policy check failed:\n')
+    for (const issue of issues) console.error(`- ${issue}`)
+    process.exit(1)
+  }
+
+  console.log('Commit trailer policy check passed.')
+}
+
+function parseCommits(args: string[], commitsJsonEnv: string | undefined): CommitMetadata[] {
+  let rawValue = commitsJsonEnv
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    const nextValue = args[index + 1]
+
+    if (arg === '--commits-json' && nextValue) {
+      rawValue = nextValue
+      index += 1
+      continue
+    }
+
+    throw new Error(`Unknown or incomplete argument: ${arg}`)
+  }
+
+  if (!rawValue) return []
+
+  const parsedValue = JSON.parse(rawValue)
+  if (!Array.isArray(parsedValue)) {
+    throw new Error('Commits must be a JSON array.')
+  }
+
+  return parsedValue.map((value, index) => {
+    if (
+      typeof value !== 'object' ||
+      value === null ||
+      typeof value.sha !== 'string' ||
+      typeof value.message !== 'string'
+    ) {
+      throw new Error(`Commit at index ${index} must include string sha and message fields.`)
+    }
+
+    return {
+      message: value.message,
+      sha: value.sha,
+    }
+  })
+}

--- a/test/commit-trailer-policy.test.ts
+++ b/test/commit-trailer-policy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { validateCommitTrailerPolicy } from '../scripts/commit-trailer-policy'
+
+describe('commit trailer policy', () => {
+  it('accepts commits without co-author trailers', () => {
+    expect(
+      validateCommitTrailerPolicy({
+        commits: [
+          {
+            message: 'feat(agents): add deepseek tui support',
+            sha: 'ca43b811dd86bfb33dde7aece06bff1dc26deed9',
+          },
+        ],
+      }),
+    ).toEqual([])
+  })
+
+  it('rejects co-authored-by trailers case-insensitively', () => {
+    const issues = validateCommitTrailerPolicy({
+      commits: [
+        {
+          message: [
+            'chore: release 0.13.0',
+            '',
+            'Co-authored-by: quantex-release[bot] <41898282+github-actions[bot]@users.noreply.github.com>',
+          ].join('\n'),
+          sha: 'ed71cdd2256803d96035e49494ec7c9f3720b9fa',
+        },
+        {
+          message: ['docs: example', '', 'co-authored-by: Example Bot <bot@example.com>'].join('\n'),
+          sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+      ],
+    })
+
+    expect(issues).toHaveLength(2)
+    expect(issues[0]).toContain('ed71cdd22568')
+    expect(issues[0]).toContain('Co-authored-by:')
+    expect(issues[1]).toContain('aaaaaaaaaaaa')
+    expect(issues[1]).toContain('co-authored-by:')
+  })
+})

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
+const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8')
 const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml', 'utf8')
 const prTemplate = readFileSync('.github/pull_request_template.md', 'utf8')
 const prBodyPolicyScript = readFileSync('scripts/pr-body-policy.ts', 'utf8')
@@ -39,5 +40,11 @@ describe('pr governance release intent', () => {
   it('keeps PR template compatible with agent-driven OpenSpec archive closure', () => {
     expect(prTemplate).toContain('## Closure Check')
     expect(prTemplate).toContain('queued for agent-driven archive closure')
+  })
+
+  it('runs commit trailer governance from CI through a local repository script', () => {
+    expect(ciWorkflow).toContain('Validate commit trailer policy')
+    expect(ciWorkflow).toContain('bun run scripts/commit-trailer-policy.ts')
+    expect(ciWorkflow).toContain('List commits for trailer policy')
   })
 })


### PR DESCRIPTION
## Summary

Add CI-governed commit trailer validation that rejects newly introduced `Co-authored-by:` trailers on pull requests and protected-branch pushes.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `block-coauthored-by-trailers`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - process-only CI governance guard for commit metadata

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- The new trailer policy is enforced from the required `lint` CI job so branch protection cannot bypass it as a non-required check.
- The policy evaluates only the commits introduced by the current pull request or protected-branch push; it does not retroactively scan the full repository history.
