### PR TITLE
fix: handle Windows Bun lifecycle trust parsing

### DIFF
--- a/openspec/changes/fix-windows-bun-trust/.openspec.yaml
+++ b/openspec/changes/fix-windows-bun-trust/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/fix-windows-bun-trust/design.md
+++ b/openspec/changes/fix-windows-bun-trust/design.md
@@ -1,0 +1,31 @@
+## Context
+
+Quantex runs Bun global install and update commands for Bun-managed agents, then checks `bun pm -g untrusted` so it can trust requested packages whose lifecycle scripts were blocked. This matters for packages such as Claude Code, where the Windows package ships a small placeholder binary and relies on `postinstall` to place the real native executable.
+
+The current parser recognizes only `./node_modules/<package> @<version>` output. Bun on Windows emits the same package list with backslashes, such as `.\node_modules\@anthropic-ai\claude-code @2.1.132`, so the package is not trusted even though Quantex reports the update as successful.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Parse Bun untrusted package output with POSIX or Windows path separators.
+- Keep trust scoped to packages explicitly requested by the install or update operation.
+- Preserve current behavior for non-matching lines and failed Bun commands.
+- Cover the parser with regression tests for scoped package names and Windows-style paths.
+
+**Non-Goals:**
+
+- Change Quantex into a general Bun repair tool.
+- Trust every blocked transitive lifecycle script by default.
+- Change structured output schemas or command catalog entries.
+
+## Decisions
+
+- Normalize path separators before matching package names. This keeps the parser small and avoids duplicating regexes for each platform.
+- Continue filtering parsed untrusted packages against the requested package names. This preserves the current least-surprise behavior and avoids trusting unrelated blocked scripts from global dependencies.
+- Export only the small parser helper for tests. The install/update execution flow remains unchanged, while the platform-sensitive behavior becomes directly testable without invoking global Bun.
+
+## Risks / Trade-offs
+
+- Windows path output could contain future Bun formatting changes -> keep parsing conservative around `node_modules/<package> @` and ignore unknown lines.
+- A requested package might depend on a transitive package whose blocked script is also required -> this change keeps existing trust scope unchanged; broader trust policy would need a separate OpenSpec decision.

--- a/openspec/changes/fix-windows-bun-trust/proposal.md
+++ b/openspec/changes/fix-windows-bun-trust/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Implementation requested work-intake classification: this change modifies observable agent update behavior for Bun-managed installs on Windows, so it requires OpenSpec before file edits.
+
+When Bun blocks a global package lifecycle script on Windows, `bun pm -g untrusted` prints package paths with backslashes. Quantex only recognizes POSIX-style paths today, so `qtx update --all` can report a Bun-managed agent as updated while leaving its required postinstall blocked and its binary unusable.
+
+## What Changes
+
+- Teach Bun-managed install and update flows to recognize blocked lifecycle package paths emitted with either POSIX or Windows separators.
+- Ensure requested Bun-managed packages whose lifecycle scripts were blocked are trusted after a successful global install or update.
+- Add regression coverage for Windows-style `bun pm -g untrusted` output.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: Managed Bun update behavior must complete required blocked lifecycle trust for requested packages regardless of platform path separator style.
+
+## Impact
+
+- Affected code: `src/package-manager/bun.ts` and related tests.
+- Affected specs: `openspec/specs/agent-update/spec.md` through a change delta.
+- No structured output, schema version, command catalog, or dependency changes are intended.

--- a/openspec/changes/fix-windows-bun-trust/specs/agent-update/spec.md
+++ b/openspec/changes/fix-windows-bun-trust/specs/agent-update/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Bun-managed updates MUST trust requested blocked lifecycle scripts across platform path styles
+
+The agent update system SHALL recognize Bun global untrusted package output for requested managed packages regardless of whether Bun prints `node_modules` paths with POSIX or Windows separators.
+
+#### Scenario: Trusting a requested scoped package from Windows Bun output
+
+- **GIVEN** a Bun-managed agent package was requested by `quantex install`, `quantex update <agent>`, or `quantex update --all`
+- **AND** `bun pm -g untrusted` reports that package using a Windows-style path such as `.\node_modules\@scope\name @1.2.3`
+- **WHEN** the Bun install or update command exits successfully
+- **THEN** Quantex trusts the requested package lifecycle script
+- **AND** the agent update does not leave the requested package's required postinstall blocked because of path separator parsing
+
+#### Scenario: Ignoring unrelated blocked packages
+
+- **GIVEN** a Bun-managed install or update requested one or more package names
+- **AND** `bun pm -g untrusted` reports additional packages that were not requested
+- **WHEN** Quantex evaluates blocked lifecycle packages
+- **THEN** Quantex only trusts blocked packages whose names match the requested package list

