### PR TITLE
fix(self-upgrade): verify managed installs via cli entrypoint

### DIFF
--- a/openspec/changes/fix-node-self-upgrade-verification/.openspec.yaml
+++ b/openspec/changes/fix-node-self-upgrade-verification/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/fix-node-self-upgrade-verification/design.md
+++ b/openspec/changes/fix-node-self-upgrade-verification/design.md
@@ -1,0 +1,36 @@
+## Context
+
+The published Quantex CLI package now runs under Node, so `process.execPath` points to the Node executable for Bun- and npm-managed installs. Managed self-upgrade verification still assumes that `process.execPath` is the Quantex CLI itself, then calls `getInstalledVersion(process.execPath)`. That makes the post-upgrade verification path read `node --version` instead of the upgraded Quantex package version.
+
+The bug is limited to managed self-upgrade verification. Binary installs still need the real executable path for release asset selection and in-place replacement behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Verify managed self-upgrades against the installed Quantex CLI package entrypoint.
+- Preserve binary self-upgrade executable-path behavior.
+- Add regression coverage for Node-runtime managed installs.
+
+**Non-Goals:**
+
+- Redesign the self-inspection output surface.
+- Change binary release selection or replacement semantics.
+- Introduce a broader command-resolution subsystem for unrelated agent probes.
+
+## Decisions
+
+### Separate managed verification from binary executable-path usage
+
+Managed installs will verify the upgraded version by executing the installed package entrypoint under the current host runtime. That means Quantex will build a version-probe command such as `node <packageRoot>/dist/cli.mjs --version` instead of re-running `process.execPath` directly.
+
+Binary installs will keep using the executable path already stored in `SelfInspection`.
+
+### Keep the fallback narrow
+
+If Quantex cannot resolve a managed package entrypoint from `packageRoot`, it will fall back to the existing executable-path probe. This limits the behavior change to the path that is known to be wrong under the Node runtime while preserving current recovery semantics for unexpected layouts.
+
+## Risks / Trade-offs
+
+- If a managed install layout changes and no longer ships `dist/cli.mjs`, verification falls back to the legacy probe and may still fail conservatively.
+- The verification command now depends on `packageRoot` staying aligned with the installed package layout, which is already a core assumption elsewhere in self inspection.

--- a/openspec/changes/fix-node-self-upgrade-verification/proposal.md
+++ b/openspec/changes/fix-node-self-upgrade-verification/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Implementation requested work-intake classification: this change modifies observable self-upgrade behavior, so it requires OpenSpec before file edits.
+
+Managed self-upgrade verification currently re-runs `process.execPath` after Bun or npm reports success. Since the published CLI now runs through `#!/usr/bin/env node`, that path resolves to the host Node binary instead of the installed Quantex CLI entrypoint, causing false upgrade failures such as `22.22.2` versus `0.14.0`.
+
+## What Changes
+
+- Make managed self-upgrade verification execute the installed Quantex CLI package entrypoint instead of the host runtime binary.
+- Keep binary self-upgrade behavior unchanged so standalone release asset detection and replacement still use the real executable path.
+- Add regression coverage for Node-runtime managed installs so successful upgrades no longer fail verification by reading the Node version.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `self-upgrade`: managed self-upgrade verification must probe the installed Quantex CLI entrypoint rather than the host Node runtime.
+
+## Impact
+
+- Affected code: `src/self/`, `src/utils/version.ts`, self-upgrade tests.
+- Affected behavior: `quantex upgrade` / `qtx upgrade` verification for Bun and npm installs under the Node-based published runtime.

--- a/openspec/changes/fix-node-self-upgrade-verification/specs/self-upgrade/spec.md
+++ b/openspec/changes/fix-node-self-upgrade-verification/specs/self-upgrade/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Managed self-upgrade MUST verify the installed version after update
+
+Managed self-upgrade SHALL verify that the installed Quantex CLI entrypoint reports the expected version after Bun or npm reports a successful install.
+
+#### Scenario: Managed self-upgrade verifies the installed CLI version
+
+- GIVEN Quantex was installed via `bun` or `npm`
+- AND a managed self-upgrade attempt reports success from the package manager
+- WHEN Quantex re-runs the installed Quantex CLI entrypoint with `--version`
+- THEN the reported version matches the upgrade target
+
+#### Scenario: Managed self-upgrade does not confuse the host runtime with Quantex
+
+- GIVEN the published Quantex CLI runs through a host runtime such as `node`
+- AND `process.execPath` therefore points to that host runtime binary
+- WHEN Quantex verifies a managed self-upgrade result
+- THEN it probes the installed Quantex package entrypoint instead of the host runtime binary
+- AND a host runtime version like `22.22.2` does not become the observed Quantex version
+
+#### Scenario: Managed self-upgrade reports registry lag when verification fails
+
+- GIVEN Quantex was installed via `bun` or `npm`
+- AND the package manager reported success
+- BUT the installed Quantex CLI entrypoint still reports the previous version
+- WHEN Quantex finishes the upgrade attempt
+- THEN the command fails instead of reporting success
+- AND the output includes recovery guidance for reinstalling or retrying against a different registry

