### PR TITLE
feat: add jcode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
 | Goose | `qtx goose` | Block's open-source extensible AI agent CLI |
+| jcode CLI | `qtx jcode` | High-performance coding agent harness for multi-session workflows |
 | Junie CLI | `qtx junie` | JetBrains' AI coding agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
 | Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -185,6 +185,7 @@ qtx upgrade --channel beta
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
 | Goose | `qtx goose` | Block 开源可扩展 AI Agent CLI |
+| jcode CLI | `qtx jcode` | 面向多 session 工作流的高性能编程 Agent harness |
 | Junie CLI | `qtx junie` | JetBrains 官方 AI 编程 Agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
 | Kimi Code | `qtx kimi` | Moonshot AI 编程助手 CLI |

--- a/openspec/changes/add-jcode-cli-support/.openspec.yaml
+++ b/openspec/changes/add-jcode-cli-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/add-jcode-cli-support/design.md
+++ b/openspec/changes/add-jcode-cli-support/design.md
@@ -1,0 +1,45 @@
+## Context
+
+`jcode` is distributed from `1jehuang/jcode` with official shell and PowerShell installers plus a documented Homebrew tap for macOS. The install script downloads the latest GitHub release artifact and can replace an existing installation, but upstream user-facing docs do not publish a stable dedicated `jcode update` subcommand or a single cross-platform upgrade command that fits Quantex's current `selfUpdate.command` model.
+
+Quantex should add `jcode` as a distinct supported lifecycle agent without inventing package metadata or upgrade semantics that upstream has not documented as a stable CLI contract.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `jcode` as a supported lifecycle agent.
+- Record only upstream-documented install methods and stable version-probe behavior.
+- Keep the implementation aligned with existing catalog/test/documentation patterns.
+
+**Non-Goals:**
+
+- Adding first-class managed package metadata beyond the documented Homebrew tap.
+- Inventing a synthetic self-update command for `jcode`.
+- Modeling source builds, provider login flows, browser setup, or other upstream feature areas unrelated to lifecycle metadata.
+
+## Decisions
+
+- Use `jcode` as both the canonical Quantex slug and executable name because the upstream binary and project branding are both `jcode`.
+- Use the GitHub repository URL as the homepage because the upstream repository README is the primary published installation reference.
+- Model the macOS Homebrew option as `brew install 1jehuang/jcode/jcode`, which preserves the documented tap source while fitting Quantex's managed Homebrew metadata shape.
+- Model the shell and PowerShell one-liners from the upstream installation docs as script install methods for macOS, Linux, and Windows.
+- Use `jcode --version` as the version probe because the official install script checks the existing installation with that command before replacing it.
+- Omit `selfUpdate` metadata because upstream documentation currently publishes install paths, not a stable dedicated upgrade subcommand or a single portable command array that Quantex can safely execute across platforms.
+
+## Risks / Trade-offs
+
+- [Managed lifecycle gap] Homebrew is only documented for macOS, so Linux remains script-only. → Mitigation: record only the install methods upstream actually documents.
+- [Upgrade expectation gap] The installer can update an existing install, but there is no single stable cross-platform update command in docs. → Mitigation: leave `selfUpdate` unset instead of encoding shell-specific pipelines into a global command array.
+- [Doc drift] Upstream install snippets can change quickly. → Mitigation: keep the catalog scoped to canonical installer URLs and validate against the current repository docs when refreshing the entry.
+
+## Migration Plan
+
+- Add the `jcode` agent definition and register it in the catalog and root exports.
+- Add tests that verify lookup, install methods, version probing, and the absence of `selfUpdate`.
+- Update supported-agent tables to list `jcode`.
+- Validate with lint, format check, typecheck, tests, and OpenSpec validation.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/add-jcode-cli-support/proposal.md
+++ b/openspec/changes/add-jcode-cli-support/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`jcode` is a separate upstream coding-agent CLI with official install scripts, a documented Homebrew tap, and active GitHub releases. Quantex should support it as its own lifecycle agent so users can install, inspect, resolve, and run `jcode` through the same stable catalog used for other supported CLIs.
+
+This request requires OpenSpec because it adds supported agent catalog metadata and updates product-facing supported-agent documentation.
+
+## What Changes
+
+- Add a supported `jcode` catalog entry with verified install methods, version probing, and homepage metadata from the official upstream repository.
+- Register the new agent in the runtime registry and root exports.
+- Add test coverage for `jcode` lookup, install metadata, and version probing.
+- Update supported-agent documentation to list `jcode` in the user-facing support matrix.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-catalog`: add `jcode` as a supported lifecycle agent with official install methods and version-probe metadata
+
+## Impact
+
+- `src/agents/definitions/jcode.ts` - new `jcode` lifecycle metadata definition
+- `src/agents/index.ts` and `src/index.ts` - register and re-export `jcode`
+- `test/agents.test.ts` and `test/index.test.ts` - cover `jcode` lookup and metadata
+- `README.md` and `README.zh-CN.md` - add `jcode` to supported-agent tables
+- `openspec/changes/add-jcode-cli-support/specs/agent-catalog/spec.md` - record the catalog contract delta

--- a/openspec/changes/add-jcode-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-jcode-cli-support/specs/agent-catalog/spec.md
@@ -1,0 +1,31 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: jcode MUST be a supported lifecycle agent
+
+Quantex SHALL include `jcode` in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, and stable identification.
+
+#### Scenario: Looking up `jcode`
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `jcode`
+- **THEN** Quantex returns a supported agent entry for `jcode`
+- **AND** the entry identifies `jcode` as the executable binary
+- **AND** the entry identifies `https://github.com/1jehuang/jcode` as the homepage
+
+#### Scenario: Installing `jcode` through supported methods
+
+- **WHEN** Quantex renders or executes install options for `jcode`
+- **THEN** macOS includes the official Homebrew tap formula option (`brew install 1jehuang/jcode/jcode`)
+- **AND** macOS and Linux include the official shell installer option (`curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash`)
+- **AND** Windows includes the official PowerShell installer option (`irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex`)
+
+#### Scenario: Probing `jcode` version
+
+- **WHEN** Quantex probes the installed version of `jcode`
+- **THEN** it runs `jcode --version` and parses the output
+
+#### Scenario: Planning `jcode` updates
+
+- **WHEN** Quantex plans an update for a `jcode` installation
+- **THEN** the catalog does not expose a self-update command because upstream installation docs publish platform-specific installer flows rather than a stable dedicated update subcommand

