### PR TITLE
test(self-upgrade): add sandbox managed upgrade smoke

### DIFF
--- a/docs/runbooks/modal-sandbox-testing.md
+++ b/docs/runbooks/modal-sandbox-testing.md
@@ -40,6 +40,7 @@ Default scenarios:
 - `adopt-preinstalled`: the sandbox preinstalls the agent outside Quantex first, then verifies `quantex install <agent>` adopts and tracks that existing install.
 - `ambiguous-multi-method`: the sandbox places a fake multi-install-method agent binary in PATH and verifies Quantex does not guess an install source.
 - `self-binary`: the sandbox builds a Linux standalone Quantex binary, installs it into the isolated HOME, then verifies binary-entrypoint command discovery, agent inspection, and `upgrade --check` self-inspection.
+- `self-managed`: the sandbox builds local Quantex package tarballs, serves them from a sandbox-local registry, seeds an older Bun-managed Quantex install, and verifies `quantex upgrade` upgrades that install to the current checkout version.
 
 For each selected agent, the `managed` scenario executes the real Quantex CLI flow:
 
@@ -79,6 +80,7 @@ To limit scenarios, set `QTX_ISOLATION_SCENARIOS`:
 ```bash
 QTX_ISOLATION_SCENARIOS=managed,adopt-preinstalled bun run test:container
 QTX_ISOLATION_SCENARIOS=self-binary bun run test:container
+QTX_ISOLATION_SCENARIOS=self-managed bun run test:container
 QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:container
 ```
 
