### PR TITLE
ci: block squash coauthor trailer risk before merge

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -35,6 +35,25 @@ jobs:
 
             core.setOutput('changed_files', JSON.stringify(files.map(file => file.filename)))
 
+      - name: List pull request commits
+        id: commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            })
+
+            core.setOutput('commits_json', JSON.stringify(commits.map(commit => ({
+              authorEmail: commit.commit.author?.email || '',
+              authorName: commit.commit.author?.name || '',
+              message: commit.commit.message,
+              sha: commit.sha,
+            }))))
+
       - name: Classify pull request scope
         id: classify
         env:
@@ -48,3 +67,8 @@ jobs:
           PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: bun run pr:body:check
+
+      - name: Validate PR merge commit policy
+        env:
+          PR_COMMITS_JSON: ${{ steps.commits.outputs.commits_json }}
+        run: bun run scripts/pr-merge-commit-policy.ts

--- a/openspec/changes/prevent-squash-coauthor-trailers/.openspec.yaml
+++ b/openspec/changes/prevent-squash-coauthor-trailers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-06

--- a/openspec/changes/prevent-squash-coauthor-trailers/design.md
+++ b/openspec/changes/prevent-squash-coauthor-trailers/design.md
@@ -1,0 +1,42 @@
+## Context
+
+GitHub creates the final squash merge commit after all pull request checks have passed. If GitHub adds `Co-authored-by:` trailers to that generated commit, the existing push-time commit trailer policy detects the violation only after the pull request has already merged.
+
+The repository needs a pre-merge gate that treats unsafe squash-merge inputs as a PR governance failure.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Fail pull requests before merge when their commits are likely to produce a squash commit with co-author trailers.
+- Keep the protected-branch push trailer policy as a backstop.
+- Provide actionable remediation: pre-squash and re-author the PR commits before merge.
+
+**Non-Goals:**
+
+- Rewriting existing `main` history.
+- Adding a repo-local PR merge wrapper command.
+- Replacing GitHub branch protection or rulesets.
+
+## Decisions
+
+- Add a dedicated `scripts/pr-merge-commit-policy.ts` validator, separate from PR body policy and commit trailer policy.
+- Run it from `PR Governance` using pull request commit metadata from the GitHub API.
+- Reject PRs with multiple commits because GitHub squash merge can synthesize co-author trailers from multi-commit contributor metadata.
+- Reject known agent/bot commit authors whose metadata has already produced generated co-author trailers in squash merge commits.
+
+## Risks / Trade-offs
+
+- [Stricter PR hygiene] Multi-commit implementation PRs must be squashed before merge. Mitigation: the failure explains the exact remediation.
+- [Known-author list may need updates] New agent commit identities can appear later. Mitigation: keep push-time trailer validation as a backstop and extend the PR validator when a new identity is observed.
+
+## Migration Plan
+
+- Add the PR merge commit policy validator and tests.
+- Wire the validator into `PR Governance`.
+- Update release governance spec requirements.
+- Validate with lint, format, typecheck, tests, OpenSpec validation, and memory checks.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/prevent-squash-coauthor-trailers/proposal.md
+++ b/openspec/changes/prevent-squash-coauthor-trailers/proposal.md
@@ -1,0 +1,19 @@
+## Why
+
+`Co-authored-by:` trailer governance currently runs on pull request commits and protected-branch push commits. That catches direct trailers before merge, but it does not catch trailers that GitHub synthesizes into the final squash merge commit. PR #179 demonstrated the gap: PR checks passed, auto-merge completed, and the subsequent `main` push CI failed because the generated squash commit contained prohibited co-author trailers.
+
+## What Changes
+
+- Add PR Governance validation that rejects pull requests whose commit shape is unsafe for GitHub squash merge under the no-`Co-authored-by` policy.
+- Require regular pull requests to be pre-squashed into one commit and reject known agent/bot commit authors that GitHub can re-emit as co-author trailers in the squash commit body.
+- Keep protected-branch push validation as a backstop instead of the first place this failure appears.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `release-governance`: PR governance MUST fail before merge when a pull request is likely to produce a squash merge commit containing prohibited `Co-authored-by:` trailers.
+
+## Impact
+
+- Affected files: `.github/workflows/pr-governance.yml`, `scripts/`, `test/`, `openspec/specs/release-governance/spec.md`.