--- a/openspec/changes/add-jcode-cli-support/tasks.md
+++ b/openspec/changes/add-jcode-cli-support/tasks.md
@@ -1,0 +1,20 @@
+## 1. OpenSpec And Docs
+
+- [x] 1.1 Write the proposal, design, tasks, and `agent-catalog` delta for `jcode` support
+- [x] 1.2 Update supported-agent documentation to list `jcode`
+
+## 2. Catalog Implementation
+
+- [x] 2.1 Add `src/agents/definitions/jcode.ts` with verified lifecycle metadata
+- [x] 2.2 Register and re-export `jcode` in the agent catalog
+- [x] 2.3 Add tests covering `jcode` lookup, version probing, install methods, and missing self-update metadata
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, and `bun run typecheck`
+- [x] 3.2 Run `bun run test` and `bun run openspec:validate`
+
+## 4. Delivery
+
+- [ ] 4.1 Commit the change on a dedicated branch
+- [ ] 4.2 Push the branch and open a pull request with a validated PR body

--- a/openspec/changes/add-jcode-cli-support/tasks.md
+++ b/openspec/changes/add-jcode-cli-support/tasks.md
@@ -16,5 +16,5 @@
 
 ## 4. Delivery
 
-- [ ] 4.1 Commit the change on a dedicated branch
-- [ ] 4.2 Push the branch and open a pull request with a validated PR body
+- [x] 4.1 Commit the change on a dedicated branch
+- [x] 4.2 Push the branch and open a pull request with a validated PR body

