### PR TITLE
fix(self-upgrade): suppress stale latest-version downgrades

### DIFF
--- a/openspec/changes/fix-self-upgrade-stale-latest/.openspec.yaml
+++ b/openspec/changes/fix-self-upgrade-stale-latest/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/fix-self-upgrade-stale-latest/design.md
+++ b/openspec/changes/fix-self-upgrade-stale-latest/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The current self-upgrade flow determines update availability with direct string inequality checks. That works only when the resolved `latestVersion` is trustworthy and newer than the installed CLI. With cached or lagging registry data, Quantex can see `latestVersion=0.14.0` while the installed CLI is already `0.15.0`, then attempt an upgrade and fail verification after Bun or npm installs the real latest package.
+
+The user-visible problem is not limited to `quantex upgrade`. The same stale comparison also affects `quantex doctor` and passive update notices.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Treat self updates as available only when `latestVersion` is semantically newer than `currentVersion`.
+- Prevent managed self-upgrade from entering downgrade or stale-target paths.
+- Keep the fix narrow to self-upgrade surfaces and related messaging.
+
+**Non-Goals:**
+
+- Rework the general network cache policy in this change.
+- Change managed agent update semantics outside Quantex self-upgrade.
+- Add a new persistent self-upgrade state file or cross-command cache invalidation mechanism.
+
+## Decisions
+
+### Use semantic version comparison for self-update availability
+
+Quantex will compare `latestVersion` and `currentVersion` semantically instead of with raw string inequality. When `latestVersion` is equal to or lower than the installed CLI version, Quantex will treat self-upgrade as unavailable for that command path.
+
+### Apply the same availability rule to all self-update surfaces
+
+The same “strictly newer only” rule will drive:
+
+- `quantex upgrade`
+- `quantex doctor`
+- passive self-update notices
+
+This keeps user-visible state consistent and avoids a path where one surface suppresses a stale downgrade while another still advertises it.
+
+## Risks / Trade-offs
+
+- A semver comparison helper adds parsing logic to the runtime surface, but the versions involved are already semver-shaped package and release versions.
+- This change does not auto-refresh stale cache entries; it only blocks false downgrade behavior. Users may still need `--refresh` or `--no-cache` to discover a newer release immediately after a publish.

--- a/openspec/changes/fix-self-upgrade-stale-latest/proposal.md
+++ b/openspec/changes/fix-self-upgrade-stale-latest/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Implementation requested work-intake classification: this change modifies observable self-upgrade and doctor behavior, so it requires OpenSpec before file edits.
+
+Quantex currently treats any `latestVersion` that differs from `currentVersion` as an available self-update. When cached or mirrored registry data falls behind the installed version, Quantex can attempt a managed self-upgrade toward an older target and then report failure after the package manager correctly installs a newer version.
+
+## What Changes
+
+- Prevent self-upgrade surfaces from treating a lower `latestVersion` as an available update.
+- Make `quantex upgrade`, `quantex doctor`, and passive self-update notices use semantic version comparison instead of simple inequality.
+- Add regression coverage for stale cached latest-version data so Quantex no longer attempts or advertises self downgrades.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `self-upgrade`: managed self-upgrade planning and user-facing self-update surfaces must reject stale or lower latest-version data instead of entering a downgrade path.
+
+## Impact
+
+- Affected code: `src/commands/upgrade.ts`, `src/commands/doctor.ts`, `src/self/update-notice.ts`, `src/utils/version.ts`.
+- Affected tests: self-upgrade command, doctor command, and self-update notice regression coverage.