@@ -104,6 +106,7 @@ The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AG
    ```
 
 2. Run `bun run test:container` when the change is sensitive to HOME, PATH, global tools, or filesystem isolation and you want a local fallback that does not require Modal.
+   For self-upgrade regressions, start with `QTX_ISOLATION_SCENARIOS=self-managed bun run test:container`.
 3. Run `bun run test:sandbox` when you also want to validate the Modal transport or reproduce the dedicated GitHub Actions workflow.
 4. If an isolated run fails, compare whether the failure is code-related or environment-related by rerunning the same agent list locally.
 5. If Modal setup is missing, install or repair the local Modal CLI before treating the failure as a product regression.

--- a/docs/runbooks/release-and-self-upgrade-debugging.md
+++ b/docs/runbooks/release-and-self-upgrade-debugging.md
@@ -232,6 +232,14 @@ If Bun reports success but the installed `qtx --version` does not move:
 - prefer the self-upgrade path that re-declares the direct package target with `bun add -g quantex-cli@<tag>` instead of relying on global `bun update`
 - npm has a similar range-sensitive `update` behavior; use `npm install -g quantex-cli@<tag>` when the intent is to replace the direct global package target
 
+If you need an isolated reproduction of the Bun-managed self-upgrade path without depending on public registry timing:
+
+```bash
+QTX_ISOLATION_SCENARIOS=self-managed bun run test:container
+```
+
+This scenario builds local Quantex tarballs, seeds an older Bun-managed install from a sandbox-local registry, then verifies that `quantex upgrade --no-cache` reaches the current checkout version.
+
 ### 7. Reproduce the CI release verification path locally
 
 The closest local sequence to the release verification workflow is:

--- a/openspec/changes/add-self-upgrade-sandbox-tests/.openspec.yaml
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/add-self-upgrade-sandbox-tests/design.md
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The repository already has an optional isolation layer that runs real Quantex lifecycle flows inside Docker or Modal-backed Bun environments. That layer covers managed agent lifecycle, preinstalled adoption, ambiguous PATH detection, and standalone-binary self inspection. It does not cover the highest-risk self-upgrade path: Quantex installed through Bun and then upgrading itself through a managed package flow.
+
+The self-upgrade bugs reported so far were end-to-end failures. Unit tests helped after the fact, but the escaping behavior depended on the interaction between real package-manager installs, a real Quantex entrypoint, registry metadata resolution, and post-upgrade verification. The isolation layer is the right place to protect that chain.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a deterministic managed self-upgrade smoke scenario to the existing isolation layer.
+- Keep the scenario local to the sandbox process rather than depending on public npm release timing.
+- Reuse the current `scripts/lifecycle-smoke.ts` entrypoint so Docker and Modal continue to exercise the same scenario set.
+- Validate the specific Bun-managed flow that has produced the recent self-upgrade regressions.
+
+**Non-Goals:**
+
+- Re-architecting the self-upgrade implementation in this change.
+- Covering every managed self-upgrade provider in the first sandbox pass.
+- Turning the isolation layer into a general-purpose local registry framework.
+- Replacing unit and integration tests with sandbox-only validation.
+
+## Decisions
+
+- Add a new `self-managed` lifecycle smoke scenario inside the existing lifecycle smoke script.
+  Rationale: the current Docker and Modal harnesses already delegate to `scripts/lifecycle-smoke.ts`, so extending that script keeps both transports aligned without introducing a second remote entrypoint.
+
+- Use an ephemeral local npm-style registry served from inside the sandbox process.
+  Rationale: managed self-upgrade needs a deterministic upgrade target. A local registry avoids dependency on public npm freshness, mirror lag, or release timing while still exercising Quantex through its real managed self-upgrade path.
+
+- Generate two local Quantex package tarballs for the scenario: a seeded older version and the current checkout version.
+  Rationale: the scenario must start from a version that is semantically older than the current checkout, then upgrade to the current version. Packaging both tarballs locally lets the test control that version graph precisely.
+
+- Seed the older package by rewriting the packaged version strings instead of maintaining a second source tree.
+  Rationale: the self-upgrade sandbox only needs an older packaged artifact, not a maintained historical branch. Rewriting the staged package contents keeps the fixture lightweight and local to the scenario.
+
+- Scope the first managed self-upgrade sandbox scenario to Bun installs.
+  Rationale: Bun is the repository default package manager and the source of the recent user-facing self-upgrade failures. One stable Bun scenario provides useful regression coverage without doubling runtime and fixture complexity in the first pass.
+
+## Risks / Trade-offs
+
+- [Longer isolation runtime] Packaging tarballs and running a local registry increases sandbox duration. → Mitigation: keep the fixture self-contained, reuse the current checkout build output, and limit the first managed self-upgrade scenario to Bun.
+- [Fixture drift] The sandbox registry could diverge from what Bun expects from a real npm registry. → Mitigation: use a minimal metadata shape proven by a direct `bun add -g` local-registry prototype and keep the scenario focused on the fields Quantex itself consumes.
+- [Packaged-version rewriting misses a new embedded version string] The seeded “older version” package could still report the current version if future build output changes. → Mitigation: assert the seeded `qtx --version` value before running `upgrade --check`, so the scenario fails early if the seed package stops behaving like an older install.

--- a/openspec/changes/add-self-upgrade-sandbox-tests/proposal.md
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Work-intake classification: this change adds maintainer-facing sandbox validation coverage for Quantex self-upgrade behavior, so it modifies a durable workflow contract and requires OpenSpec before implementation.
+
+Recent self-upgrade regressions did not come from one isolated function; they came from the full managed-upgrade chain across package-manager install source detection, registry selection, version resolution, command execution, and post-install verification. The existing sandbox layer only covers standalone-binary self inspection, so Bun-managed self-upgrade bugs can still escape until contributors reproduce them manually.
+
+## What Changes
+
+- Extend the optional lifecycle smoke layer with a managed self-upgrade scenario that runs Quantex from an isolated Bun global install.
+- Build a local sandbox-only npm-style registry from repository tarballs so the self-upgrade scenario can seed an older Quantex package version and upgrade it to the current checkout version without depending on public registry timing.
+- Make the managed self-upgrade scenario part of the default isolated smoke scenario list so both `bun run test:container` and `bun run test:sandbox` exercise it unless maintainers narrow the scenario set explicitly.
+- Update maintainer runbooks to describe the new self-upgrade isolation scenario and how to run it directly while debugging self-upgrade regressions.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: The optional Docker- and Modal-backed isolation workflow now includes Bun-managed self-upgrade coverage in addition to the existing agent lifecycle and standalone-binary checks.
+
+## Impact
+
+- Affected code: `scripts/lifecycle-smoke.ts`.
+- Affected docs: `docs/runbooks/modal-sandbox-testing.md`, `docs/runbooks/release-and-self-upgrade-debugging.md`.
+- Affected contract: `openspec/specs/code-quality-tooling/spec.md`.

--- a/openspec/changes/add-self-upgrade-sandbox-tests/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/specs/code-quality-tooling/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Optional isolation validation commands
+
+The repository SHALL expose `bun run test:sandbox` and `bun run test:container` as optional maintainer-facing validation commands for running real Quantex agent lifecycle smoke checks inside isolated Bun environments. These commands MUST complement rather than replace the canonical local `bun run test` workflow.
+
+#### Scenario: Isolation smoke includes Bun-managed self-upgrade
+
+- **WHEN** the isolated lifecycle smoke script runs the default self-upgrade coverage
+- **THEN** it seeds a Bun-managed Quantex install from a sandbox-local registry at a version older than the current checkout package
+- **AND** `quantex upgrade --check --no-cache` reports that a newer self version is available from that local registry
+- **AND** `quantex upgrade --no-cache` upgrades the managed install to the current checkout package version
+- **AND** the upgraded sandbox `qtx --version` output matches that current checkout package version

--- a/openspec/changes/add-self-upgrade-sandbox-tests/tasks.md
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract
+
+- [x] 1.1 Write the OpenSpec proposal, design, and code-quality-tooling delta for managed self-upgrade sandbox coverage.
+- [x] 1.2 Update maintainer runbooks for the new isolated self-upgrade scenario.
+
+## 2. Implementation
+
+- [x] 2.1 Extend `scripts/lifecycle-smoke.ts` with a Bun-managed self-upgrade scenario backed by a local sandbox registry and seeded older package version.
+- [x] 2.2 Add or update automated tests that cover the isolation harness changes introduced by the new scenario.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -1,4 +1,12 @@
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import process from 'node:process'
+import {
+  buildSelfManagedRegistryMetadata,
+  parsePackedTarballName,
+  SEEDED_SELF_VERSION,
+} from '../src/testing/self-upgrade-sandbox'
 
 interface CommandOutput {
   exitCode: number
@@ -15,8 +23,16 @@ interface JsonResult {
 }
 
 const DEFAULT_SMOKE_AGENTS = ['pi', 'qoder']
-const DEFAULT_SMOKE_SCENARIOS = ['managed', 'adopt-preinstalled', 'ambiguous-multi-method', 'self-binary']
+const DEFAULT_SMOKE_SCENARIOS = [
+  'managed',
+  'adopt-preinstalled',
+  'ambiguous-multi-method',
+  'self-binary',
+  'self-managed',
+]
 const DEFAULT_COMMAND_TIMEOUT_MS = Number(process.env.QTX_ISOLATION_COMMAND_TIMEOUT_MS ?? 300_000)
+const ROOT_PACKAGE_JSON_PATH = 'package.json'
+const DIST_DIR = 'dist'
 const agents = resolveSmokeAgents()
 const scenarios = resolveSmokeScenarios()
 const cli = ['bun', 'run', 'src/cli.ts', '--json', '--non-interactive', '--yes', '--color', 'never']
@@ -44,6 +60,8 @@ try {
   if (scenarios.includes('ambiguous-multi-method')) await smokeAmbiguousMultiMethodAgent()
 
   if (scenarios.includes('self-binary')) await smokeSelfBinaryLifecycle()
+
+  if (scenarios.includes('self-managed')) await smokeManagedSelfUpgradeLifecycle()
 } finally {
   for (const agent of installedAgents.toReversed())
     await runJson(`cleanup uninstall ${agent}`, [...cli, 'uninstall', agent], {
@@ -171,6 +189,125 @@ async function smokeSelfBinaryLifecycle(): Promise<void> {
   assertResult(upgrade, result => result.data?.canAutoUpdate === true, 'binary qtx should support self auto-update')
 }
 
+async function smokeManagedSelfUpgradeLifecycle(): Promise<void> {
+  console.log('\n[self] build managed self-upgrade package')
+  await runText('build managed self package', ['bun', 'run', 'build'])
+
+  const currentPackage = await readRootPackageManifest()
+  const sandboxRoot = await mkdtemp(join(tmpdir(), 'quantex-self-managed-'))
+
+  try {
+    const registry = await createSelfManagedRegistry(sandboxRoot, currentPackage)
+
+    try {
+      const bunInstallDir = join(sandboxRoot, 'bun-global')
+      const managedBinDir = join(bunInstallDir, 'bin')
+      const managedQtx = join(managedBinDir, 'qtx')
+      const managedEnv = {
+        BUN_INSTALL: bunInstallDir,
+        PATH: `${managedBinDir}:${process.env.PATH ?? ''}`,
+        QTX_SELF_UPDATE_REGISTRY: registry.registryUrl,
+      }
+
+      console.log('[self] install seeded Bun-managed Quantex from local registry')
+      await runText(
+        'install seeded Bun-managed Quantex',
+        ['bun', 'add', '-g', `${currentPackage.name}@${SEEDED_SELF_VERSION}`, '--registry', registry.registryUrl],
+        { env: managedEnv },
+      )
+
+      const seededVersion = await runText('seeded Bun-managed qtx version', [managedQtx, '--version'], {
+        env: managedEnv,
+      })
+      if (seededVersion.stdout.trim() !== SEEDED_SELF_VERSION) {
+        throw new Error(
+          `Seeded Bun-managed qtx should report ${SEEDED_SELF_VERSION}, received ${seededVersion.stdout.trim() || '(empty)'}.`,
+        )
+      }
+
+      console.log('[self] managed upgrade check')
+      const upgradeCheck = await runJson(
+        'managed self upgrade check',
+        [...buildSelfJsonCommand(managedQtx), 'upgrade', '--check'],
+        {
+          allowExitCodes: [1],
+          env: managedEnv,
+        },
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.action === 'upgrade',
+        'managed self upgrade check should emit upgrade action',
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.data?.status === 'update-available',
+        'managed self upgrade check should report update-available',
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.data?.currentVersion === SEEDED_SELF_VERSION,
+        'managed self upgrade check should report the seeded current version',
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.data?.latestVersion === currentPackage.version,
+        'managed self upgrade check should resolve the current checkout version as latest',
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.data?.installSource === 'bun',
+        'managed self upgrade check should inspect the install source as bun',
+      )
+
+      console.log('[self] managed self-upgrade execution')
+      const upgrade = await runJson('managed self upgrade', [...buildSelfJsonCommand(managedQtx), 'upgrade'], {
+        env: managedEnv,
+      })
+      assertResult(upgrade, result => result.action === 'upgrade', 'managed self upgrade should emit upgrade action')
+      assertResult(upgrade, result => result.data?.status === 'updated', 'managed self upgrade should report updated')
+      assertResult(
+        upgrade,
+        result => result.data?.installSource === 'bun',
+        'managed self upgrade should keep the bun install source',
+      )
+
+      const upgradedVersion = await runText('upgraded Bun-managed qtx version', [managedQtx, '--version'], {
+        env: managedEnv,
+      })
+      if (upgradedVersion.stdout.trim() !== currentPackage.version) {
+        throw new Error(
+          `Upgraded Bun-managed qtx should report ${currentPackage.version}, received ${upgradedVersion.stdout.trim() || '(empty)'}.`,
+        )
+      }
+
+      console.log('[self] managed upgrade check after upgrade')
+      const postUpgradeCheck = await runJson(
+        'managed self upgrade check after upgrade',
+        [...buildSelfJsonCommand(managedQtx), 'upgrade', '--check'],
+        {
+          allowExitCodes: [0],
+          env: managedEnv,
+        },
+      )
+      assertResult(
+        postUpgradeCheck,
+        result => result.data?.status === 'up-to-date',
+        'managed self upgrade check should report up-to-date after upgrade',
+      )
+      assertResult(
+        postUpgradeCheck,
+        result => result.data?.currentVersion === currentPackage.version,
+        'managed self upgrade check should report the upgraded current version',
+      )
+    } finally {
+      registry.close()
+    }
+  } finally {
+    await rm(sandboxRoot, { force: true, recursive: true })
+  }
+}
+
 async function smokeAmbiguousMultiMethodAgent(): Promise<void> {
   const agent = 'qoder'
   const binaryName = 'qodercli'
@@ -209,9 +346,14 @@ async function smokeAmbiguousMultiMethodAgent(): Promise<void> {
 async function runJson(
   label: string,
   command: string[],
-  options: { allowExitCodes?: number[]; allowFailure?: boolean } = {},
+  options: {
+    allowExitCodes?: number[]
+    allowFailure?: boolean
+    cwd?: string
+    env?: Record<string, string | undefined>
+  } = {},
 ): Promise<JsonResult> {
-  const output = await runCommand(label, command)
+  const output = await runCommand(label, command, options)
   const allowedExitCodes = options.allowExitCodes ?? [0]
   if (!allowedExitCodes.includes(output.exitCode) && !options.allowFailure) throw commandError(label, command, output)
 
@@ -223,16 +365,26 @@ async function runJson(
   return parsed
 }
 
-async function runText(label: string, command: string[]): Promise<CommandOutput> {
-  const output = await runCommand(label, command)
+async function runText(
+  label: string,
+  command: string[],
+  options: { cwd?: string; env?: Record<string, string | undefined> } = {},
+): Promise<CommandOutput> {
+  const output = await runCommand(label, command, options)
   if (output.exitCode !== 0) throw commandError(label, command, output)
   return output
 }
 
-async function runCommand(label: string, command: string[]): Promise<CommandOutput> {
+async function runCommand(
+  label: string,
+  command: string[],
+  options: { cwd?: string; env?: Record<string, string | undefined> } = {},
+): Promise<CommandOutput> {
   const proc = Bun.spawn(command, {
+    cwd: options.cwd,
     env: {
       ...process.env,
+      ...options.env,
       NO_COLOR: '1',
     },
     stdio: ['ignore', 'pipe', 'pipe'] as const,
@@ -328,6 +480,10 @@ function shellCommand(command: string): string[] {
   return ['sh', '-c', command]
 }
 
+function buildSelfJsonCommand(binaryPath: string): string[] {
+  return [binaryPath, '--json', '--non-interactive', '--yes', '--color', 'never', '--no-cache']
+}
+
 function withPathPrefix(prefix: string, command: string[]): string[] {
   return ['env', `PATH=${prefix}:${process.env.PATH ?? ''}`, ...command]
 }
@@ -337,4 +493,127 @@ function getCurrentLinuxBinaryTarget(): 'linux-arm64' | 'linux-x64' {
   if (process.arch === 'x64') return 'linux-x64'
 
   throw new Error(`Unsupported Linux binary smoke architecture: ${process.arch}`)
+}
+
+async function readRootPackageManifest(): Promise<{ name: string; version: string }> {
+  const packageJson = JSON.parse(await readFile(ROOT_PACKAGE_JSON_PATH, 'utf8')) as {
+    name?: string
+    version?: string
+  }
+
+  if (!packageJson.name || !packageJson.version) {
+    throw new Error('The root package.json must define name and version for the self-managed smoke scenario.')
+  }
+
+  return {
+    name: packageJson.name,
+    version: packageJson.version,
+  }
+}
+
+async function createSelfManagedRegistry(
+  sandboxRoot: string,
+  currentPackage: { name: string; version: string },
+): Promise<{ close: () => void; registryUrl: string }> {
+  const registryDir = join(sandboxRoot, 'registry')
+  const latestStageDir = join(sandboxRoot, 'latest-package')
+  const seededStageDir = join(sandboxRoot, 'seeded-package')
+
+  await mkdir(registryDir, { recursive: true })
+  await stageSelfManagedPackage(latestStageDir, currentPackage.version)
+  await stageSelfManagedPackage(seededStageDir, SEEDED_SELF_VERSION)
+
+  const latestTarball = await packSelfManagedPackage('pack latest self-managed package', latestStageDir, registryDir)
+  const seededTarball = await packSelfManagedPackage('pack seeded self-managed package', seededStageDir, registryDir)
+
+  const encodedPackagePath = `/${encodeURIComponent(currentPackage.name)}`
+  const encodedLatestPath = `${encodedPackagePath}/latest`
+  const encodedSeededPath = `${encodedPackagePath}/${encodeURIComponent(SEEDED_SELF_VERSION)}`
+  const encodedCurrentPath = `${encodedPackagePath}/${encodeURIComponent(currentPackage.version)}`
+
+  let server: ReturnType<typeof Bun.serve>
+  server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url)
+      const origin = url.origin
+
+      if (url.pathname === encodedPackagePath || url.pathname === `/${currentPackage.name}`) {
+        return Response.json(
+          buildSelfManagedRegistryMetadata({
+            latestTarballName: latestTarball,
+            latestVersion: currentPackage.version,
+            origin,
+            packageName: currentPackage.name,
+            seededTarballName: seededTarball,
+          }),
+        )
+      }
+
+      if (url.pathname === encodedLatestPath) return Response.json({ version: currentPackage.version })
+      if (url.pathname === encodedSeededPath) return Response.json({ version: SEEDED_SELF_VERSION })
+      if (url.pathname === encodedCurrentPath) return Response.json({ version: currentPackage.version })
+
+      if (url.pathname === `/${seededTarball}`) {
+        return new Response(Bun.file(join(registryDir, seededTarball)), {
+          headers: {
+            'content-type': 'application/octet-stream',
+          },
+        })
+      }
+
+      if (url.pathname === `/${latestTarball}`) {
+        return new Response(Bun.file(join(registryDir, latestTarball)), {
+          headers: {
+            'content-type': 'application/octet-stream',
+          },
+        })
+      }
+
+      return new Response('not found', { status: 404 })
+    },
+  })
+
+  return {
+    close: () => server.stop(true),
+    registryUrl: `http://127.0.0.1:${server.port}`,
+  }
+}
+
+async function stageSelfManagedPackage(stageDir: string, targetVersion: string): Promise<void> {
+  await mkdir(stageDir, { recursive: true })
+  await cp(DIST_DIR, join(stageDir, DIST_DIR), { recursive: true })
+  await cp(ROOT_PACKAGE_JSON_PATH, join(stageDir, ROOT_PACKAGE_JSON_PATH))
+
+  const packageJsonPath = join(stageDir, ROOT_PACKAGE_JSON_PATH)
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as Record<string, unknown>
+  const currentVersion = typeof packageJson.version === 'string' ? packageJson.version : undefined
+
+  if (!currentVersion) throw new Error('The root package.json must define version for the self-managed smoke scenario.')
+
+  packageJson.version = targetVersion
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf8')
+
+  if (targetVersion === currentVersion) return
+
+  const distFiles = await readdir(join(stageDir, DIST_DIR))
+  for (const fileName of distFiles) {
+    if (!fileName.endsWith('.mjs') && !fileName.endsWith('.mts')) continue
+
+    const filePath = join(stageDir, DIST_DIR, fileName)
+    const content = await readFile(filePath, 'utf8')
+    await writeFile(filePath, content.replaceAll(currentVersion, targetVersion), 'utf8')
+  }
+}
+
+async function packSelfManagedPackage(label: string, packageDir: string, registryDir: string): Promise<string> {
+  const output = await runText(label, ['npm', 'pack', '--ignore-scripts', '--pack-destination', registryDir], {
+    cwd: packageDir,
+  })
+  const tarballName = parsePackedTarballName(output.stdout)
+
+  if (!tarballName) throw new Error(`${label} did not report a tarball filename.`)
+
+  return tarballName
 }