--- a/openspec/changes/prevent-squash-coauthor-trailers/specs/release-governance/spec.md
+++ b/openspec/changes/prevent-squash-coauthor-trailers/specs/release-governance/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Protected-branch CI MUST reject prohibited co-author trailers in new commits
+
+Repository CI SHALL reject newly introduced commits on pull requests and protected-branch pushes when their commit messages contain `Co-authored-by:` trailers. PR Governance SHALL also reject pull requests before merge when their commit metadata is likely to make GitHub synthesize prohibited co-author trailers into the final squash merge commit.
+
+#### Scenario: Pull request introduces co-author trailer
+
+- **WHEN** CI evaluates the commits introduced by a pull request targeting a protected branch
+- **AND** any of those commit messages contains a `Co-authored-by:` trailer
+- **THEN** CI fails before merge
+- **AND** it reports the offending commit SHA and trailer line
+
+#### Scenario: Pull request would generate co-author trailer on squash merge
+
+- **WHEN** PR Governance evaluates a pull request targeting a protected branch
+- **AND** its commit shape is unsafe for GitHub squash merge under the no-co-author-trailer policy
+- **THEN** PR Governance fails before merge
+- **AND** it explains how to pre-squash or re-author the pull request commits before retrying
+
+#### Scenario: Protected-branch push introduces co-author trailer
+
+- **WHEN** CI evaluates the commits introduced by a direct push to a protected branch
+- **AND** any of those commit messages contains a `Co-authored-by:` trailer
+- **THEN** CI fails before downstream release automation treats the push as releasable history
+- **AND** it reports the offending commit SHA and trailer line

--- a/openspec/changes/prevent-squash-coauthor-trailers/tasks.md
+++ b/openspec/changes/prevent-squash-coauthor-trailers/tasks.md
@@ -1,0 +1,5 @@
+- [x] Add PR merge commit policy validator for squash co-author trailer risk.
+- [x] Wire the validator into PR Governance before merge.
+- [x] Add regression tests for unsafe multi-commit and agent-authored PRs.
+- [x] Update release governance spec.
+- [x] Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, `bun run openspec:validate`, and `bun run memory:check`.

--- a/openspec/specs/release-governance/spec.md
+++ b/openspec/specs/release-governance/spec.md
@@ -75,7 +75,7 @@ Release-please generated Release PRs SHALL remain governed by the dedicated Rele
 
 ### Requirement: Protected-branch CI MUST reject prohibited co-author trailers in new commits
 
-Repository CI SHALL reject newly introduced commits on pull requests and protected-branch pushes when their commit messages contain `Co-authored-by:` trailers.
+Repository CI SHALL reject newly introduced commits on pull requests and protected-branch pushes when their commit messages contain `Co-authored-by:` trailers. PR Governance SHALL also reject pull requests before merge when their commit metadata is likely to make GitHub synthesize prohibited co-author trailers into the final squash merge commit.
 
 #### Scenario: Pull request introduces co-author trailer
 
@@ -83,6 +83,13 @@ Repository CI SHALL reject newly introduced commits on pull requests and protect
 - **AND** any of those commit messages contains a `Co-authored-by:` trailer
 - **THEN** CI fails before merge
 - **AND** it reports the offending commit SHA and trailer line
+
+#### Scenario: Pull request would generate co-author trailer on squash merge
+
+- **WHEN** PR Governance evaluates a pull request targeting a protected branch
+- **AND** its commit shape is unsafe for GitHub squash merge under the no-co-author-trailer policy
+- **THEN** PR Governance fails before merge
+- **AND** it explains how to pre-squash or re-author the pull request commits before retrying
 
 #### Scenario: Protected-branch push introduces co-author trailer
 