--- a/openspec/changes/fix-self-upgrade-stale-latest/specs/self-upgrade/spec.md
+++ b/openspec/changes/fix-self-upgrade-stale-latest/specs/self-upgrade/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Managed self-upgrade MUST keep registry checks and installs consistent
+
+Managed self-upgrade SHALL use the same resolved registry for package-manager version checks and managed-install execution, SHALL install the selected package tag directly instead of relying on package-manager update semantics, and SHALL not treat a lower reported latest version as an update target.
+
+#### Scenario: Managed self-upgrade suppresses stale downgrade targets
+
+- GIVEN Quantex was installed via `bun` or `npm`
+- AND the current CLI version is newer than the resolved `latestVersion` from cache or registry
+- WHEN the user runs `quantex upgrade` or `quantex upgrade --check`
+- THEN Quantex does not invoke managed self-upgrade toward that lower version
+- AND it does not present the lower version as an available update
+
+### Requirement: Self-upgrade MUST expose recovery guidance
+
+The self-upgrade system SHALL provide recovery hints when automatic upgrade is unavailable or fails, and SHALL only advertise self-updates when the resolved latest version is newer than the installed CLI version.
+
+#### Scenario: Doctor suppresses stale self-update warnings
+
+- GIVEN Quantex resolves a self `latestVersion` that is lower than the installed CLI version
+- WHEN the user runs `quantex doctor`
+- THEN the doctor output does not emit `SELF_UPDATE_AVAILABLE`
+- AND it does not label the installed CLI as outdated
+
+#### Scenario: Passive update notices suppress stale self-update warnings
+
+- GIVEN Quantex resolves a self `latestVersion` that is lower than the installed CLI version
+- WHEN a successful human-mode command evaluates the passive self-update notice
+- THEN Quantex does not display an available-update notice for that lower version

--- a/openspec/changes/fix-self-upgrade-stale-latest/tasks.md
+++ b/openspec/changes/fix-self-upgrade-stale-latest/tasks.md
@@ -1,0 +1,14 @@
+## 1. Spec And Design
+
+- [x] 1.1 Document the stale latest-version downgrade bug and the intended self-update availability behavior in proposal, design, and self-upgrade spec deltas.
+
+## 2. Implementation
+
+- [x] 2.1 Add semantic self-version comparison and use it to suppress stale or lower self-update targets in `upgrade`, `doctor`, and passive notices.
+- [x] 2.2 Add regression tests covering stale latest-version behavior for upgrade, doctor, and self-update notices.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, and `bun run typecheck`.
+- [x] 3.2 Run `bun run test`.
+- [x] 3.3 Run `bun run openspec:validate`.

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -6,6 +6,7 @@ import { getSelfUpgradeRecoveryHintForInspection, inspectSelf } from '../self'
 import { inspectRegisteredAgents } from '../services/agents'
 import { pc } from '../utils/color'
 import { isBrewAvailable, isBunAvailable, isNpmAvailable, isWingetAvailable } from '../utils/detect'
+import { isVersionNewer } from '../utils/version'
 
 type DoctorIssueCategory = 'agent' | 'installers' | 'self'
 type DoctorIssueSubjectKind = 'agent' | 'self' | 'system'
@@ -66,7 +67,9 @@ export async function doctorCommand(): Promise<CommandResult<DoctorData>> {
   const wingetAvailable = await isWingetAvailable()
 
   const selfInspection = await inspectSelf()
-  const selfOutdated = selfInspection.latestVersion && selfInspection.latestVersion !== selfInspection.currentVersion
+  const selfOutdated = selfInspection.latestVersion
+    ? isVersionNewer(selfInspection.latestVersion, selfInspection.currentVersion)
+    : false
   const inspections = await inspectRegisteredAgents()
   const installedAgents = inspections
     .filter(inspection => inspection.inPath)

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -5,6 +5,7 @@ import { createErrorResult, createSuccessResult, emitCommandResult } from '../ou
 import { getSelfUpgradeRecoveryHintForInspection, inspectSelf, upgradeSelf } from '../self'
 import { pc } from '../utils/color'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
+import { compareVersions, isVersionNewer } from '../utils/version'
 
 interface UpgradeCommandData {
   canAutoUpdate: boolean
@@ -22,8 +23,12 @@ export async function upgradeCommand(
   const inspection = await inspectSelf({ updateChannel: options.channel })
   const dryRun = isDryRunEnabled()
   const registryWarnings = getManagedRegistryWarnings(inspection)
+  const staleLatestWarning = getStaleLatestWarning(inspection)
+  const updateAvailable = inspection.latestVersion
+    ? isVersionNewer(inspection.latestVersion, inspection.currentVersion)
+    : false
 
-  if (inspection.latestVersion && inspection.latestVersion === inspection.currentVersion) {
+  if (!updateAvailable) {
     return emitCommandResult(
       createSuccessResult<UpgradeCommandData>({
         action: 'upgrade',
@@ -39,7 +44,7 @@ export async function upgradeCommand(
           kind: 'self',
           name: 'quantex',
         },
-        warnings: registryWarnings,
+        warnings: [...registryWarnings, ...(staleLatestWarning ? [staleLatestWarning] : [])],
       }),
       renderUpgradeHuman,
     )
@@ -65,6 +70,7 @@ export async function upgradeCommand(
           },
           warnings: [
             ...registryWarnings,
+            ...(staleLatestWarning ? [staleLatestWarning] : []),
             ...(dryRun
               ? [
                   {
@@ -97,7 +103,7 @@ export async function upgradeCommand(
           kind: 'self',
           name: 'quantex',
         },
-        warnings: registryWarnings,
+        warnings: [...registryWarnings, ...(staleLatestWarning ? [staleLatestWarning] : [])],
       }),
       renderUpgradeHuman,
     )
@@ -125,7 +131,7 @@ export async function upgradeCommand(
           kind: 'self',
           name: 'quantex',
         },
-        warnings: registryWarnings,
+        warnings: [...registryWarnings, ...(staleLatestWarning ? [staleLatestWarning] : [])],
       }),
       renderUpgradeHuman,
     )
@@ -148,7 +154,7 @@ export async function upgradeCommand(
           kind: 'self',
           name: 'quantex',
         },
-        warnings: registryWarnings,
+        warnings: [...registryWarnings, ...(staleLatestWarning ? [staleLatestWarning] : [])],
       }),
       renderUpgradeHuman,
     )