--- a/src/testing/self-upgrade-sandbox.ts
+++ b/src/testing/self-upgrade-sandbox.ts
@@ -1,0 +1,57 @@
+export const SEEDED_SELF_VERSION = '0.0.0-sandbox-old'
+
+export function buildSelfManagedRegistryMetadata(options: {
+  latestTarballName: string
+  latestVersion: string
+  origin: string
+  packageName: string
+  seededTarballName: string
+  seededVersion?: string
+}): {
+  'dist-tags': { latest: string }
+  name: string
+  versions: Record<
+    string,
+    {
+      dist: {
+        tarball: string
+      }
+      name: string
+      version: string
+    }
+  >
+} {
+  const seededVersion = options.seededVersion ?? SEEDED_SELF_VERSION
+
+  return {
+    'dist-tags': {
+      latest: options.latestVersion,
+    },
+    name: options.packageName,
+    versions: {
+      [seededVersion]: {
+        dist: {
+          tarball: `${options.origin}/${options.seededTarballName}`,
+        },
+        name: options.packageName,
+        version: seededVersion,
+      },
+      [options.latestVersion]: {
+        dist: {
+          tarball: `${options.origin}/${options.latestTarballName}`,
+        },
+        name: options.packageName,
+        version: options.latestVersion,
+      },
+    },
+  }
+}
+
+export function parsePackedTarballName(output: string): string | undefined {
+  return output
+    .trim()
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .at(-1)
+}