--- a/openspec/changes/fix-node-self-upgrade-verification/tasks.md
+++ b/openspec/changes/fix-node-self-upgrade-verification/tasks.md
@@ -1,0 +1,14 @@
+## 1. Spec And Design
+
+- [x] 1.1 Document the managed self-upgrade verification regression and the intended verification behavior in proposal, design, and self-upgrade spec deltas.
+
+## 2. Implementation
+
+- [x] 2.1 Update managed self-upgrade verification to probe the installed Quantex CLI entrypoint instead of the host runtime binary.
+- [x] 2.2 Add regression tests covering Node-runtime managed self-upgrade verification and fallback behavior.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, and `bun run typecheck`.
+- [x] 3.2 Run `bun run test`.
+- [x] 3.3 Run `bun run openspec:validate`.

--- a/src/self/index.ts
+++ b/src/self/index.ts
@@ -202,7 +202,7 @@ async function verifyManagedSelfUpgradeResult(
 
   if (inspection.installSource !== 'bun' && inspection.installSource !== 'npm') return result
 
-  const observedVersion = await getInstalledVersion(inspection.executablePath)
+  const observedVersion = await getManagedInstalledSelfVersion(inspection)
   if (!observedVersion) {
     return {
       error: {
@@ -248,6 +248,26 @@ async function verifyManagedSelfUpgradeResult(
     ...result,
     newVersion: observedVersion,
   }
+}
+
+async function getManagedInstalledSelfVersion(inspection: SelfInspection): Promise<string | undefined> {
+  const managedVersionProbe = getManagedSelfVersionProbeCommand(inspection.packageRoot)
+
+  if (managedVersionProbe) {
+    const managedVersion = await getInstalledVersion(inspection.executablePath, {
+      command: managedVersionProbe,
+    })
+
+    if (managedVersion) return managedVersion
+  }
+
+  return getInstalledVersion(inspection.executablePath)
+}
+
+function getManagedSelfVersionProbeCommand(packageRoot: string): string[] | undefined {
+  if (!packageRoot) return undefined
+
+  return [process.execPath, join(packageRoot, 'dist', 'cli.mjs'), '--version']
 }
 
 async function readPackageJson(packageJsonPath: string): Promise<{ name?: string; version?: string } | undefined> {

--- a/test/self.test.ts
+++ b/test/self.test.ts
@@ -104,6 +104,7 @@ describe('self helpers', () => {
     const { getSelfUpgradeLockPath, upgradeSelf } = await import('../src/self')
     bunInstallSpy.mockResolvedValue(true)
     installedVersionSpy.mockResolvedValue('1.1.0')
+    const packageRoot = '/Users/test/.bun/install/global/node_modules/quantex-cli'
 
     const result = await upgradeSelf({
       canAutoUpdate: true,
@@ -112,7 +113,7 @@ describe('self helpers', () => {
       installSource: 'bun',
       latestVersion: '1.1.0',
       managedRegistry: 'https://registry.npmjs.org',
-      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
+      packageRoot,
       recommendedUpgradeCommand: 'quantex upgrade',
       updateChannel: 'stable',
     })
@@ -125,6 +126,9 @@ describe('self helpers', () => {
     })
     expect(bunInstallSpy).toHaveBeenCalledWith('quantex-cli', 'latest', 'https://registry.npmjs.org')
     expect(bunUpdateSpy).not.toHaveBeenCalled()
+    expect(installedVersionSpy).toHaveBeenCalledWith('/Users/test/.bun/bin/quantex', {
+      command: [process.execPath, join(packageRoot, 'dist', 'cli.mjs'), '--version'],
+    })
     expect(existsSync(getSelfUpgradeLockPath())).toBe(false)
   })
 
@@ -132,6 +136,7 @@ describe('self helpers', () => {
     const { upgradeSelf } = await import('../src/self')
     npmInstallSpy.mockResolvedValue(true)
     installedVersionSpy.mockResolvedValue('1.1.0')
+    const packageRoot = '/usr/local/lib/node_modules/quantex-cli'
 
     const result = await upgradeSelf({
       canAutoUpdate: true,
@@ -140,7 +145,7 @@ describe('self helpers', () => {
       installSource: 'npm',
       latestVersion: '1.1.0',
       managedRegistry: 'https://registry.npmjs.org',
-      packageRoot: '/usr/local/lib/node_modules/quantex-cli',
+      packageRoot,
       recommendedUpgradeCommand: 'quantex upgrade',
       updateChannel: 'stable',
     })
@@ -153,6 +158,9 @@ describe('self helpers', () => {
     })
     expect(npmInstallSpy).toHaveBeenCalledWith('quantex-cli', 'latest', 'https://registry.npmjs.org')
     expect(npmUpdateSpy).not.toHaveBeenCalled()
+    expect(installedVersionSpy).toHaveBeenCalledWith('/usr/local/bin/quantex', {
+      command: [process.execPath, join(packageRoot, 'dist', 'cli.mjs'), '--version'],
+    })
   })
 
   it('reports source installs as unsupported for auto-update', async () => {
@@ -445,5 +453,69 @@ describe('self helpers', () => {
       installSource: 'npm',
       success: false,
     })
+  })
+
+  it('verifies managed self-upgrade against the installed cli entrypoint under node runtime', async () => {
+    const { upgradeSelf } = await import('../src/self')
+    npmInstallSpy.mockResolvedValue(true)
+    const packageRoot = '/usr/local/lib/node_modules/quantex-cli'
+    const expectedCommand = [process.execPath, join(packageRoot, 'dist', 'cli.mjs'), '--version']
+
+    installedVersionSpy.mockImplementation(async (_binaryName, versionProbe) => {
+      return JSON.stringify(versionProbe?.command) === JSON.stringify(expectedCommand) ? '1.1.0' : '22.22.2'
+    })
+
+    const result = await upgradeSelf({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: process.execPath,
+      installSource: 'npm',
+      latestVersion: '1.1.0',
+      managedRegistry: 'https://registry.npmjs.org',
+      packageRoot,
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    expect(result).toEqual({
+      error: undefined,
+      installSource: 'npm',
+      newVersion: '1.1.0',
+      success: true,
+    })
+    expect(installedVersionSpy).toHaveBeenCalledTimes(1)
+    expect(installedVersionSpy).toHaveBeenCalledWith(process.execPath, {
+      command: expectedCommand,
+    })
+  })
+
+  it('falls back to the executable-path probe when the managed entrypoint probe fails', async () => {
+    const { upgradeSelf } = await import('../src/self')
+    npmInstallSpy.mockResolvedValue(true)
+    installedVersionSpy.mockResolvedValueOnce(undefined).mockResolvedValueOnce('1.1.0')
+    const packageRoot = '/usr/local/lib/node_modules/quantex-cli'
+
+    const result = await upgradeSelf({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: '/usr/local/bin/quantex',
+      installSource: 'npm',
+      latestVersion: '1.1.0',
+      managedRegistry: 'https://registry.npmjs.org',
+      packageRoot,
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    expect(result).toEqual({
+      error: undefined,
+      installSource: 'npm',
+      newVersion: '1.1.0',
+      success: true,
+    })
+    expect(installedVersionSpy).toHaveBeenNthCalledWith(1, '/usr/local/bin/quantex', {
+      command: [process.execPath, join(packageRoot, 'dist', 'cli.mjs'), '--version'],
+    })
+    expect(installedVersionSpy).toHaveBeenNthCalledWith(2, '/usr/local/bin/quantex')
   })
 })


### PR DESCRIPTION
## Summary

Fix managed self-upgrade verification under the Node-based published CLI. Quantex now verifies Bun and npm installs by executing the installed package entrypoint instead of reading the host Node runtime version from `process.execPath`.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `fix-node-self-upgrade-verification`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Adds regression coverage for Node-runtime managed installs and preserves a conservative fallback to the old executable-path probe if the package entrypoint cannot be resolved.