--- a/openspec/changes/fix-windows-bun-trust/tasks.md
+++ b/openspec/changes/fix-windows-bun-trust/tasks.md
@@ -1,0 +1,17 @@
+## 1. OpenSpec
+
+- [x] 1.1 Create proposal, design, and agent-update spec delta for Windows Bun lifecycle trust behavior.
+
+## 2. Implementation
+
+- [x] 2.1 Update Bun untrusted package parsing to recognize POSIX and Windows path separators.
+- [x] 2.2 Keep trust execution scoped to explicitly requested Bun package names.
+
+## 3. Validation
+
+- [x] 3.1 Add regression tests for Windows-style scoped package paths and unrelated blocked packages.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.
+
+## 4. Delivery
+
+- [x] 4.1 Review git state, commit the change, push the branch, and open a PR with a validated body file.

--- a/src/package-manager/bun.ts
+++ b/src/package-manager/bun.ts
@@ -103,11 +103,12 @@ async function readGlobalUntrustedPackages(): Promise<string | undefined> {
   }
 }
 
-function parseUntrustedPackages(output: string): Set<string> {
+export function parseUntrustedPackages(output: string): Set<string> {
   const packages = new Set<string>()
 
   for (const line of output.split('\n')) {
-    const match = line.match(/^\.\/node_modules\/(.+?) @/)
+    const normalizedLine = line.replaceAll('\\', '/')
+    const match = normalizedLine.match(/^\.\/node_modules\/(.+?) @/)
     if (match?.[1]) packages.add(match[1])
   }
 

--- a/test/package-manager/bun.test.ts
+++ b/test/package-manager/bun.test.ts
@@ -129,6 +129,47 @@ describe('bun updateMany', () => {
     expect(await updateMany(['some-package', 'other-package'])).toBe(true)
     expect(mockSpawn).toHaveBeenNthCalledWith(3, ['bun', 'pm', '-g', 'trust', 'some-package'], expect.any(Object))
   })
+
+  it('trusts requested scoped packages from Windows untrusted output', async () => {
+    const { updateMany } = await import('../../src/package-manager/bun')
+    mockSpawn
+      .mockReturnValueOnce(createProc(0))
+      .mockReturnValueOnce(
+        createProc(
+          0,
+          [
+            '.\\node_modules\\@anthropic-ai\\claude-code @2.1.132',
+            ' » [postinstall]: node install.cjs',
+            '.\\node_modules\\unrelated-package @1.0.0',
+            ' » [postinstall]: node scripts/postinstall.js',
+          ].join('\n'),
+        ),
+      )
+      .mockReturnValueOnce(createProc(0))
+
+    expect(await updateMany(['@anthropic-ai/claude-code', 'other-package'])).toBe(true)
+    expect(mockSpawn).toHaveBeenNthCalledWith(
+      3,
+      ['bun', 'pm', '-g', 'trust', '@anthropic-ai/claude-code'],
+      expect.any(Object),
+    )
+  })
+})
+
+describe('parseUntrustedPackages', () => {
+  it('parses scoped package names from POSIX and Windows node_modules paths', async () => {
+    const { parseUntrustedPackages } = await import('../../src/package-manager/bun')
+
+    expect(
+      parseUntrustedPackages(
+        [
+          './node_modules/some-package @1.0.0',
+          '.\\node_modules\\@anthropic-ai\\claude-code @2.1.132',
+          '.\\node_modules\\@scope\\nested-name @3.0.0',
+        ].join('\n'),
+      ),
+    ).toEqual(new Set(['some-package', '@anthropic-ai/claude-code', '@scope/nested-name']))
+  })
 })
 
 describe('bun uninstall', () => {


### PR DESCRIPTION
## Summary

Fix Bun-managed lifecycle trust on Windows so `qtx update --all` can recover requested packages whose postinstall was blocked, including Claude Code.

The bug was that Quantex only parsed `bun pm -g untrusted` entries like `./node_modules/<pkg> @...`; Bun on Windows prints `.\node_modules\<pkg> @...`, so Quantex skipped `bun pm -g trust` while still reporting the update as successful.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/fix-windows-bun-trust`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [ ] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [x] Not run, explained below

`bun run format:check` was run and failed on this Windows worktree because many existing tracked files are checked out with CRLF while `.oxfmtrc.json` requires LF. The files changed in this PR passed a targeted check: `bunx oxfmt --check src\package-manager\bun.ts test\package-manager\bun.test.ts`.

Additional validation:

- [x] `bun run openspec:validate`
- [x] `bun run test -- test/package-manager/bun.test.ts`
- [x] `bunx oxfmt --check src\package-manager\bun.ts test\package-manager\bun.test.ts`

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The implementation keeps trust scoped to requested package names; it does not trust unrelated blocked transitive lifecycle scripts.
