### PR TITLE
chore: add editorconfig line-ending defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+max_line_length = 120

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.gz binary
+*.tgz binary
+*.exe binary
+*.dll binary
+*.node binary

--- a/openspec/changes/add-editorconfig-line-endings/.openspec.yaml
+++ b/openspec/changes/add-editorconfig-line-endings/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-07

--- a/openspec/changes/add-editorconfig-line-endings/design.md
+++ b/openspec/changes/add-editorconfig-line-endings/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The repository already configures `oxfmt` with `endOfLine: "lf"`, but that only applies after formatter execution and only to files inside oxfmt's supported surface. Windows contributors can still create CRLF churn through editor defaults or Git `core.autocrlf` behavior before validation runs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make LF the repository-wide default for text files at both editor and Git normalization layers.
+- Keep editor defaults aligned with the existing two-space, UTF-8, final-newline formatting contract.
+- Avoid adding a new formatter, linter, hook, or runtime dependency.
+
+**Non-Goals:**
+
+- Reformatting every tracked file as part of this change.
+- Expanding the oxfmt surface to Markdown or generated artifacts.
+- Changing CLI runtime behavior or release packaging.
+
+## Decisions
+
+### Use `.editorconfig` for editor defaults
+
+The repository will add a root `.editorconfig` with `root = true`, LF endings, UTF-8 charset, final newlines, trailing whitespace trimming, and two-space indentation. This catches the common Windows editor case before files reach `bun run format` or CI.
+
+Alternative considered:
+
+- Rely only on `.vscode/settings.json`. Rejected because contributors and agents may use other EditorConfig-aware editors.
+
+### Use `.gitattributes` for repository line-ending normalization
+
+The repository will add a root `.gitattributes` with text files normalized to LF. This is the Git-level guard that keeps checkout and commit behavior stable across platforms regardless of local `core.autocrlf` settings.
+
+Alternative considered:
+
+- Add only `.editorconfig`. Rejected because it does not control Git's line-ending conversion.
+
+## Risks / Trade-offs
+
+- [Git may report many files changed if contributors renormalize later] -> This change adds the policy first and avoids a broad reformat unless a future dedicated cleanup needs it.
+- [Markdown authors may intentionally use trailing spaces for hard breaks] -> The repository's default trims trailing whitespace; contributors can use explicit Markdown syntax instead of relying on invisible spaces.

--- a/openspec/changes/add-editorconfig-line-endings/proposal.md
+++ b/openspec/changes/add-editorconfig-line-endings/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Windows contributors and agents can accidentally introduce CRLF or editor-specific whitespace churn even though the formatter already normalizes managed code to LF. A root `.editorconfig` should make the repository's cross-platform editing defaults explicit before files reach formatter, lint, or CI.
+
+## What Changes
+
+- Add a root `.editorconfig` that declares UTF-8, final newlines, trailing whitespace trimming, and LF as the default line ending.
+- Add a root `.gitattributes` that normalizes tracked text files to LF so Windows `core.autocrlf` settings cannot reintroduce repository-wide CRLF churn.
+- Document the EditorConfig contract in the existing code quality tooling specification.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: Define repository-wide editor defaults and line-ending expectations.
+
+## Impact
+
+- Adds repository root editor configuration consumed by EditorConfig-aware editors.
+- Adds repository root Git attributes consumed by Git checkout and commit normalization.
+- Updates OpenSpec code quality tooling contract and change tasks.
+- No CLI runtime behavior, command schema, package dependency, or release artifact changes.

--- a/openspec/changes/add-editorconfig-line-endings/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/add-editorconfig-line-endings/specs/code-quality-tooling/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Repository editor and line-ending defaults
+
+The repository SHALL keep a root `.editorconfig` that declares LF line endings, UTF-8 charset, final newlines, trailing whitespace trimming, and two-space indentation as the default editing contract for repository text files. The repository SHALL keep a root `.gitattributes` that normalizes tracked text files to LF so platform-specific Git settings do not introduce CRLF churn.
+
+#### Scenario: Contributor edits on Windows
+
+- **WHEN** a contributor or coding agent edits repository text files on Windows with an EditorConfig-aware editor and Git checkout settings that would otherwise prefer CRLF
+- **THEN** the editor defaults prefer LF line endings before formatting runs
+- **AND** Git normalization preserves LF line endings for tracked text files
+
+#### Scenario: Contributor inspects formatting policy
+
+- **WHEN** a contributor or coding agent inspects repository formatting and line-ending configuration
+- **THEN** `.editorconfig`, `.gitattributes`, and `.oxfmtrc.json` all declare LF as the repository text line-ending policy

--- a/openspec/changes/add-editorconfig-line-endings/tasks.md
+++ b/openspec/changes/add-editorconfig-line-endings/tasks.md
@@ -1,0 +1,12 @@
+## 1. OpenSpec And Contract Updates
+
+- [x] 1.1 Add proposal, design, and code-quality-tooling spec delta for repository editor and line-ending defaults.
+
+## 2. Repository Configuration
+
+- [x] 2.1 Add root `.editorconfig` with cross-editor LF, UTF-8, final-newline, trailing-whitespace, and indentation defaults.
+- [x] 2.2 Add root `.gitattributes` with Git-level LF normalization for tracked text files.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run openspec:validate`.


### PR DESCRIPTION
## Summary

Add repository-wide editor and Git line-ending policy so Windows checkouts and EditorConfig-aware editors preserve LF text files consistently.

This pairs `.editorconfig` editor defaults with `.gitattributes` Git normalization, and records the durable contract through an OpenSpec change.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/add-editorconfig-line-endings`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [x] Not run, explained below

`bun run test` was not run because this change does not alter CLI behavior, structured output, runtime logic, or integration behavior.

## Release Intent

- Release: not applicable - repository editor/Git line-ending policy only

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge and queued for agent-driven archive closure.
- [x] Release is not applicable.

## Notes

The implementation intentionally avoids a broad committed renormalization diff. Existing tracked text files were already indexed as LF; the new attributes prevent Windows working-tree CRLF drift going forward.