@@ -274,5 +280,21 @@ function renderInformationalWarnings(warnings: CommandWarning[]): void {
   for (const warning of warnings) {
     if (warning.code === 'DRY_RUN' || warning.code === 'MANUAL_RECOVERY') continue
     printWarn(pc.yellow(warning.message))
+  }
+}
+
+function getStaleLatestWarning(inspection: Awaited<ReturnType<typeof inspectSelf>>): CommandWarning | undefined {
+  if (!inspection.latestVersion) return undefined
+
+  const comparison = compareVersions(inspection.latestVersion, inspection.currentVersion)
+  if (comparison === undefined || comparison >= 0) return undefined
+
+  return {
+    code: 'STALE_LATEST_VERSION',
+    details: {
+      currentVersion: inspection.currentVersion,
+      latestVersion: inspection.latestVersion,
+    },
+    message: `The resolved latest version ${inspection.latestVersion} is older than the installed Quantex CLI ${inspection.currentVersion}. Quantex will not downgrade; retry with --refresh or --no-cache if you need a fresh check.`,
   }
 }

--- a/src/self/update-notice.ts
+++ b/src/self/update-notice.ts
@@ -2,6 +2,7 @@ import { getCliContext } from '../cli-context'
 import { getSelfState, setSelfUpdateNoticeState } from '../state'
 import { pc } from '../utils/color'
 import { printInfo } from '../utils/user-output'
+import { isVersionNewer } from '../utils/version'
 import { inspectSelf } from './index'
 
 const UPDATE_NOTICE_THROTTLE_MS = 24 * 60 * 60 * 1000
@@ -14,7 +15,7 @@ export async function maybeRenderSelfUpdateNotice(options: { action: string; ok:
   if (context.outputMode !== 'human' || context.quiet) return
 
   const inspection = await inspectSelf()
-  if (!inspection.latestVersion || inspection.latestVersion === inspection.currentVersion) return
+  if (!inspection.latestVersion || !isVersionNewer(inspection.latestVersion, inspection.currentVersion)) return
 
   const selfState = await getSelfState()
   const now = Date.now()

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -16,6 +16,24 @@ function parseInstalledVersionOutput(text: string, parser?: AgentVersionProbe['p
   return match ? match[1] : firstLine || undefined
 }
 
+export function compareVersions(left: string, right: string): number | undefined {
+  const leftVersion = parseVersion(left)
+  const rightVersion = parseVersion(right)
+
+  if (!leftVersion || !rightVersion) return undefined
+
+  for (let index = 0; index < 3; index += 1) {
+    const difference = leftVersion.core[index]! - rightVersion.core[index]!
+    if (difference !== 0) return difference > 0 ? 1 : -1
+  }
+
+  return comparePrerelease(leftVersion.prerelease, rightVersion.prerelease)
+}
+
+export function isVersionNewer(candidate: string, current: string): boolean {
+  return compareVersions(candidate, current) === 1
+}
+
 export async function getInstalledVersion(
   binaryName: string,
   versionProbe?: AgentVersionProbe,
@@ -69,4 +87,47 @@ export async function getResolvedBinaryPath(binaryPath?: string): Promise<string
   } catch {
     return binaryPath
   }
+}
+
+interface ParsedVersion {
+  core: [number, number, number]
+  prerelease: string[]
+}
+
+function parseVersion(value: string): ParsedVersion | undefined {
+  const match = value.trim().match(/^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9a-z.-]+))?$/i)
+  if (!match) return undefined
+
+  return {
+    core: [Number(match[1]), Number(match[2]), Number(match[3])],
+    prerelease: match[4] ? match[4].split('.') : [],
+  }
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (left.length === 0 && right.length === 0) return 0
+  if (left.length === 0) return 1
+  if (right.length === 0) return -1
+
+  const maxLength = Math.max(left.length, right.length)
+
+  for (let index = 0; index < maxLength; index += 1) {
+    const leftPart = left[index]
+    const rightPart = right[index]
+
+    if (leftPart === undefined) return -1
+    if (rightPart === undefined) return 1
+    if (leftPart === rightPart) continue
+
+    const leftNumeric = /^\d+$/.test(leftPart)
+    const rightNumeric = /^\d+$/.test(rightPart)
+
+    if (leftNumeric && rightNumeric) return Number(leftPart) > Number(rightPart) ? 1 : -1
+    if (leftNumeric) return -1
+    if (rightNumeric) return 1
+
+    return leftPart > rightPart ? 1 : -1
+  }
+
+  return 0
 }

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as agents from '../../src/agents'
-import { setCliContext } from '../../src/cli-context'
+import { resetCliContext, setCliContext } from '../../src/cli-context'
 import { doctorCommand } from '../../src/commands/doctor'
 import * as selfModule from '../../src/self'
 import * as state from '../../src/state'