--- a/src/agents/definitions/jcode.ts
+++ b/src/agents/definitions/jcode.ts
@@ -1,0 +1,22 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, scriptInstall } from '../methods'
+
+export const jcode: AgentDefinition = {
+  name: 'jcode',
+  displayName: 'jcode CLI',
+  homepage: 'https://github.com/1jehuang/jcode',
+  binaryName: 'jcode',
+  versionProbe: {
+    command: ['jcode', '--version'],
+  },
+  platforms: {
+    windows: [scriptInstall('irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex')],
+    macos: [
+      brewInstall('1jehuang/jcode/jcode'),
+      scriptInstall('curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash'),
+    ],
+    linux: [
+      scriptInstall('curl -fsSL https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh | bash'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -14,6 +14,7 @@ import { droid } from './definitions/droid'
 import { forgecode } from './definitions/forgecode'
 import { gemini } from './definitions/gemini'
 import { goose } from './definitions/goose'
+import { jcode } from './definitions/jcode'
 import { junie } from './definitions/junie'
 import { kilo } from './definitions/kilo'
 import { kimi } from './definitions/kimi'
@@ -41,6 +42,7 @@ const agents: AgentDefinition[] = [
   forgecode,
   gemini,
   goose,
+  jcode,
   junie,
   kilo,
   kimi,
@@ -81,6 +83,7 @@ export {
   forgecode,
   gemini,
   goose,
+  jcode,
   junie,
   kilo,
   kimi,

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
   devin,
   droid,
   gemini,
+  jcode,
   getAgentByLookupName,
   getAgentByNameOrAlias,
   getAllAgents,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -12,6 +12,7 @@ import { deepseek } from '../src/agents/definitions/deepseek'
 import { devin } from '../src/agents/definitions/devin'
 import { droid } from '../src/agents/definitions/droid'
 import { gemini } from '../src/agents/definitions/gemini'
+import { jcode } from '../src/agents/definitions/jcode'
 import { junie } from '../src/agents/definitions/junie'
 import { kilo } from '../src/agents/definitions/kilo'
 import { opencode } from '../src/agents/definitions/opencode'
@@ -410,6 +411,51 @@ describe('deepseek', () => {
     expect(deepseek.platforms.windows!.find(m => m.type === 'npm')).toBeDefined()
     expect(deepseek.platforms.macos!.find(m => m.type === 'npm')).toBeDefined()
     expect(deepseek.platforms.linux!.find(m => m.type === 'npm')).toBeDefined()
+  })
+})
+
+describe('jcode', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('jcode')).toBe(jcode)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(jcode)
+    expect(jcode.name).toBe('jcode')
+    expect(jcode.lookupAliases).toBeUndefined()
+    expect(jcode.displayName).toBe('jcode CLI')
+    expect(jcode.packages).toBeUndefined()
+    expect(jcode.binaryName).toBe('jcode')
+    expect(jcode.homepage).toBe('https://github.com/1jehuang/jcode')
+    expect(jcode.selfUpdate).toBeUndefined()
+    expect(jcode.versionProbe?.command).toEqual(['jcode', '--version'])
+  })
+
+  it('supports official Homebrew and script installers without inventing update metadata', () => {
+    expect(jcode.platforms.windows).toEqual([
+      {
+        command: 'irm https://raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.ps1 | iex',
+        type: 'script',
+      },
+    ])
+    expect(
+      jcode.platforms.macos!.find(m => m.type === 'brew' && m.packageName === '1jehuang/jcode/jcode'),
+    ).toBeDefined()
+    expect(
+      jcode.platforms.macos!.find(
+        m =>
+          m.type === 'script' &&
+          m.command.includes('raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh'),
+      ),
+    ).toBeDefined()
+    expect(
+      jcode.platforms.linux!.find(
+        m =>
+          m.type === 'script' &&
+          m.command.includes('raw.githubusercontent.com/1jehuang/jcode/master/scripts/install.sh'),
+      ),
+    ).toBeDefined()
+    expect(jcode.selfUpdate).toBeUndefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,7 @@ import {
   devin,
   droid,
   gemini,
+  jcode,
   getAgentByLookupName,
   getAgentByNameOrAlias,
   getAllAgents,
@@ -68,6 +69,13 @@ describe('agent registry', () => {
     expect(agent).toBeDefined()
     expect(agent!.name).toBe('openhands')
     expect(agent!.binaryName).toBe('openhands')
+  })
+
+  it('finds jcode by name', () => {
+    const agent = getAgentByNameOrAlias('jcode')
+    expect(agent).toBeDefined()
+    expect(agent!.name).toBe('jcode')
+    expect(agent!.binaryName).toBe('jcode')
   })
 
   it('resolves CodeBuddy by package-style alias', () => {
@@ -159,6 +167,15 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('junie')
   })
 
+  it('jcode has correct structure', () => {
+    const agent = getAgentByNameOrAlias('jcode')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('jcode CLI')
+    expect(agent!.binaryName).toBe('jcode')
+    expect(agent!.homepage).toBe('https://github.com/1jehuang/jcode')
+    expect(agent!.selfUpdate).toBeUndefined()
+  })
+
   it('deepseek has correct structure', () => {
     const agent = getAgentByNameOrAlias('deepseek')
     expect(agent).toBeDefined()
@@ -185,6 +202,7 @@ describe('agent definitions', () => {
     expect(devin.name).toBe('devin')
     expect(droid.name).toBe('droid')
     expect(gemini.name).toBe('gemini')
+    expect(jcode.name).toBe('jcode')
     expect(junie.name).toBe('junie')
     expect(kilo.name).toBe('kilo')
     expect(openhands.name).toBe('openhands')


### PR DESCRIPTION
## Summary

Add `jcode` as a supported Quantex agent with official install metadata, version probing, tests, and support-matrix documentation updates.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/add-jcode-cli-support/`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

`jcode` currently ships official installer flows, but Quantex does not expose a `selfUpdate` command for it because upstream does not document a stable dedicated upgrade subcommand or a single portable command array that fits the current catalog contract.