--- a/test/testing/self-upgrade-sandbox.test.ts
+++ b/test/testing/self-upgrade-sandbox.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSelfManagedRegistryMetadata,
+  parsePackedTarballName,
+  SEEDED_SELF_VERSION,
+} from '../../src/testing/self-upgrade-sandbox'
+
+describe('buildSelfManagedRegistryMetadata', () => {
+  it('publishes the current version as latest and keeps the seeded older version installable', () => {
+    const metadata = buildSelfManagedRegistryMetadata({
+      latestTarballName: 'quantex-cli-0.15.1.tgz',
+      latestVersion: '0.15.1',
+      origin: 'http://127.0.0.1:4873',
+      packageName: 'quantex-cli',
+      seededTarballName: 'quantex-cli-0.0.0-sandbox-old.tgz',
+    })
+
+    expect(metadata.name).toBe('quantex-cli')
+    expect(metadata['dist-tags'].latest).toBe('0.15.1')
+    expect(metadata.versions[SEEDED_SELF_VERSION]).toEqual({
+      dist: {
+        tarball: 'http://127.0.0.1:4873/quantex-cli-0.0.0-sandbox-old.tgz',
+      },
+      name: 'quantex-cli',
+      version: SEEDED_SELF_VERSION,
+    })
+    expect(metadata.versions['0.15.1']).toEqual({
+      dist: {
+        tarball: 'http://127.0.0.1:4873/quantex-cli-0.15.1.tgz',
+      },
+      name: 'quantex-cli',
+      version: '0.15.1',
+    })
+  })
+})
+
+describe('parsePackedTarballName', () => {
+  it('returns the last non-empty line from npm pack output', () => {
+    expect(parsePackedTarballName('\nquantex-cli-0.15.1.tgz\n')).toBe('quantex-cli-0.15.1.tgz')
+    expect(parsePackedTarballName('npm notice something\nquantex-cli-0.15.1.tgz\n')).toBe('quantex-cli-0.15.1.tgz')
+  })
+
+  it('returns undefined when npm pack output is empty', () => {
+    expect(parsePackedTarballName('\n\n')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Add a managed self-upgrade sandbox scenario to the optional isolation smoke layer. The new `self-managed` scenario builds local Quantex tarballs, serves them from a sandbox-local npm-style registry, seeds an older Bun-managed install, and verifies that `quantex upgrade --check --no-cache` and `quantex upgrade --no-cache` move that install to the current checkout version.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `add-self-upgrade-sandbox-tests`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- Maintainer docs now point self-upgrade debugging toward `QTX_ISOLATION_SCENARIOS=self-managed bun run test:container`.
- `QTX_ISOLATION_SCENARIOS=self-managed bun run test:container` was attempted locally, but the Docker-isolated `bun install --frozen-lockfile --ignore-scripts --no-progress` step failed on an external tarball integrity error for `@esbuild/linux-arm64` before the new smoke scenario itself executed.