@@ -60,6 +60,7 @@ describe('doctorCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    resetCliContext()
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     allAgentsSpy.mockClear()
     isBunSpy.mockClear()
@@ -87,6 +88,7 @@ describe('doctorCommand', () => {
   })
 
   afterEach(() => {
+    resetCliContext()
     logSpy.mockRestore()
   })
 
@@ -125,6 +127,31 @@ describe('doctorCommand', () => {
     const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
     expect(output).toContain('Recovery:')
     expect(output).toContain('bun add -g quantex-cli@latest')
+  })
+
+  it('does not flag self as outdated when latest version is lower than current', async () => {
+    isBunSpy.mockResolvedValue(true)
+    isNpmSpy.mockResolvedValue(true)
+    allAgentsSpy.mockReturnValue([])
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '0.15.0',
+      executablePath: '/Users/test/.bun/bin/qtx',
+      installSource: 'bun',
+      latestVersion: '0.14.0',
+      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    const result = await doctorCommand()
+
+    expect(result.data?.self.outdated).toBe(false)
+    expect(result.data?.issues.find(issue => issue.code === 'SELF_UPDATE_AVAILABLE')).toBeUndefined()
+
+    const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
+    expect(output).toContain('Latest:       0.14.0')
+    expect(output).not.toContain('update available')
   })
 
   it('shows manual recovery for outdated binary installs', async () => {

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { setCliContext } from '../../src/cli-context'
+import { resetCliContext, setCliContext } from '../../src/cli-context'
 import { upgradeCommand } from '../../src/commands/upgrade'
 import * as selfModule from '../../src/self'
 
@@ -16,6 +16,7 @@ describe('upgradeCommand', () => {
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    resetCliContext()
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
     inspectSelfSpy.mockClear()
@@ -23,6 +24,7 @@ describe('upgradeCommand', () => {
   })
 
   afterEach(() => {
+    resetCliContext()
     logSpy.mockRestore()
     stdoutWriteSpy.mockRestore()
   })
@@ -44,6 +46,33 @@ describe('upgradeCommand', () => {
 
     expect(upgradeSelfSpy).not.toHaveBeenCalled()
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('already up to date'))
+  })
+
+  it('treats a lower latest version as stale instead of attempting a downgrade', async () => {
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '0.15.0',
+      executablePath: '/tmp/quantex',
+      installSource: 'npm',
+      latestVersion: '0.14.0',
+      managedRegistry: 'https://registry.npmjs.org',
+      packageRoot: '/tmp/quantex',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    const result = await upgradeCommand()
+
+    expect(result.ok).toBe(true)
+    expect(result.data?.status).toBe('up-to-date')
+    expect(result.warnings).toContainEqual(
+      expect.objectContaining({
+        code: 'STALE_LATEST_VERSION',
+      }),
+    )
+    expect(upgradeSelfSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('already up to date'))
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('will not downgrade'))
   })
 
   it('warns when upstream npm is newer than the selected registry', async () => {
@@ -270,6 +299,26 @@ describe('upgradeCommand', () => {
     expect(upgradeSelfSpy).not.toHaveBeenCalled()
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Update available'))
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('(beta)'))
+  })
+
+  it('treats a lower latest version as up to date in --check mode', async () => {
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '0.15.0',
+      executablePath: '/tmp/quantex',
+      installSource: 'npm',
+      latestVersion: '0.14.0',
+      packageRoot: '/tmp/quantex',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    const result = await upgradeCommand({ check: true })
+
+    expect(result.ok).toBe(true)
+    expect(result.exitCode).toBeUndefined()
+    expect(result.data?.status).toBe('up-to-date')
+    expect(upgradeSelfSpy).not.toHaveBeenCalled()
   })
 
   it('emits a structured envelope in json mode', async () => {

--- a/test/self-update-notice.test.ts
+++ b/test/self-update-notice.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setCliContext } from '../src/cli-context'
+import * as selfModule from '../src/self'
+import { maybeRenderSelfUpdateNotice } from '../src/self/update-notice'
+import * as state from '../src/state'
+
+const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelf')
+const getSelfStateSpy = vi.spyOn(state, 'getSelfState')
+const setSelfUpdateNoticeStateSpy = vi.spyOn(state, 'setSelfUpdateNoticeState')
+
+describe('maybeRenderSelfUpdateNotice', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    inspectSelfSpy.mockClear()
+    getSelfStateSpy.mockClear()
+    setSelfUpdateNoticeStateSpy.mockClear()
+    getSelfStateSpy.mockResolvedValue({})
+    setCliContext({
+      interactive: true,
+      outputMode: 'human',
+      runId: 'notice-run-id',
+    })
+  })
+
+  afterEach(() => {
+    logSpy.mockRestore()
+  })
+
+  it('suppresses passive notices when latest version is lower than current', async () => {
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '0.15.0',
+      executablePath: '/Users/test/.bun/bin/qtx',
+      installSource: 'bun',
+      latestVersion: '0.14.0',
+      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    await maybeRenderSelfUpdateNotice({ action: 'list', ok: true })
+
+    expect(logSpy).not.toHaveBeenCalled()
+    expect(setSelfUpdateNoticeStateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/test/utils/version.test.ts
+++ b/test/utils/version.test.ts
@@ -145,6 +145,36 @@ describe('getInstalledVersion', () => {
   })
 })
 
+describe('compareVersions', () => {
+  it('orders newer patch versions higher', async () => {
+    const { compareVersions, isVersionNewer } = await import('../../src/utils/version')
+
+    expect(compareVersions('1.0.1', '1.0.0')).toBe(1)
+    expect(compareVersions('1.0.0', '1.0.1')).toBe(-1)
+    expect(isVersionNewer('1.0.1', '1.0.0')).toBe(true)
+  })
+
+  it('treats equal versions as equal', async () => {
+    const { compareVersions, isVersionNewer } = await import('../../src/utils/version')
+
+    expect(compareVersions('1.0.0', '1.0.0')).toBe(0)
+    expect(isVersionNewer('1.0.0', '1.0.0')).toBe(false)
+  })
+
+  it('orders release versions above prereleases', async () => {
+    const { compareVersions } = await import('../../src/utils/version')
+
+    expect(compareVersions('1.0.0', '1.0.0-beta.1')).toBe(1)
+    expect(compareVersions('1.0.0-beta.2', '1.0.0-beta.1')).toBe(1)
+  })
+
+  it('returns undefined for unparsable versions', async () => {
+    const { compareVersions } = await import('../../src/utils/version')
+
+    expect(compareVersions('main', '1.0.0')).toBeUndefined()
+  })
+})
+
 describe('getLatestVersion', () => {
   it('returns version from npm registry on success', async () => {
     const { getLatestVersion } = await import('../../src/utils/version')


### PR DESCRIPTION
## Summary

Prevent Quantex self-upgrade surfaces from treating stale or lower `latestVersion` data as an available update. `quantex upgrade`, `quantex doctor`, and passive self-update notices now use semantic version comparison and suppress downgrade paths caused by stale cache or lagging registry data.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `fix-self-upgrade-stale-latest`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Adds regression coverage for stale latest-version data across `upgrade`, `doctor`, passive self-update notices, and the new semantic version comparison helper.