--- a/scripts/pr-merge-commit-policy.ts
+++ b/scripts/pr-merge-commit-policy.ts
@@ -1,0 +1,119 @@
+import process from 'node:process'
+
+export interface PullRequestCommitMetadata {
+  authorEmail?: string
+  authorName?: string
+  message: string
+  sha: string
+}
+
+export interface PullRequestMergeCommitPolicyInput {
+  commits: PullRequestCommitMetadata[]
+}
+
+const prohibitedTrailerPattern = /^co-authored-by:\s*/i
+const riskyAuthorPatterns = [/cursoragent@cursor\.com/i, /^cursor agent$/i, /\[bot\]@users\.noreply\.github\.com$/i]
+
+export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeCommitPolicyInput): string[] {
+  const commits = input.commits
+  const issues: string[] = []
+
+  for (const commit of commits) {
+    const offendingLines = commit.message
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => prohibitedTrailerPattern.test(line))
+
+    for (const line of offendingLines) {
+      issues.push(`Commit ${formatSha(commit.sha)} contains prohibited trailer: ${line}`)
+    }
+  }
+
+  if (commits.length > 1) {
+    issues.push(
+      [
+        `Pull request contains ${commits.length} commits; GitHub squash merge can synthesize Co-authored-by trailers from multi-commit contributor metadata.`,
+        'Squash the branch to one clean commit before merge.',
+      ].join('\n'),
+    )
+  }
+
+  for (const commit of commits) {
+    const authorValues = [commit.authorEmail, commit.authorName].filter(Boolean) as string[]
+    if (!authorValues.some(value => riskyAuthorPatterns.some(pattern => pattern.test(value)))) continue
+
+    issues.push(
+      [
+        `Commit ${formatSha(commit.sha)} uses author metadata that can be re-emitted as a Co-authored-by trailer by GitHub squash merge.`,
+        `Author: ${formatAuthor(commit)}`,
+        'Re-author the commit to an allowed maintainer identity before merge.',
+      ].join('\n'),
+    )
+  }
+
+  return issues
+}
+
+if (import.meta.main) {
+  const commits = parseCommits(process.argv.slice(2), process.env.PR_COMMITS_JSON)
+  const issues = validatePullRequestMergeCommitPolicy({ commits })
+
+  if (issues.length > 0) {
+    console.error('PR merge commit policy check failed:\n')
+    for (const issue of issues) console.error(`- ${issue}`)
+    process.exit(1)
+  }
+
+  console.log('PR merge commit policy check passed.')
+}
+
+function parseCommits(args: string[], commitsJsonEnv: string | undefined): PullRequestCommitMetadata[] {
+  let rawValue = commitsJsonEnv
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    const nextValue = args[index + 1]
+
+    if (arg === '--commits-json' && nextValue) {
+      rawValue = nextValue
+      index += 1
+      continue
+    }
+
+    throw new Error(`Unknown or incomplete argument: ${arg}`)
+  }
+
+  if (!rawValue) return []
+
+  const parsedValue = JSON.parse(rawValue)
+  if (!Array.isArray(parsedValue)) {
+    throw new Error('Pull request commits must be a JSON array.')
+  }
+
+  return parsedValue.map((value, index) => {
+    if (
+      typeof value !== 'object' ||
+      value === null ||
+      typeof value.sha !== 'string' ||
+      typeof value.message !== 'string'
+    ) {
+      throw new Error(`Commit at index ${index} must include string sha and message fields.`)
+    }
+
+    return {
+      authorEmail: typeof value.authorEmail === 'string' ? value.authorEmail : undefined,
+      authorName: typeof value.authorName === 'string' ? value.authorName : undefined,
+      message: value.message,
+      sha: value.sha,
+    }
+  })
+}
+
+function formatSha(sha: string): string {
+  return (sha || '<unknown>').slice(0, 12)
+}
+
+function formatAuthor(commit: PullRequestCommitMetadata): string {
+  if (commit.authorName && commit.authorEmail) return `${commit.authorName} <${commit.authorEmail}>`
+  return commit.authorEmail ?? commit.authorName ?? '<unknown>'
+}

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -5,6 +5,7 @@ const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8')
 const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml', 'utf8')
 const prTemplate = readFileSync('.github/pull_request_template.md', 'utf8')
 const prBodyPolicyScript = readFileSync('scripts/pr-body-policy.ts', 'utf8')
+const prMergeCommitPolicyScript = readFileSync('scripts/pr-merge-commit-policy.ts', 'utf8')
 
 describe('pr governance release intent', () => {
   it('requires a release intent section in PR bodies', () => {
@@ -46,5 +47,12 @@ describe('pr governance release intent', () => {
     expect(ciWorkflow).toContain('Validate commit trailer policy')
     expect(ciWorkflow).toContain('bun run scripts/commit-trailer-policy.ts')
     expect(ciWorkflow).toContain('List commits for trailer policy')
+  })
+
+  it('runs PR merge commit governance before merge', () => {
+    expect(prGovernanceWorkflow).toContain('Validate PR merge commit policy')
+    expect(prGovernanceWorkflow).toContain('bun run scripts/pr-merge-commit-policy.ts')
+    expect(prGovernanceWorkflow).toContain('PR_COMMITS_JSON')
+    expect(prMergeCommitPolicyScript).toContain('GitHub squash merge')
   })
 })

--- a/test/pr-merge-commit-policy.test.ts
+++ b/test/pr-merge-commit-policy.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { validatePullRequestMergeCommitPolicy } from '../scripts/pr-merge-commit-policy'
+
+describe('pr merge commit policy', () => {
+  it('accepts one clean maintainer-authored commit', () => {
+    expect(
+      validatePullRequestMergeCommitPolicy({
+        commits: [
+          {
+            authorEmail: '540628938@qq.com',
+            authorName: 'drswith',
+            message: 'ci: tighten PR governance',
+            sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+          },
+        ],
+      }),
+    ).toEqual([])
+  })
+
+  it('rejects multiple commits because GitHub squash can synthesize co-author trailers', () => {
+    const issues = validatePullRequestMergeCommitPolicy({
+      commits: [
+        {
+          authorEmail: 'cursoragent@cursor.com',
+          authorName: 'Cursor Agent',
+          message: 'fix(ci): load release PR policy from trusted base ref',
+          sha: 'a1bf9b84bb9d44cd7dfc3eb8c04d717d94a2403a',
+        },
+        {
+          authorEmail: '540628938@qq.com',
+          authorName: 'drswith',
+          message: 'Merge remote-tracking branch origin/main',
+          sha: 'faccfe099ca1de911087caf6904263ae22283e22',
+        },
+      ],
+    })
+
+    expect(issues).toContainEqual(expect.stringContaining('Pull request contains 2 commits'))
+    expect(issues).toContainEqual(expect.stringContaining('a1bf9b84bb9d'))
+  })
+
+  it('rejects known agent commit authors even for single-commit PRs', () => {
+    const issues = validatePullRequestMergeCommitPolicy({
+      commits: [
+        {
+          authorEmail: 'cursoragent@cursor.com',
+          authorName: 'Cursor Agent',
+          message: 'fix(self-upgrade): avoid false managed verify when latestVersion unresolved',
+          sha: 'bdc8bde0a7e5d5fc689dd6144ecafed336f165b6',
+        },
+      ],
+    })
+
+    expect(issues).toContainEqual(expect.stringContaining('bdc8bde0a7e5'))
+    expect(issues).toContainEqual(expect.stringContaining('Re-author the commit'))
+  })
+
+  it('rejects direct co-author trailers in PR commit messages', () => {
+    const issues = validatePullRequestMergeCommitPolicy({
+      commits: [
+        {
+          authorEmail: '540628938@qq.com',
+          authorName: 'drswith',
+          message: ['ci: example', '', 'Co-authored-by: Cursor Agent <cursoragent@cursor.com>'].join('\n'),
+          sha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        },
+      ],
+    })
+
+    expect(issues).toContainEqual(expect.stringContaining('Co-authored-by:'))
+  })
+})


### PR DESCRIPTION
## Summary

Fixes the governance gap that let PR #179 merge cleanly and only fail after `main` received the generated squash commit.

The existing trailer policy checked pull request commits before merge and protected-branch push commits after merge. GitHub can synthesize `Co-authored-by:` trailers into the final squash merge commit after PR checks have passed, so this adds a PR Governance pre-merge check for unsafe squash inputs:

- PRs with multiple commits are rejected because GitHub squash merge can synthesize co-author trailers from contributor metadata.
- PRs authored by known agent/bot identities that have produced generated co-author trailers are rejected until re-authored.
- Direct `Co-authored-by:` trailers in PR commit messages remain rejected.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/prevent-squash-coauthor-trailers`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - CI/governance hardening only

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This does not rewrite the existing `main` commit. It prevents the same merge-after-green-PR failure mode by moving the squash co-author trailer risk check into PR Governance before auto-merge can complete.
