### PR TITLE
refactor(self-upgrade): transactional planning and sandbox smoke coverage

### DIFF
--- a/docs/runbooks/modal-sandbox-testing.md
+++ b/docs/runbooks/modal-sandbox-testing.md
@@ -40,6 +40,7 @@ Default scenarios:
 - `adopt-preinstalled`: the sandbox preinstalls the agent outside Quantex first, then verifies `quantex install <agent>` adopts and tracks that existing install.
 - `ambiguous-multi-method`: the sandbox places a fake multi-install-method agent binary in PATH and verifies Quantex does not guess an install source.
 - `self-binary`: the sandbox builds a Linux standalone Quantex binary, installs it into the isolated HOME, then verifies binary-entrypoint command discovery, agent inspection, and `upgrade --check` self-inspection.
+- `self-managed`: the sandbox builds local Quantex package tarballs, serves them from a sandbox-local registry, seeds an older Bun-managed Quantex install, and verifies `quantex upgrade` upgrades that install to the current checkout version.
 
 For each selected agent, the `managed` scenario executes the real Quantex CLI flow:
 
@@ -79,6 +80,7 @@ To limit scenarios, set `QTX_ISOLATION_SCENARIOS`:
 ```bash
 QTX_ISOLATION_SCENARIOS=managed,adopt-preinstalled bun run test:container
 QTX_ISOLATION_SCENARIOS=self-binary bun run test:container
+QTX_ISOLATION_SCENARIOS=self-managed bun run test:container
 QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:container
 ```
 
@@ -104,6 +106,7 @@ The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AG
    ```
 
 2. Run `bun run test:container` when the change is sensitive to HOME, PATH, global tools, or filesystem isolation and you want a local fallback that does not require Modal.
+   For self-upgrade regressions, start with `QTX_ISOLATION_SCENARIOS=self-managed bun run test:container`.
 3. Run `bun run test:sandbox` when you also want to validate the Modal transport or reproduce the dedicated GitHub Actions workflow.
 4. If an isolated run fails, compare whether the failure is code-related or environment-related by rerunning the same agent list locally.
 5. If Modal setup is missing, install or repair the local Modal CLI before treating the failure as a product regression.

--- a/docs/runbooks/release-and-self-upgrade-debugging.md
+++ b/docs/runbooks/release-and-self-upgrade-debugging.md
@@ -232,6 +232,14 @@ If Bun reports success but the installed `qtx --version` does not move:
 - prefer the self-upgrade path that re-declares the direct package target with `bun add -g quantex-cli@<tag>` instead of relying on global `bun update`
 - npm has a similar range-sensitive `update` behavior; use `npm install -g quantex-cli@<tag>` when the intent is to replace the direct global package target
 
+If you need an isolated reproduction of the Bun-managed self-upgrade path without depending on public registry timing:
+
+```bash
+QTX_ISOLATION_SCENARIOS=self-managed bun run test:container
+```
+
+This scenario builds local Quantex tarballs, seeds an older Bun-managed install from a sandbox-local registry, then verifies that `quantex upgrade --no-cache` reaches the current checkout version.
+
 ### 7. Reproduce the CI release verification path locally
 
 The closest local sequence to the release verification workflow is:

--- a/openspec/changes/add-self-upgrade-sandbox-tests/.openspec.yaml
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/add-self-upgrade-sandbox-tests/design.md
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The repository already has an optional isolation layer that runs real Quantex lifecycle flows inside Docker or Modal-backed Bun environments. That layer covers managed agent lifecycle, preinstalled adoption, ambiguous PATH detection, and standalone-binary self inspection. It does not cover the highest-risk self-upgrade path: Quantex installed through Bun and then upgrading itself through a managed package flow.
+
+The self-upgrade bugs reported so far were end-to-end failures. Unit tests helped after the fact, but the escaping behavior depended on the interaction between real package-manager installs, a real Quantex entrypoint, registry metadata resolution, and post-upgrade verification. The isolation layer is the right place to protect that chain.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a deterministic managed self-upgrade smoke scenario to the existing isolation layer.
+- Keep the scenario local to the sandbox process rather than depending on public npm release timing.
+- Reuse the current `scripts/lifecycle-smoke.ts` entrypoint so Docker and Modal continue to exercise the same scenario set.
+- Validate the specific Bun-managed flow that has produced the recent self-upgrade regressions.
+
+**Non-Goals:**
+
+- Re-architecting the self-upgrade implementation in this change.
+- Covering every managed self-upgrade provider in the first sandbox pass.
+- Turning the isolation layer into a general-purpose local registry framework.
+- Replacing unit and integration tests with sandbox-only validation.
+
+## Decisions
+
+- Add a new `self-managed` lifecycle smoke scenario inside the existing lifecycle smoke script.
+  Rationale: the current Docker and Modal harnesses already delegate to `scripts/lifecycle-smoke.ts`, so extending that script keeps both transports aligned without introducing a second remote entrypoint.
+
+- Use an ephemeral local npm-style registry served from inside the sandbox process.
+  Rationale: managed self-upgrade needs a deterministic upgrade target. A local registry avoids dependency on public npm freshness, mirror lag, or release timing while still exercising Quantex through its real managed self-upgrade path.
+
+- Generate two local Quantex package tarballs for the scenario: a seeded older version and the current checkout version.
+  Rationale: the scenario must start from a version that is semantically older than the current checkout, then upgrade to the current version. Packaging both tarballs locally lets the test control that version graph precisely.
+
+- Seed the older package by rewriting the packaged version strings instead of maintaining a second source tree.
+  Rationale: the self-upgrade sandbox only needs an older packaged artifact, not a maintained historical branch. Rewriting the staged package contents keeps the fixture lightweight and local to the scenario.
+
+- Scope the first managed self-upgrade sandbox scenario to Bun installs.
+  Rationale: Bun is the repository default package manager and the source of the recent user-facing self-upgrade failures. One stable Bun scenario provides useful regression coverage without doubling runtime and fixture complexity in the first pass.
+
+## Risks / Trade-offs
+
+- [Longer isolation runtime] Packaging tarballs and running a local registry increases sandbox duration. → Mitigation: keep the fixture self-contained, reuse the current checkout build output, and limit the first managed self-upgrade scenario to Bun.
+- [Fixture drift] The sandbox registry could diverge from what Bun expects from a real npm registry. → Mitigation: use a minimal metadata shape proven by a direct `bun add -g` local-registry prototype and keep the scenario focused on the fields Quantex itself consumes.
+- [Packaged-version rewriting misses a new embedded version string] The seeded “older version” package could still report the current version if future build output changes. → Mitigation: assert the seeded `qtx --version` value before running `upgrade --check`, so the scenario fails early if the seed package stops behaving like an older install.

--- a/openspec/changes/add-self-upgrade-sandbox-tests/proposal.md
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Work-intake classification: this change adds maintainer-facing sandbox validation coverage for Quantex self-upgrade behavior, so it modifies a durable workflow contract and requires OpenSpec before implementation.
+
+Recent self-upgrade regressions did not come from one isolated function; they came from the full managed-upgrade chain across package-manager install source detection, registry selection, version resolution, command execution, and post-install verification. The existing sandbox layer only covers standalone-binary self inspection, so Bun-managed self-upgrade bugs can still escape until contributors reproduce them manually.
+
+## What Changes
+
+- Extend the optional lifecycle smoke layer with a managed self-upgrade scenario that runs Quantex from an isolated Bun global install.
+- Build a local sandbox-only npm-style registry from repository tarballs so the self-upgrade scenario can seed an older Quantex package version and upgrade it to the current checkout version without depending on public registry timing.
+- Make the managed self-upgrade scenario part of the default isolated smoke scenario list so both `bun run test:container` and `bun run test:sandbox` exercise it unless maintainers narrow the scenario set explicitly.
+- Update maintainer runbooks to describe the new self-upgrade isolation scenario and how to run it directly while debugging self-upgrade regressions.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: The optional Docker- and Modal-backed isolation workflow now includes Bun-managed self-upgrade coverage in addition to the existing agent lifecycle and standalone-binary checks.
+
+## Impact
+
+- Affected code: `scripts/lifecycle-smoke.ts`.
+- Affected docs: `docs/runbooks/modal-sandbox-testing.md`, `docs/runbooks/release-and-self-upgrade-debugging.md`.
+- Affected contract: `openspec/specs/code-quality-tooling/spec.md`.

--- a/openspec/changes/add-self-upgrade-sandbox-tests/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/specs/code-quality-tooling/spec.md
@@ -1,0 +1,13 @@
+## MODIFIED Requirements
+
+### Requirement: Optional isolation validation commands
+
+The repository SHALL expose `bun run test:sandbox` and `bun run test:container` as optional maintainer-facing validation commands for running real Quantex agent lifecycle smoke checks inside isolated Bun environments. These commands MUST complement rather than replace the canonical local `bun run test` workflow.
+
+#### Scenario: Isolation smoke includes Bun-managed self-upgrade
+
+- **WHEN** the isolated lifecycle smoke script runs the default self-upgrade coverage
+- **THEN** it seeds a Bun-managed Quantex install from a sandbox-local registry at a version older than the current checkout package
+- **AND** `quantex upgrade --check --no-cache` reports that a newer self version is available from that local registry
+- **AND** `quantex upgrade --no-cache` upgrades the managed install to the current checkout package version
+- **AND** the upgraded sandbox `qtx --version` output matches that current checkout package version

--- a/openspec/changes/add-self-upgrade-sandbox-tests/tasks.md
+++ b/openspec/changes/add-self-upgrade-sandbox-tests/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract
+
+- [x] 1.1 Write the OpenSpec proposal, design, and code-quality-tooling delta for managed self-upgrade sandbox coverage.
+- [x] 1.2 Update maintainer runbooks for the new isolated self-upgrade scenario.
+
+## 2. Implementation
+
+- [x] 2.1 Extend `scripts/lifecycle-smoke.ts` with a Bun-managed self-upgrade scenario backed by a local sandbox registry and seeded older package version.
+- [x] 2.2 Add or update automated tests that cover the isolation harness changes introduced by the new scenario.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.

--- a/openspec/changes/rearchitect-self-upgrade-transaction/.openspec.yaml
+++ b/openspec/changes/rearchitect-self-upgrade-transaction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/rearchitect-self-upgrade-transaction/design.md
+++ b/openspec/changes/rearchitect-self-upgrade-transaction/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The current self-upgrade implementation flattens too many concerns into `SelfInspection`: local runtime facts, resolved latest version, registry warnings, auto-update capability, and user-facing recommendation strings. The `upgrade` command then performs additional plan-like decisions on top of that flattened object, while providers still infer upgrade intent from fields such as `latestVersion`, `managedRegistry`, and `updateChannel`.
+
+That shape has made recent self-upgrade regressions harder to contain because the system does not freeze an explicit “what are we trying to do?” object before execution. Detection, execution, and verification all read overlapping fields and can disagree about the upgrade target.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce a first-class internal self-upgrade plan that separates facts, remote target resolution, status planning, and execution.
+- Preserve the existing CLI command surface and structured response schema while reducing internal ambiguity.
+- Make provider execution and post-install verification consume the same frozen target information.
+- Centralize update-availability decisions so `inspectSelf()`, `quantex upgrade`, and `quantex upgrade --check` do not each re-derive the same semantics differently.
+
+**Non-Goals:**
+
+- Reworking the package-manager backends beyond the inputs they consume.
+- Changing self-upgrade channels, cache configuration flags, or the user-visible command catalog in this change.
+- Collapsing self-upgrade and agent update into one subsystem.
+
+## Decisions
+
+- Introduce internal phases: `resolveSelfInstallFacts()`, `resolveSelfUpdateTarget()`, `planSelfUpgrade()`, and `executeSelfUpgradePlan()`.
+  Rationale: these phase boundaries match the real problem domains and give the code one place to answer each question.
+
+- Keep `SelfInspection` as the public-facing summary object, but derive it from the new planning model.
+  Rationale: commands and tests already consume `SelfInspection`, so this change should preserve outward compatibility while relocating the logic behind it.
+
+- Make providers execute against a `SelfUpgradePlan` instead of a bare `SelfInspection`.
+  Rationale: a provider should not guess target version or registry from a summary snapshot; it should receive the exact execution inputs already selected by the planner.
+
+- Keep availability semantics unchanged where possible, but move them out of `src/commands/upgrade.ts` into self-upgrade planning.
+  Rationale: the command layer should render results, not own the transaction rules.
+
+## Risks / Trade-offs
+
+- [Partial refactor leaves two competing paths] During transition, old and new helpers could coexist and drift. → Mitigation: route `inspectSelf()` and `upgradeSelf()` through the new planner in the same change.
+- [Type churn across tests] Self-upgrade tests currently build raw `SelfInspection` literals in many places. → Mitigation: preserve the public inspection shape and add targeted plan tests instead of rewriting every consumer.
+- [Behavior-preserving refactor still changes edge cases] Centralizing status logic may shift a few previously implicit edge paths. → Mitigation: keep the existing command tests and add planner-specific regression coverage around stale latest, unresolved latest, and verification target consistency.

--- a/openspec/changes/rearchitect-self-upgrade-transaction/proposal.md
+++ b/openspec/changes/rearchitect-self-upgrade-transaction/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Work-intake classification: this change restructures Quantex self-upgrade behavior and internal architecture, so it affects observable upgrade behavior and requires OpenSpec before implementation.
+
+Recent self-upgrade bugs have not come from one isolated provider bug; they have come from state leaking across detection, latest-version resolution, provider execution, and post-install verification. The current implementation relies on a flattened `SelfInspection` snapshot that mixes local facts, remote target guesses, and user-facing hints, which makes it too easy for one stale or ambiguous field to corrupt the whole upgrade transaction.
+
+## What Changes
+
+- Refactor self-upgrade internals into explicit phases for install facts, remote target resolution, upgrade planning, and execution/verification.
+- Introduce an internal self-upgrade plan object that freezes the install source, resolved target version, registry or release source, and verification strategy before execution starts.
+- Make `quantex upgrade`, `quantex upgrade --check`, and `inspectSelf()` derive their status from the same self-upgrade planning logic instead of duplicating update-availability decisions in command code.
+- Update managed and binary self-upgrade providers to consume the execution plan rather than infer upgrade targets from loosely related inspection fields.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `self-upgrade`: self-upgrade now resolves an explicit execution-grade plan before provider execution and post-install verification.
+
+## Impact
+
+- Affected code: `src/self/`, `src/commands/upgrade.ts`, and self-upgrade tests.
+- Affected contract: `openspec/specs/self-upgrade/spec.md`.

--- a/openspec/changes/rearchitect-self-upgrade-transaction/specs/self-upgrade/spec.md
+++ b/openspec/changes/rearchitect-self-upgrade-transaction/specs/self-upgrade/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Managed self-upgrade MUST keep registry checks and installs consistent
+
+Managed self-upgrade SHALL use the same resolved registry for package-manager version checks and managed-install execution, SHALL install the selected package tag directly instead of relying on package-manager update semantics, SHALL not treat a lower reported latest version as an update target, and SHALL freeze the chosen target version and verification strategy in an execution plan before running the provider.
+
+#### Scenario: Managed self-upgrade suppresses stale downgrade targets
+
+- GIVEN Quantex was installed via `bun` or `npm`
+- AND the current CLI version is newer than the resolved `latestVersion` from cache or registry
+- WHEN the user runs `quantex upgrade` or `quantex upgrade --check`
+- THEN Quantex does not invoke managed self-upgrade toward that lower version
+- AND it does not present the lower version as an available update
+
+#### Scenario: Managed self-upgrade executes against a frozen plan
+
+- GIVEN Quantex was installed via `bun` or `npm`
+- AND self-upgrade resolution identifies an installable target version and registry
+- WHEN Quantex starts a managed self-upgrade attempt
+- THEN it passes one execution plan to the provider that already includes the install source, target version, resolved registry, and post-install verification probe
+- AND post-install verification compares the observed installed CLI version against that same plan target instead of re-deriving the target from mutable inspection fields

--- a/openspec/changes/rearchitect-self-upgrade-transaction/tasks.md
+++ b/openspec/changes/rearchitect-self-upgrade-transaction/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract
+
+- [x] 1.1 Write the proposal, design, and self-upgrade delta for the transactional self-upgrade rewrite.
+
+## 2. Implementation
+
+- [x] 2.1 Add internal self-upgrade facts, target, and plan types plus planner helpers.
+- [x] 2.2 Refactor `inspectSelf()`, `upgradeSelf()`, and self-upgrade providers to consume the new plan model.
+- [x] 2.3 Simplify `src/commands/upgrade.ts` so it renders the planner result instead of re-implementing update-availability decisions.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -1,4 +1,12 @@
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import process from 'node:process'
+import {
+  buildSelfManagedRegistryMetadata,
+  parsePackedTarballName,
+  SEEDED_SELF_VERSION,
+} from '../src/testing/self-upgrade-sandbox'
 
 interface CommandOutput {
   exitCode: number
@@ -15,8 +23,16 @@ interface JsonResult {
 }
 
 const DEFAULT_SMOKE_AGENTS = ['pi', 'qoder']
-const DEFAULT_SMOKE_SCENARIOS = ['managed', 'adopt-preinstalled', 'ambiguous-multi-method', 'self-binary']
+const DEFAULT_SMOKE_SCENARIOS = [
+  'managed',
+  'adopt-preinstalled',
+  'ambiguous-multi-method',
+  'self-binary',
+  'self-managed',
+]
 const DEFAULT_COMMAND_TIMEOUT_MS = Number(process.env.QTX_ISOLATION_COMMAND_TIMEOUT_MS ?? 300_000)
+const ROOT_PACKAGE_JSON_PATH = 'package.json'
+const DIST_DIR = 'dist'
 const agents = resolveSmokeAgents()
 const scenarios = resolveSmokeScenarios()
 const cli = ['bun', 'run', 'src/cli.ts', '--json', '--non-interactive', '--yes', '--color', 'never']
@@ -44,6 +60,8 @@ try {
   if (scenarios.includes('ambiguous-multi-method')) await smokeAmbiguousMultiMethodAgent()
 
   if (scenarios.includes('self-binary')) await smokeSelfBinaryLifecycle()
+
+  if (scenarios.includes('self-managed')) await smokeManagedSelfUpgradeLifecycle()
 } finally {
   for (const agent of installedAgents.toReversed())
     await runJson(`cleanup uninstall ${agent}`, [...cli, 'uninstall', agent], {
@@ -171,6 +189,125 @@ async function smokeSelfBinaryLifecycle(): Promise<void> {
   assertResult(upgrade, result => result.data?.canAutoUpdate === true, 'binary qtx should support self auto-update')
 }
 
+async function smokeManagedSelfUpgradeLifecycle(): Promise<void> {
+  console.log('\n[self] build managed self-upgrade package')
+  await runText('build managed self package', ['bun', 'run', 'build'])
+
+  const currentPackage = await readRootPackageManifest()
+  const sandboxRoot = await mkdtemp(join(tmpdir(), 'quantex-self-managed-'))
+
+  try {
+    const registry = await createSelfManagedRegistry(sandboxRoot, currentPackage)
+
+    try {
+      const bunInstallDir = join(sandboxRoot, 'bun-global')
+      const managedBinDir = join(bunInstallDir, 'bin')
+      const managedQtx = join(managedBinDir, 'qtx')
+      const managedEnv = {
+        BUN_INSTALL: bunInstallDir,
+        PATH: `${managedBinDir}:${process.env.PATH ?? ''}`,
+        QTX_SELF_UPDATE_REGISTRY: registry.registryUrl,
+      }
+
+      console.log('[self] install seeded Bun-managed Quantex from local registry')
+      await runText(
+        'install seeded Bun-managed Quantex',
+        ['bun', 'add', '-g', `${currentPackage.name}@${SEEDED_SELF_VERSION}`, '--registry', registry.registryUrl],
+        { env: managedEnv },
+      )
+
+      const seededVersion = await runText('seeded Bun-managed qtx version', [managedQtx, '--version'], {
+        env: managedEnv,
+      })
+      if (seededVersion.stdout.trim() !== SEEDED_SELF_VERSION) {
+        throw new Error(
+          `Seeded Bun-managed qtx should report ${SEEDED_SELF_VERSION}, received ${seededVersion.stdout.trim() || '(empty)'}.`,
+        )
+      }
+
+      console.log('[self] managed upgrade check')
+      const upgradeCheck = await runJson(
+        'managed self upgrade check',
+        [...buildSelfJsonCommand(managedQtx), 'upgrade', '--check'],
+        {
+          allowExitCodes: [1],
+          env: managedEnv,
+        },
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.action === 'upgrade',
+        'managed self upgrade check should emit upgrade action',
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.data?.status === 'update-available',
+        'managed self upgrade check should report update-available',
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.data?.currentVersion === SEEDED_SELF_VERSION,
+        'managed self upgrade check should report the seeded current version',
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.data?.latestVersion === currentPackage.version,
+        'managed self upgrade check should resolve the current checkout version as latest',
+      )
+      assertResult(
+        upgradeCheck,
+        result => result.data?.installSource === 'bun',
+        'managed self upgrade check should inspect the install source as bun',
+      )
+
+      console.log('[self] managed self-upgrade execution')
+      const upgrade = await runJson('managed self upgrade', [...buildSelfJsonCommand(managedQtx), 'upgrade'], {
+        env: managedEnv,
+      })
+      assertResult(upgrade, result => result.action === 'upgrade', 'managed self upgrade should emit upgrade action')
+      assertResult(upgrade, result => result.data?.status === 'updated', 'managed self upgrade should report updated')
+      assertResult(
+        upgrade,
+        result => result.data?.installSource === 'bun',
+        'managed self upgrade should keep the bun install source',
+      )
+
+      const upgradedVersion = await runText('upgraded Bun-managed qtx version', [managedQtx, '--version'], {
+        env: managedEnv,
+      })
+      if (upgradedVersion.stdout.trim() !== currentPackage.version) {
+        throw new Error(
+          `Upgraded Bun-managed qtx should report ${currentPackage.version}, received ${upgradedVersion.stdout.trim() || '(empty)'}.`,
+        )
+      }
+
+      console.log('[self] managed upgrade check after upgrade')
+      const postUpgradeCheck = await runJson(
+        'managed self upgrade check after upgrade',
+        [...buildSelfJsonCommand(managedQtx), 'upgrade', '--check'],
+        {
+          allowExitCodes: [0],
+          env: managedEnv,
+        },
+      )
+      assertResult(
+        postUpgradeCheck,
+        result => result.data?.status === 'up-to-date',
+        'managed self upgrade check should report up-to-date after upgrade',
+      )
+      assertResult(
+        postUpgradeCheck,
+        result => result.data?.currentVersion === currentPackage.version,
+        'managed self upgrade check should report the upgraded current version',
+      )
+    } finally {
+      registry.close()
+    }
+  } finally {
+    await rm(sandboxRoot, { force: true, recursive: true })
+  }
+}
+
 async function smokeAmbiguousMultiMethodAgent(): Promise<void> {
   const agent = 'qoder'
   const binaryName = 'qodercli'
@@ -209,9 +346,14 @@ async function smokeAmbiguousMultiMethodAgent(): Promise<void> {
 async function runJson(
   label: string,
   command: string[],
-  options: { allowExitCodes?: number[]; allowFailure?: boolean } = {},
+  options: {
+    allowExitCodes?: number[]
+    allowFailure?: boolean
+    cwd?: string
+    env?: Record<string, string | undefined>
+  } = {},
 ): Promise<JsonResult> {
-  const output = await runCommand(label, command)
+  const output = await runCommand(label, command, options)
   const allowedExitCodes = options.allowExitCodes ?? [0]
   if (!allowedExitCodes.includes(output.exitCode) && !options.allowFailure) throw commandError(label, command, output)
 
@@ -223,16 +365,26 @@ async function runJson(
   return parsed
 }
 
-async function runText(label: string, command: string[]): Promise<CommandOutput> {
-  const output = await runCommand(label, command)
+async function runText(
+  label: string,
+  command: string[],
+  options: { cwd?: string; env?: Record<string, string | undefined> } = {},
+): Promise<CommandOutput> {
+  const output = await runCommand(label, command, options)
   if (output.exitCode !== 0) throw commandError(label, command, output)
   return output
 }
 
-async function runCommand(label: string, command: string[]): Promise<CommandOutput> {
+async function runCommand(
+  label: string,
+  command: string[],
+  options: { cwd?: string; env?: Record<string, string | undefined> } = {},
+): Promise<CommandOutput> {
   const proc = Bun.spawn(command, {
+    cwd: options.cwd,
     env: {
       ...process.env,
+      ...options.env,
       NO_COLOR: '1',
     },
     stdio: ['ignore', 'pipe', 'pipe'] as const,
@@ -328,6 +480,10 @@ function shellCommand(command: string): string[] {
   return ['sh', '-c', command]
 }
 
+function buildSelfJsonCommand(binaryPath: string): string[] {
+  return [binaryPath, '--json', '--non-interactive', '--yes', '--color', 'never', '--no-cache']
+}
+
 function withPathPrefix(prefix: string, command: string[]): string[] {
   return ['env', `PATH=${prefix}:${process.env.PATH ?? ''}`, ...command]
 }
@@ -337,4 +493,127 @@ function getCurrentLinuxBinaryTarget(): 'linux-arm64' | 'linux-x64' {
   if (process.arch === 'x64') return 'linux-x64'
 
   throw new Error(`Unsupported Linux binary smoke architecture: ${process.arch}`)
+}
+
+async function readRootPackageManifest(): Promise<{ name: string; version: string }> {
+  const packageJson = JSON.parse(await readFile(ROOT_PACKAGE_JSON_PATH, 'utf8')) as {
+    name?: string
+    version?: string
+  }
+
+  if (!packageJson.name || !packageJson.version) {
+    throw new Error('The root package.json must define name and version for the self-managed smoke scenario.')
+  }
+
+  return {
+    name: packageJson.name,
+    version: packageJson.version,
+  }
+}
+
+async function createSelfManagedRegistry(
+  sandboxRoot: string,
+  currentPackage: { name: string; version: string },
+): Promise<{ close: () => void; registryUrl: string }> {
+  const registryDir = join(sandboxRoot, 'registry')
+  const latestStageDir = join(sandboxRoot, 'latest-package')
+  const seededStageDir = join(sandboxRoot, 'seeded-package')
+
+  await mkdir(registryDir, { recursive: true })
+  await stageSelfManagedPackage(latestStageDir, currentPackage.version)
+  await stageSelfManagedPackage(seededStageDir, SEEDED_SELF_VERSION)
+
+  const latestTarball = await packSelfManagedPackage('pack latest self-managed package', latestStageDir, registryDir)
+  const seededTarball = await packSelfManagedPackage('pack seeded self-managed package', seededStageDir, registryDir)
+
+  const encodedPackagePath = `/${encodeURIComponent(currentPackage.name)}`
+  const encodedLatestPath = `${encodedPackagePath}/latest`
+  const encodedSeededPath = `${encodedPackagePath}/${encodeURIComponent(SEEDED_SELF_VERSION)}`
+  const encodedCurrentPath = `${encodedPackagePath}/${encodeURIComponent(currentPackage.version)}`
+
+  let server: ReturnType<typeof Bun.serve>
+  server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url)
+      const origin = url.origin
+
+      if (url.pathname === encodedPackagePath || url.pathname === `/${currentPackage.name}`) {
+        return Response.json(
+          buildSelfManagedRegistryMetadata({
+            latestTarballName: latestTarball,
+            latestVersion: currentPackage.version,
+            origin,
+            packageName: currentPackage.name,
+            seededTarballName: seededTarball,
+          }),
+        )
+      }
+
+      if (url.pathname === encodedLatestPath) return Response.json({ version: currentPackage.version })
+      if (url.pathname === encodedSeededPath) return Response.json({ version: SEEDED_SELF_VERSION })
+      if (url.pathname === encodedCurrentPath) return Response.json({ version: currentPackage.version })
+
+      if (url.pathname === `/${seededTarball}`) {
+        return new Response(Bun.file(join(registryDir, seededTarball)), {
+          headers: {
+            'content-type': 'application/octet-stream',
+          },
+        })
+      }
+
+      if (url.pathname === `/${latestTarball}`) {
+        return new Response(Bun.file(join(registryDir, latestTarball)), {
+          headers: {
+            'content-type': 'application/octet-stream',
+          },
+        })
+      }
+
+      return new Response('not found', { status: 404 })
+    },
+  })
+
+  return {
+    close: () => server.stop(true),
+    registryUrl: `http://127.0.0.1:${server.port}`,
+  }
+}
+
+async function stageSelfManagedPackage(stageDir: string, targetVersion: string): Promise<void> {
+  await mkdir(stageDir, { recursive: true })
+  await cp(DIST_DIR, join(stageDir, DIST_DIR), { recursive: true })
+  await cp(ROOT_PACKAGE_JSON_PATH, join(stageDir, ROOT_PACKAGE_JSON_PATH))
+
+  const packageJsonPath = join(stageDir, ROOT_PACKAGE_JSON_PATH)
+  const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as Record<string, unknown>
+  const currentVersion = typeof packageJson.version === 'string' ? packageJson.version : undefined
+
+  if (!currentVersion) throw new Error('The root package.json must define version for the self-managed smoke scenario.')
+
+  packageJson.version = targetVersion
+  await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf8')
+
+  if (targetVersion === currentVersion) return
+
+  const distFiles = await readdir(join(stageDir, DIST_DIR))
+  for (const fileName of distFiles) {
+    if (!fileName.endsWith('.mjs') && !fileName.endsWith('.mts')) continue
+
+    const filePath = join(stageDir, DIST_DIR, fileName)
+    const content = await readFile(filePath, 'utf8')
+    await writeFile(filePath, content.replaceAll(currentVersion, targetVersion), 'utf8')
+  }
+}
+
+async function packSelfManagedPackage(label: string, packageDir: string, registryDir: string): Promise<string> {
+  const output = await runText(label, ['npm', 'pack', '--ignore-scripts', '--pack-destination', registryDir], {
+    cwd: packageDir,
+  })
+  const tarballName = parsePackedTarballName(output.stdout)
+
+  if (!tarballName) throw new Error(`${label} did not report a tarball filename.`)
+
+  return tarballName
 }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -1,11 +1,16 @@
 import type { CommandResult } from '../output/types'
 import type { CommandWarning } from '../output/types'
-import type { SelfUpdateChannel } from '../self'
+import type { SelfInspection, SelfUpdateChannel } from '../self'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
-import { getSelfUpgradeRecoveryHintForInspection, inspectSelf, upgradeSelf } from '../self'
+import {
+  buildSelfInspectionFromPlan,
+  getSelfUpgradeRecoveryHintForInspection,
+  planSelfUpgrade,
+  upgradeSelf,
+} from '../self'
 import { pc } from '../utils/color'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
-import { compareVersions, isVersionNewer } from '../utils/version'
+import { compareVersions } from '../utils/version'
 
 interface UpgradeCommandData {
   canAutoUpdate: boolean
@@ -20,15 +25,13 @@ interface UpgradeCommandData {
 export async function upgradeCommand(
   options: { channel?: SelfUpdateChannel; check?: boolean } = {},
 ): Promise<CommandResult<UpgradeCommandData>> {
-  const inspection = await inspectSelf({ updateChannel: options.channel })
+  const plan = await planSelfUpgrade({ updateChannel: options.channel })
+  const inspection = buildSelfInspectionFromPlan(plan)
   const dryRun = isDryRunEnabled()
   const registryWarnings = getManagedRegistryWarnings(inspection)
   const staleLatestWarning = getStaleLatestWarning(inspection)
-  const updateAvailable = inspection.latestVersion
-    ? isVersionNewer(inspection.latestVersion, inspection.currentVersion)
-    : false
 
-  if (inspection.latestVersion && !updateAvailable) {
+  if (plan.status === 'up-to-date') {
     return emitCommandResult(
       createSuccessResult<UpgradeCommandData>({
         action: 'upgrade',
@@ -51,7 +54,7 @@ export async function upgradeCommand(
   }
 
   if (options.check || dryRun) {
-    if (inspection.latestVersion) {
+    if (plan.status === 'update-available') {
       return emitCommandResult(
         createSuccessResult<UpgradeCommandData>({
           action: 'upgrade',
@@ -109,7 +112,7 @@ export async function upgradeCommand(
     )
   }
 
-  if (!inspection.canAutoUpdate) {
+  if (plan.status === 'manual-required') {
     const manualCommand = getSelfUpgradeRecoveryHintForInspection(inspection)
     return emitCommandResult(
       createErrorResult<UpgradeCommandData>({
@@ -137,7 +140,7 @@ export async function upgradeCommand(
     )
   }
 
-  const result = await upgradeSelf(inspection)
+  const result = await upgradeSelf(plan)
   if (result.success) {
     return emitCommandResult(
       createSuccessResult<UpgradeCommandData>({
@@ -259,7 +262,7 @@ function renderUpgradeHuman(result: {
   for (const warning of result.warnings) printWarn(pc.cyan(warning.message.replace(/^Manual recovery:/, 'Next step:')))
 }
 
-function getManagedRegistryWarnings(inspection: Awaited<ReturnType<typeof inspectSelf>>): CommandWarning[] {
+function getManagedRegistryWarnings(inspection: SelfInspection): CommandWarning[] {
   if (!inspection.latestVersion || !inspection.upstreamLatestVersion) return []
   if (inspection.latestVersion === inspection.upstreamLatestVersion) return []
   if (inspection.installSource !== 'bun' && inspection.installSource !== 'npm') return []
@@ -283,7 +286,7 @@ function renderInformationalWarnings(warnings: CommandWarning[]): void {
   }
 }
 
-function getStaleLatestWarning(inspection: Awaited<ReturnType<typeof inspectSelf>>): CommandWarning | undefined {
+function getStaleLatestWarning(inspection: SelfInspection): CommandWarning | undefined {
   if (!inspection.latestVersion) return undefined
 
   const comparison = compareVersions(inspection.latestVersion, inspection.currentVersion)

--- a/src/self/facts.ts
+++ b/src/self/facts.ts
@@ -1,0 +1,128 @@
+import type { SelfInstallFacts, SelfInstallSource, SelfPackageMetadata, SelfUpdateChannel } from './types'
+import { readFile } from 'node:fs/promises'
+import { basename, dirname, join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { loadConfig } from '../config'
+import { BUILD_PACKAGE_NAME, BUILD_VERSION } from '../generated/build-meta'
+import { getSelfState, setSelfInstallSource } from '../state'
+import { getSelfUpdateChannel } from './release'
+
+const CLI_NPM_PACKAGE_NAME = BUILD_PACKAGE_NAME
+const BUN_GLOBAL_PATH_SEGMENT = '/.bun/install/global/'
+const NODE_MODULES_SEGMENT = `/node_modules/${CLI_NPM_PACKAGE_NAME}`
+
+export async function resolveSelfInstallFacts(options?: {
+  updateChannel?: SelfUpdateChannel
+}): Promise<SelfInstallFacts> {
+  const metadata = await resolveSelfPackageMetadata()
+  const executablePath = process.execPath
+  const detectedInstallSource = metadata.foundPackageJson
+    ? detectSelfInstallSource(metadata.packageRoot)
+    : detectSelfInstallSource('', executablePath)
+  const state = await getSelfState()
+  const installSource = await reconcileSelfInstallSource(state.installSource, detectedInstallSource)
+  const config = await loadConfig()
+  const updateChannel = getSelfUpdateChannel(options?.updateChannel, config.selfUpdateChannel)
+
+  return {
+    canAutoUpdate: canAutoUpdateSelf(installSource),
+    currentVersion: metadata.version || BUILD_VERSION,
+    executablePath,
+    installSource,
+    packageRoot: metadata.packageRoot,
+    updateChannel,
+  }
+}
+
+export function canAutoUpdateSelf(installSource: SelfInstallSource): boolean {
+  return installSource === 'binary' || installSource === 'bun' || installSource === 'npm'
+}
+
+export async function reconcileSelfInstallSource(
+  storedInstallSource: SelfInstallSource | undefined,
+  detectedInstallSource: SelfInstallSource,
+): Promise<SelfInstallSource> {
+  if (detectedInstallSource !== 'unknown' && storedInstallSource !== detectedInstallSource) {
+    await setSelfInstallSource(detectedInstallSource)
+    return detectedInstallSource
+  }
+
+  return storedInstallSource ?? detectedInstallSource
+}
+
+export function detectSelfInstallSource(
+  packageRoot: string,
+  executablePath: string = process.execPath,
+): SelfInstallSource {
+  const normalizedPath = normalizePath(packageRoot)
+
+  if (normalizedPath.includes(BUN_GLOBAL_PATH_SEGMENT)) return 'bun'
+
+  if (normalizedPath.includes(NODE_MODULES_SEGMENT)) return 'npm'
+
+  if (normalizedPath) return 'source'
+
+  if (isStandaloneBinaryExecutable(executablePath)) return 'binary'
+
+  return 'unknown'
+}
+
+export async function resolveSelfPackageMetadata(moduleUrl: string = import.meta.url): Promise<SelfPackageMetadata> {
+  const modulePath = resolveModulePath(moduleUrl)
+  let currentDir = dirname(modulePath)
+
+  while (true) {
+    const packageJsonPath = join(currentDir, 'package.json')
+    const packageJson = await readPackageJson(packageJsonPath)
+
+    if (packageJson?.name === CLI_NPM_PACKAGE_NAME) {
+      return {
+        foundPackageJson: true,
+        packageJsonPath,
+        packageRoot: currentDir,
+        version: packageJson.version ?? BUILD_VERSION,
+      }
+    }
+
+    const parentDir = dirname(currentDir)
+    if (parentDir === currentDir) break
+    currentDir = parentDir
+  }
+
+  return {
+    foundPackageJson: false,
+    packageJsonPath: join(dirname(modulePath), 'package.json'),
+    packageRoot: dirname(modulePath),
+    version: BUILD_VERSION,
+  }
+}
+
+export function getSelfVersion(): string {
+  return BUILD_VERSION
+}
+
+async function readPackageJson(packageJsonPath: string): Promise<{ name?: string; version?: string } | undefined> {
+  try {
+    return JSON.parse(await readFile(packageJsonPath, 'utf8')) as { name?: string; version?: string }
+  } catch {
+    return undefined
+  }
+}
+
+function normalizePath(path: string): string {
+  return path.replaceAll('\\', '/').toLowerCase()
+}
+
+function isStandaloneBinaryExecutable(executablePath: string): boolean {
+  const executableName = basename(normalizePath(executablePath))
+  return executableName !== 'bun' && executableName !== 'bun.exe'
+}
+
+function resolveModulePath(moduleUrl: string): string {
+  try {
+    return fileURLToPath(moduleUrl)
+  } catch {
+    return process.execPath
+  }
+}

--- a/src/self/index.ts
+++ b/src/self/index.ts
@@ -4,55 +4,33 @@ import type {
   SelfPackageMetadata,
   SelfUpdateChannel,
   SelfUpdateResult,
+  SelfUpgradePlan,
 } from './types'
-import { readFile } from 'node:fs/promises'
-import { basename, dirname, join } from 'node:path'
 import process from 'node:process'
-import { fileURLToPath } from 'node:url'
-import { loadConfig } from '../config'
-import { BUILD_PACKAGE_NAME, BUILD_VERSION } from '../generated/build-meta'
-import { getSelfState, setSelfInstallSource } from '../state'
-import { OFFICIAL_NPM_REGISTRY } from '../utils/registry'
-import { getInstalledVersion, getLatestVersion } from '../utils/version'
+import {
+  canAutoUpdateSelf,
+  detectSelfInstallSource,
+  getSelfVersion,
+  reconcileSelfInstallSource,
+  resolveSelfInstallFacts,
+  resolveSelfPackageMetadata,
+} from './facts'
 import { acquireSelfUpgradeLock } from './lock'
+import {
+  buildPlanFromInspection,
+  buildSelfInspectionFromPlan,
+  planSelfUpgrade,
+  verifySelfUpgradeResult,
+} from './planning'
 import { getSelfUpgradeProvider } from './providers'
 import { getSelfUpgradeRecoveryHint } from './recovery'
-import { resolveManagedSelfUpdateRegistry } from './registry'
-import { fetchBinaryReleaseManifest, getSelfUpdateChannel, resolveBinaryReleaseAsset } from './release'
-
-const CLI_NPM_PACKAGE_NAME = BUILD_PACKAGE_NAME
-const BUN_GLOBAL_PATH_SEGMENT = '/.bun/install/global/'
-const NODE_MODULES_SEGMENT = `/node_modules/${CLI_NPM_PACKAGE_NAME}`
 
 export async function inspectSelf(options?: { updateChannel?: SelfUpdateChannel }): Promise<SelfInspection> {
-  const metadata = await resolveSelfPackageMetadata()
-  const executablePath = process.execPath
-  const detectedInstallSource = metadata.foundPackageJson
-    ? detectSelfInstallSource(metadata.packageRoot)
-    : detectSelfInstallSource('', executablePath)
-  const state = await getSelfState()
-  const installSource = await reconcileSelfInstallSource(state.installSource, detectedInstallSource)
-  const config = await loadConfig()
-  const updateChannel = getSelfUpdateChannel(options?.updateChannel, config.selfUpdateChannel)
-  const latestVersionState = await resolveSelfLatestVersion(installSource, executablePath, updateChannel, config)
-
-  return {
-    canAutoUpdate: canAutoUpdateSelf(installSource),
-    currentVersion: metadata.version || BUILD_VERSION,
-    executablePath,
-    installSource,
-    latestVersion: latestVersionState.installableLatestVersion,
-    managedRegistry: latestVersionState.managedRegistry,
-    managedRegistryIsOverride: latestVersionState.managedRegistryIsOverride,
-    packageRoot: metadata.packageRoot,
-    recommendedUpgradeCommand: canAutoUpdateSelf(installSource) ? 'quantex upgrade' : undefined,
-    upstreamLatestVersion: latestVersionState.upstreamLatestVersion,
-    updateChannel,
-  }
+  return buildSelfInspectionFromPlan(await planSelfUpgrade({ updateChannel: options?.updateChannel }))
 }
 
-export async function upgradeSelf(inspection?: SelfInspection): Promise<SelfUpdateResult> {
-  const resolvedInspection = inspection ?? (await inspectSelf())
+export async function upgradeSelf(planOrInspection?: SelfInspection | SelfUpgradePlan): Promise<SelfUpdateResult> {
+  const resolvedPlan = await coerceSelfUpgradePlan(planOrInspection)
   const releaseLock = await acquireSelfUpgradeLock()
 
   if (!releaseLock) {
@@ -61,84 +39,17 @@ export async function upgradeSelf(inspection?: SelfInspection): Promise<SelfUpda
         kind: 'locked',
         message: 'Another qtx upgrade is already running.',
       },
-      installSource: resolvedInspection.installSource,
+      installSource: resolvedPlan.facts.installSource,
       success: false,
     }
   }
 
   try {
-    const result = await getSelfUpgradeProvider(resolvedInspection).upgrade(resolvedInspection)
-    return verifyManagedSelfUpgradeResult(resolvedInspection, result)
+    const result = await getSelfUpgradeProvider(resolvedPlan).upgrade(resolvedPlan)
+    return verifySelfUpgradeResult(resolvedPlan, result)
   } finally {
     await releaseLock()
   }
-}
-
-export function canAutoUpdateSelf(installSource: SelfInstallSource): boolean {
-  return installSource === 'binary' || installSource === 'bun' || installSource === 'npm'
-}
-
-export async function reconcileSelfInstallSource(
-  storedInstallSource: SelfInstallSource | undefined,
-  detectedInstallSource: SelfInstallSource,
-): Promise<SelfInstallSource> {
-  if (detectedInstallSource !== 'unknown' && storedInstallSource !== detectedInstallSource) {
-    await setSelfInstallSource(detectedInstallSource)
-    return detectedInstallSource
-  }
-
-  return storedInstallSource ?? detectedInstallSource
-}
-
-export function detectSelfInstallSource(
-  packageRoot: string,
-  executablePath: string = process.execPath,
-): SelfInstallSource {
-  const normalizedPath = normalizePath(packageRoot)
-
-  if (normalizedPath.includes(BUN_GLOBAL_PATH_SEGMENT)) return 'bun'
-
-  if (normalizedPath.includes(NODE_MODULES_SEGMENT)) return 'npm'
-
-  if (normalizedPath) return 'source'
-
-  if (isStandaloneBinaryExecutable(executablePath)) return 'binary'
-
-  return 'unknown'
-}
-
-export async function resolveSelfPackageMetadata(moduleUrl: string = import.meta.url): Promise<SelfPackageMetadata> {
-  const modulePath = resolveModulePath(moduleUrl)
-  let currentDir = dirname(modulePath)
-
-  while (true) {
-    const packageJsonPath = join(currentDir, 'package.json')
-    const packageJson = await readPackageJson(packageJsonPath)
-
-    if (packageJson?.name === CLI_NPM_PACKAGE_NAME) {
-      return {
-        foundPackageJson: true,
-        packageJsonPath,
-        packageRoot: currentDir,
-        version: packageJson.version ?? BUILD_VERSION,
-      }
-    }
-
-    const parentDir = dirname(currentDir)
-    if (parentDir === currentDir) break
-    currentDir = parentDir
-  }
-
-  return {
-    foundPackageJson: false,
-    packageJsonPath: join(dirname(modulePath), 'package.json'),
-    packageRoot: dirname(modulePath),
-    version: BUILD_VERSION,
-  }
-}
-
-export function getSelfVersion(): string {
-  return BUILD_VERSION
 }
 
 export function getManualSelfUpgradeCommand(
@@ -148,154 +59,40 @@ export function getManualSelfUpgradeCommand(
   return getSelfUpgradeRecoveryHint(installSource, executablePath)
 }
 
-async function resolveSelfLatestVersion(
-  installSource: SelfInstallSource,
-  executablePath: string,
-  updateChannel: SelfUpdateChannel,
-  config: Awaited<ReturnType<typeof loadConfig>>,
-): Promise<{
-  installableLatestVersion?: string
-  managedRegistry?: string
-  managedRegistryIsOverride?: boolean
-  upstreamLatestVersion?: string
-}> {
-  if (installSource === 'binary') {
-    try {
-      const manifest = await fetchBinaryReleaseManifest(updateChannel)
-      const asset = resolveBinaryReleaseAsset(manifest, executablePath)
-      return {
-        installableLatestVersion: asset ? manifest.version : undefined,
-      }
-    } catch {
-      return {}
-    }
-  }
-
-  const distTag = updateChannel === 'beta' ? 'beta' : 'latest'
-  const upstreamLatestVersion = await getLatestVersion(CLI_NPM_PACKAGE_NAME, distTag, {
-    registry: OFFICIAL_NPM_REGISTRY,
-  })
-
-  if (installSource === 'bun' || installSource === 'npm') {
-    const managedRegistry = await resolveManagedSelfUpdateRegistry(installSource, config)
-    return {
-      installableLatestVersion: await getLatestVersion(CLI_NPM_PACKAGE_NAME, distTag, {
-        registry: managedRegistry?.registry,
-      }),
-      managedRegistry: managedRegistry?.registry,
-      managedRegistryIsOverride: managedRegistry?.isOverride ?? false,
-      upstreamLatestVersion,
-    }
-  }
-
-  return {
-    installableLatestVersion: upstreamLatestVersion,
-    upstreamLatestVersion,
-  }
-}
-
-async function verifyManagedSelfUpgradeResult(
-  inspection: SelfInspection,
-  result: SelfUpdateResult,
-): Promise<SelfUpdateResult> {
-  if (!result.success) return result
-
-  if (inspection.installSource !== 'bun' && inspection.installSource !== 'npm') return result
-
-  const observedVersion = await getManagedInstalledSelfVersion(inspection)
-  if (!observedVersion) {
-    return {
-      error: {
-        kind: 'verify',
-        message: 'Managed self-upgrade finished but Quantex could not verify the installed version afterwards.',
+async function coerceSelfUpgradePlan(planOrInspection?: SelfInspection | SelfUpgradePlan): Promise<SelfUpgradePlan> {
+  if (!planOrInspection) return planSelfUpgrade()
+  if ('facts' in planOrInspection) return planOrInspection
+  if (planOrInspection.installSource === 'binary') {
+    return planSelfUpgrade({
+      facts: {
+        canAutoUpdate: planOrInspection.canAutoUpdate,
+        currentVersion: planOrInspection.currentVersion,
+        executablePath: planOrInspection.executablePath,
+        installSource: planOrInspection.installSource,
+        packageRoot: planOrInspection.packageRoot,
+        updateChannel: planOrInspection.updateChannel,
       },
-      installSource: inspection.installSource,
-      success: false,
-    }
-  }
-
-  const expectedVersion = result.newVersion ?? inspection.latestVersion
-  if (expectedVersion && observedVersion !== expectedVersion) {
-    return {
-      error: {
-        detail: {
-          expectedVersion,
-          observedVersion,
-        },
-        kind: 'verify',
-        message: `Managed self-upgrade installed version ${observedVersion}, but expected ${expectedVersion}.`,
-      },
-      installSource: inspection.installSource,
-      success: false,
-    }
-  }
-
-  if (!expectedVersion && observedVersion === inspection.currentVersion && inspection.latestVersion !== undefined) {
-    return {
-      error: {
-        detail: {
-          observedVersion,
-        },
-        kind: 'verify',
-        message: 'Managed self-upgrade completed without changing the installed Quantex version.',
-      },
-      installSource: inspection.installSource,
-      success: false,
-    }
-  }
-
-  return {
-    ...result,
-    newVersion: observedVersion,
-  }
-}
-
-async function getManagedInstalledSelfVersion(inspection: SelfInspection): Promise<string | undefined> {
-  const managedVersionProbe = getManagedSelfVersionProbeCommand(inspection.packageRoot)
-
-  if (managedVersionProbe) {
-    const managedVersion = await getInstalledVersion(inspection.executablePath, {
-      command: managedVersionProbe,
     })
-
-    if (managedVersion) return managedVersion
   }
-
-  return getInstalledVersion(inspection.executablePath)
-}
-
-function getManagedSelfVersionProbeCommand(packageRoot: string): string[] | undefined {
-  if (!packageRoot) return undefined
-
-  return [process.execPath, join(packageRoot, 'dist', 'cli.mjs'), '--version']
-}
-
-async function readPackageJson(packageJsonPath: string): Promise<{ name?: string; version?: string } | undefined> {
-  try {
-    return JSON.parse(await readFile(packageJsonPath, 'utf8')) as { name?: string; version?: string }
-  } catch {
-    return undefined
-  }
-}
-
-function normalizePath(path: string): string {
-  return path.replaceAll('\\', '/').toLowerCase()
-}
-
-function isStandaloneBinaryExecutable(executablePath: string): boolean {
-  const executableName = basename(normalizePath(executablePath))
-  return executableName !== 'bun' && executableName !== 'bun.exe'
-}
-
-function resolveModulePath(moduleUrl: string): string {
-  try {
-    return fileURLToPath(moduleUrl)
-  } catch {
-    return process.execPath
-  }
+  return buildPlanFromInspection(planOrInspection)
 }
 
 export { acquireSelfUpgradeLock, getSelfUpgradeLockPath } from './lock'
+export {
+  canAutoUpdateSelf,
+  detectSelfInstallSource,
+  getSelfVersion,
+  reconcileSelfInstallSource,
+  resolveSelfInstallFacts,
+  resolveSelfPackageMetadata,
+} from './facts'
+export {
+  buildPlanFromInspection,
+  buildSelfInspectionFromPlan,
+  isResolvedLatestBehindCurrent,
+  planSelfUpgrade,
+  resolveSelfUpdateTarget,
+} from './planning'
 export { resolveManagedSelfUpdateRegistry } from './registry'
 export { getSelfUpgradeRecoveryHint, getSelfUpgradeRecoveryHintForInspection } from './recovery'
 export {
@@ -312,8 +109,12 @@ export {
 } from './release'
 export type {
   SelfInspection,
+  SelfInstallFacts,
   SelfInstallSource,
   SelfPackageMetadata,
   SelfUpdateChannel,
   SelfUpdateResult,
+  SelfUpdateTarget,
+  SelfUpgradePlan,
+  SelfUpgradePlanStatus,
 } from './types'

--- a/src/self/planning.ts
+++ b/src/self/planning.ts
@@ -1,0 +1,224 @@
+import type { SelfInspection, SelfInstallFacts, SelfUpdateResult, SelfUpdateTarget, SelfUpgradePlan } from './types'
+import { join } from 'node:path'
+import process from 'node:process'
+import { loadConfig } from '../config'
+import { BUILD_PACKAGE_NAME } from '../generated/build-meta'
+import { OFFICIAL_NPM_REGISTRY } from '../utils/registry'
+import { compareVersions, getInstalledVersion, getLatestVersion, isVersionNewer } from '../utils/version'
+import { resolveSelfInstallFacts } from './facts'
+import { resolveManagedSelfUpdateRegistry } from './registry'
+import { fetchBinaryReleaseManifest, resolveBinaryReleaseAsset } from './release'
+
+export async function resolveSelfUpdateTarget(facts: SelfInstallFacts): Promise<SelfUpdateTarget> {
+  const config = await loadConfig()
+
+  if (facts.installSource === 'binary') {
+    try {
+      const manifest = await fetchBinaryReleaseManifest(facts.updateChannel)
+      const asset = resolveBinaryReleaseAsset(manifest, facts.executablePath)
+
+      if (!asset) {
+        return {
+          resolutionError: {
+            detail: {
+              channel: facts.updateChannel,
+            },
+            kind: 'unsupported',
+            message: `No binary asset is available for the current platform on the ${facts.updateChannel} channel.`,
+          },
+        }
+      }
+
+      return {
+        binaryAsset: asset,
+        targetVersion: manifest.version,
+      }
+    } catch {
+      return {
+        resolutionError: {
+          kind: 'network',
+          message: `Failed to resolve the ${facts.updateChannel} release manifest.`,
+        },
+      }
+    }
+  }
+
+  const packageTag = facts.updateChannel === 'beta' ? 'beta' : 'latest'
+  const upstreamLatestVersion = await getLatestVersion(BUILD_PACKAGE_NAME, packageTag, {
+    registry: OFFICIAL_NPM_REGISTRY,
+  })
+
+  if (facts.installSource === 'bun' || facts.installSource === 'npm') {
+    const managedRegistry = await resolveManagedSelfUpdateRegistry(facts.installSource, config)
+
+    return {
+      managedRegistry: managedRegistry?.registry,
+      managedRegistryIsOverride: managedRegistry?.isOverride ?? false,
+      packageTag,
+      targetVersion: await getLatestVersion(BUILD_PACKAGE_NAME, packageTag, {
+        registry: managedRegistry?.registry,
+      }),
+      upstreamLatestVersion,
+      verificationCommand: getManagedSelfVersionProbeCommand(facts.packageRoot),
+    }
+  }
+
+  return {
+    packageTag,
+    targetVersion: upstreamLatestVersion,
+    upstreamLatestVersion,
+  }
+}
+
+export async function planSelfUpgrade(options?: {
+  facts?: SelfInstallFacts
+  target?: SelfUpdateTarget
+  updateChannel?: SelfInstallFacts['updateChannel']
+}): Promise<SelfUpgradePlan> {
+  const facts = options?.facts ?? (await resolveSelfInstallFacts({ updateChannel: options?.updateChannel }))
+  const target = options?.target ?? (await resolveSelfUpdateTarget(facts))
+  const updateAvailable = target.targetVersion ? isVersionNewer(target.targetVersion, facts.currentVersion) : false
+
+  return {
+    facts,
+    status: resolveSelfUpgradePlanStatus(facts, target, updateAvailable),
+    target,
+    updateAvailable,
+  }
+}
+
+export function buildSelfInspectionFromPlan(plan: SelfUpgradePlan): SelfInspection {
+  return {
+    canAutoUpdate: plan.facts.canAutoUpdate,
+    currentVersion: plan.facts.currentVersion,
+    executablePath: plan.facts.executablePath,
+    installSource: plan.facts.installSource,
+    latestVersion: plan.target.targetVersion,
+    managedRegistry: plan.target.managedRegistry,
+    managedRegistryIsOverride: plan.target.managedRegistryIsOverride,
+    packageRoot: plan.facts.packageRoot,
+    recommendedUpgradeCommand: plan.facts.canAutoUpdate ? 'quantex upgrade' : undefined,
+    upstreamLatestVersion: plan.target.upstreamLatestVersion,
+    updateChannel: plan.facts.updateChannel,
+  }
+}
+
+export async function verifySelfUpgradeResult(
+  plan: SelfUpgradePlan,
+  result: SelfUpdateResult,
+): Promise<SelfUpdateResult> {
+  if (!result.success) return result
+
+  if (plan.facts.installSource !== 'bun' && plan.facts.installSource !== 'npm') return result
+
+  const observedVersion = await getInstalledSelfVersion(plan)
+  if (!observedVersion) {
+    return {
+      error: {
+        kind: 'verify',
+        message: 'Managed self-upgrade finished but Quantex could not verify the installed version afterwards.',
+      },
+      installSource: plan.facts.installSource,
+      success: false,
+    }
+  }
+
+  const expectedVersion = result.newVersion ?? plan.target.targetVersion
+  if (expectedVersion && observedVersion !== expectedVersion) {
+    return {
+      error: {
+        detail: {
+          expectedVersion,
+          observedVersion,
+        },
+        kind: 'verify',
+        message: `Managed self-upgrade installed version ${observedVersion}, but expected ${expectedVersion}.`,
+      },
+      installSource: plan.facts.installSource,
+      success: false,
+    }
+  }
+
+  if (!expectedVersion && observedVersion === plan.facts.currentVersion && plan.target.targetVersion !== undefined) {
+    return {
+      error: {
+        detail: {
+          observedVersion,
+        },
+        kind: 'verify',
+        message: 'Managed self-upgrade completed without changing the installed Quantex version.',
+      },
+      installSource: plan.facts.installSource,
+      success: false,
+    }
+  }
+
+  return {
+    ...result,
+    newVersion: observedVersion,
+  }
+}
+
+export function buildPlanFromInspection(inspection: SelfInspection): SelfUpgradePlan {
+  const facts: SelfInstallFacts = {
+    canAutoUpdate: inspection.canAutoUpdate,
+    currentVersion: inspection.currentVersion,
+    executablePath: inspection.executablePath,
+    installSource: inspection.installSource,
+    packageRoot: inspection.packageRoot,
+    updateChannel: inspection.updateChannel,
+  }
+  const target: SelfUpdateTarget = {
+    managedRegistry: inspection.managedRegistry,
+    managedRegistryIsOverride: inspection.managedRegistryIsOverride,
+    packageTag: inspection.updateChannel === 'beta' ? 'beta' : 'latest',
+    targetVersion: inspection.latestVersion,
+    upstreamLatestVersion: inspection.upstreamLatestVersion,
+    verificationCommand: getManagedSelfVersionProbeCommand(inspection.packageRoot),
+  }
+  const updateAvailable = inspection.latestVersion
+    ? isVersionNewer(inspection.latestVersion, inspection.currentVersion)
+    : false
+
+  return {
+    facts,
+    status: resolveSelfUpgradePlanStatus(facts, target, updateAvailable),
+    target,
+    updateAvailable,
+  }
+}
+
+export function isResolvedLatestBehindCurrent(plan: SelfUpgradePlan): boolean {
+  return plan.target.targetVersion
+    ? compareVersions(plan.target.targetVersion, plan.facts.currentVersion) === -1
+    : false
+}
+
+function resolveSelfUpgradePlanStatus(
+  facts: SelfInstallFacts,
+  target: SelfUpdateTarget,
+  updateAvailable: boolean,
+): SelfUpgradePlan['status'] {
+  if (!facts.canAutoUpdate) return 'manual-required'
+  if (target.targetVersion && !updateAvailable) return 'up-to-date'
+  if (target.targetVersion) return 'update-available'
+  return 'check-unavailable'
+}
+
+async function getInstalledSelfVersion(plan: SelfUpgradePlan): Promise<string | undefined> {
+  if (plan.target.verificationCommand) {
+    const managedVersion = await getInstalledVersion(plan.facts.executablePath, {
+      command: plan.target.verificationCommand,
+    })
+
+    if (managedVersion) return managedVersion
+  }
+
+  return getInstalledVersion(plan.facts.executablePath)
+}
+
+function getManagedSelfVersionProbeCommand(packageRoot: string): string[] | undefined {
+  if (!packageRoot) return undefined
+
+  return [process.execPath, join(packageRoot, 'dist', 'cli.mjs'), '--version']
+}

--- a/src/self/providers/binary.ts
+++ b/src/self/providers/binary.ts
@@ -1,16 +1,11 @@
-import type { SelfInspection, SelfUpdateResult } from '../types'
+import type { SelfInspection, SelfUpdateResult, SelfUpgradePlan } from '../types'
 import type { SelfUpgradeProvider } from './types'
 import { upgradeStandaloneBinary } from '../binary'
-import {
-  fetchBinaryReleaseManifest,
-  getBinaryReleaseAssetName,
-  getBinaryReleaseDownloadUrl,
-  resolveBinaryReleaseAsset,
-} from '../release'
+import { getBinaryReleaseDownloadUrl } from '../release'
 
 export const binarySelfUpgradeProvider: SelfUpgradeProvider = {
   source: 'binary',
-  canHandle: inspection => inspection.installSource === 'binary',
+  canHandle: context => getInstallSource(context) === 'binary',
   getRecoveryHint: (inspection, result) => {
     const downloadUrl =
       result?.error?.detail &&
@@ -32,56 +27,25 @@ export const binarySelfUpgradeProvider: SelfUpgradeProvider = {
 
     return `download and replace the binary from ${downloadUrl}`
   },
-  async upgrade(inspection: SelfInspection): Promise<SelfUpdateResult> {
-    const assetName = getBinaryReleaseAssetName(inspection.executablePath)
-
-    if (!assetName) {
-      return {
-        error: {
-          kind: 'unsupported',
-          message: 'No release artifact is available for the current platform and architecture.',
-        },
-        installSource: inspection.installSource,
-        success: false,
-      }
-    }
-
-    let manifest
-    try {
-      manifest = await fetchBinaryReleaseManifest(inspection.updateChannel)
-    } catch (error) {
-      return {
-        error: {
-          detail: error,
-          kind: 'network',
-          message: `Failed to resolve the ${inspection.updateChannel} release manifest.`,
-        },
-        installSource: inspection.installSource,
-        success: false,
-      }
-    }
-
-    const asset = resolveBinaryReleaseAsset(manifest, inspection.executablePath)
+  async upgrade(plan: SelfUpgradePlan): Promise<SelfUpdateResult> {
+    const asset = plan.target.binaryAsset
 
     if (!asset) {
       return {
-        error: {
-          detail: {
-            channel: inspection.updateChannel,
-          },
+        error: plan.target.resolutionError ?? {
           kind: 'unsupported',
-          message: `No binary asset is available for the current platform on the ${inspection.updateChannel} channel.`,
+          message: 'No release artifact is available for the current platform and architecture.',
         },
-        installSource: inspection.installSource,
+        installSource: plan.facts.installSource,
         success: false,
       }
     }
 
     const result = await upgradeStandaloneBinary(
       asset.downloadUrl,
-      inspection.executablePath,
+      plan.facts.executablePath,
       asset.checksum,
-      manifest.version,
+      plan.target.targetVersion ?? 'latest',
     )
 
     const enrichedResult =
@@ -102,8 +66,12 @@ export const binarySelfUpgradeProvider: SelfUpgradeProvider = {
 
     return {
       ...enrichedResult,
-      installSource: inspection.installSource,
-      newVersion: result.success ? manifest.version : undefined,
+      installSource: plan.facts.installSource,
+      newVersion: result.success ? plan.target.targetVersion : undefined,
     }
   },
+}
+
+function getInstallSource(context: SelfInspection | SelfUpgradePlan): string {
+  return 'facts' in context ? context.facts.installSource : context.installSource
 }

--- a/src/self/providers/bun.ts
+++ b/src/self/providers/bun.ts
@@ -1,18 +1,18 @@
-import type { SelfInspection, SelfUpdateResult } from '../types'
+import type { SelfInspection, SelfUpdateResult, SelfUpgradePlan } from '../types'
 import type { SelfUpgradeProvider } from './types'
 import { BUILD_PACKAGE_NAME } from '../../generated/build-meta'
 import * as bunPm from '../../package-manager/bun'
 
 export const bunSelfUpgradeProvider: SelfUpgradeProvider = {
   source: 'bun',
-  canHandle: inspection => inspection.installSource === 'bun',
+  canHandle: context => getInstallSource(context) === 'bun',
   getRecoveryHint: inspection =>
     `bun add -g ${BUILD_PACKAGE_NAME}@${inspection.updateChannel === 'beta' ? 'beta' : 'latest'}`,
-  async upgrade(inspection: SelfInspection): Promise<SelfUpdateResult> {
+  async upgrade(plan: SelfUpgradePlan): Promise<SelfUpdateResult> {
     const success = await bunPm.install(
       BUILD_PACKAGE_NAME,
-      inspection.updateChannel === 'beta' ? 'beta' : 'latest',
-      inspection.managedRegistry,
+      plan.target.packageTag ?? (plan.facts.updateChannel === 'beta' ? 'beta' : 'latest'),
+      plan.target.managedRegistry,
     )
     return {
       error: success
@@ -21,9 +21,13 @@ export const bunSelfUpgradeProvider: SelfUpgradeProvider = {
             kind: 'unknown',
             message: `Failed to update ${BUILD_PACKAGE_NAME} through Bun.`,
           },
-      installSource: inspection.installSource,
-      newVersion: success ? inspection.latestVersion : undefined,
+      installSource: plan.facts.installSource,
+      newVersion: success ? plan.target.targetVersion : undefined,
       success,
     }
   },
+}
+
+function getInstallSource(context: SelfInspection | SelfUpgradePlan): string {
+  return 'facts' in context ? context.facts.installSource : context.installSource
 }

--- a/src/self/providers/index.ts
+++ b/src/self/providers/index.ts
@@ -1,4 +1,4 @@
-import type { SelfInspection, SelfInstallSource, SelfUpdateChannel } from '../types'
+import type { SelfInspection, SelfInstallSource, SelfUpdateChannel, SelfUpgradePlan } from '../types'
 import type { SelfUpgradeProvider } from './types'
 import { binarySelfUpgradeProvider } from './binary'
 import { bunSelfUpgradeProvider } from './bun'
@@ -12,8 +12,8 @@ const selfUpgradeProviders: SelfUpgradeProvider[] = [
   sourceSelfUpgradeProvider,
 ]
 
-export function getSelfUpgradeProvider(inspection: SelfInspection): SelfUpgradeProvider {
-  return selfUpgradeProviders.find(provider => provider.canHandle(inspection)) ?? sourceSelfUpgradeProvider
+export function getSelfUpgradeProvider(context: SelfInspection | SelfUpgradePlan): SelfUpgradeProvider {
+  return selfUpgradeProviders.find(provider => provider.canHandle(context)) ?? sourceSelfUpgradeProvider
 }
 
 export function getSelfUpgradeProviderForInstallSource(

--- a/src/self/providers/npm.ts
+++ b/src/self/providers/npm.ts
@@ -1,18 +1,18 @@
-import type { SelfInspection, SelfUpdateResult } from '../types'
+import type { SelfInspection, SelfUpdateResult, SelfUpgradePlan } from '../types'
 import type { SelfUpgradeProvider } from './types'
 import { BUILD_PACKAGE_NAME } from '../../generated/build-meta'
 import * as npmPm from '../../package-manager/npm'
 
 export const npmSelfUpgradeProvider: SelfUpgradeProvider = {
   source: 'npm',
-  canHandle: inspection => inspection.installSource === 'npm',
+  canHandle: context => getInstallSource(context) === 'npm',
   getRecoveryHint: inspection =>
     `npm install -g ${BUILD_PACKAGE_NAME}@${inspection.updateChannel === 'beta' ? 'beta' : 'latest'}`,
-  async upgrade(inspection: SelfInspection): Promise<SelfUpdateResult> {
+  async upgrade(plan: SelfUpgradePlan): Promise<SelfUpdateResult> {
     const success = await npmPm.install(
       BUILD_PACKAGE_NAME,
-      inspection.updateChannel === 'beta' ? 'beta' : 'latest',
-      inspection.managedRegistry,
+      plan.target.packageTag ?? (plan.facts.updateChannel === 'beta' ? 'beta' : 'latest'),
+      plan.target.managedRegistry,
     )
     return {
       error: success
@@ -21,9 +21,13 @@ export const npmSelfUpgradeProvider: SelfUpgradeProvider = {
             kind: 'unknown',
             message: `Failed to update ${BUILD_PACKAGE_NAME} through npm.`,
           },
-      installSource: inspection.installSource,
-      newVersion: success ? inspection.latestVersion : undefined,
+      installSource: plan.facts.installSource,
+      newVersion: success ? plan.target.targetVersion : undefined,
       success,
     }
   },
+}
+
+function getInstallSource(context: SelfInspection | SelfUpgradePlan): string {
+  return 'facts' in context ? context.facts.installSource : context.installSource
 }

--- a/src/self/providers/source.ts
+++ b/src/self/providers/source.ts
@@ -1,17 +1,20 @@
-import type { SelfInspection, SelfUpdateResult } from '../types'
+import type { SelfUpdateResult, SelfUpgradePlan } from '../types'
 import type { SelfUpgradeProvider } from './types'
 
 export const sourceSelfUpgradeProvider: SelfUpgradeProvider = {
   source: 'source',
-  canHandle: inspection => inspection.installSource === 'source' || inspection.installSource === 'unknown',
+  canHandle: context => {
+    const installSource = 'facts' in context ? context.facts.installSource : context.installSource
+    return installSource === 'source' || installSource === 'unknown'
+  },
   getRecoveryHint: () => undefined,
-  async upgrade(inspection: SelfInspection): Promise<SelfUpdateResult> {
+  async upgrade(plan: SelfUpgradePlan): Promise<SelfUpdateResult> {
     return {
       error: {
         kind: 'unsupported',
-        message: `Install source "${inspection.installSource}" does not support auto-update.`,
+        message: `Install source "${plan.facts.installSource}" does not support auto-update.`,
       },
-      installSource: inspection.installSource,
+      installSource: plan.facts.installSource,
       success: false,
     }
   },

--- a/src/self/providers/types.ts
+++ b/src/self/providers/types.ts
@@ -1,8 +1,8 @@
-import type { SelfInspection, SelfInstallSource, SelfUpdateResult } from '../types'
+import type { SelfInspection, SelfInstallSource, SelfUpdateResult, SelfUpgradePlan } from '../types'
 
 export interface SelfUpgradeProvider {
-  canHandle: (inspection: SelfInspection) => boolean
+  canHandle: (context: SelfInspection | SelfUpgradePlan) => boolean
   getRecoveryHint: (inspection: SelfInspection, result?: SelfUpdateResult) => string | undefined
-  upgrade: (inspection: SelfInspection) => Promise<SelfUpdateResult>
+  upgrade: (plan: SelfUpgradePlan) => Promise<SelfUpdateResult>
   source: SelfInstallSource
 }

--- a/src/self/types.ts
+++ b/src/self/types.ts
@@ -1,5 +1,8 @@
+import type { BinaryReleaseAsset } from './release'
+
 export type SelfInstallSource = 'binary' | 'bun' | 'npm' | 'source' | 'unknown'
 export type SelfUpdateChannel = 'beta' | 'stable'
+export type SelfUpgradePlanStatus = 'check-unavailable' | 'manual-required' | 'up-to-date' | 'update-available'
 
 export interface SelfInspection {
   canAutoUpdate: boolean
@@ -42,4 +45,31 @@ export interface SelfPackageMetadata {
   packageJsonPath: string
   packageRoot: string
   version: string
+}
+
+export interface SelfInstallFacts {
+  canAutoUpdate: boolean
+  currentVersion: string
+  executablePath: string
+  installSource: SelfInstallSource
+  packageRoot: string
+  updateChannel: SelfUpdateChannel
+}
+
+export interface SelfUpdateTarget {
+  binaryAsset?: BinaryReleaseAsset
+  managedRegistry?: string
+  managedRegistryIsOverride?: boolean
+  packageTag?: 'beta' | 'latest'
+  resolutionError?: SelfUpgradeError
+  targetVersion?: string
+  upstreamLatestVersion?: string
+  verificationCommand?: string[]
+}
+
+export interface SelfUpgradePlan {
+  facts: SelfInstallFacts
+  status: SelfUpgradePlanStatus
+  target: SelfUpdateTarget
+  updateAvailable: boolean
 }

--- a/src/testing/self-upgrade-sandbox.ts
+++ b/src/testing/self-upgrade-sandbox.ts
@@ -1,0 +1,57 @@
+export const SEEDED_SELF_VERSION = '0.0.0-sandbox-old'
+
+export function buildSelfManagedRegistryMetadata(options: {
+  latestTarballName: string
+  latestVersion: string
+  origin: string
+  packageName: string
+  seededTarballName: string
+  seededVersion?: string
+}): {
+  'dist-tags': { latest: string }
+  name: string
+  versions: Record<
+    string,
+    {
+      dist: {
+        tarball: string
+      }
+      name: string
+      version: string
+    }
+  >
+} {
+  const seededVersion = options.seededVersion ?? SEEDED_SELF_VERSION
+
+  return {
+    'dist-tags': {
+      latest: options.latestVersion,
+    },
+    name: options.packageName,
+    versions: {
+      [seededVersion]: {
+        dist: {
+          tarball: `${options.origin}/${options.seededTarballName}`,
+        },
+        name: options.packageName,
+        version: seededVersion,
+      },
+      [options.latestVersion]: {
+        dist: {
+          tarball: `${options.origin}/${options.latestTarballName}`,
+        },
+        name: options.packageName,
+        version: options.latestVersion,
+      },
+    },
+  }
+}
+
+export function parsePackedTarballName(output: string): string | undefined {
+  return output
+    .trim()
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .at(-1)
+}

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -1,13 +1,14 @@
+import type { SelfUpgradePlan } from '../../src/self'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resetCliContext, setCliContext } from '../../src/cli-context'
 import { upgradeCommand } from '../../src/commands/upgrade'
 import * as selfModule from '../../src/self'
 
-const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelf')
+const planSelfUpgradeSpy = vi.spyOn(selfModule, 'planSelfUpgrade')
 const upgradeSelfSpy = vi.spyOn(selfModule, 'upgradeSelf')
 
 afterAll(() => {
-  inspectSelfSpy.mockRestore()
+  planSelfUpgradeSpy.mockRestore()
   upgradeSelfSpy.mockRestore()
 })
 
@@ -19,7 +20,7 @@ describe('upgradeCommand', () => {
     resetCliContext()
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
-    inspectSelfSpy.mockClear()
+    planSelfUpgradeSpy.mockClear()
     upgradeSelfSpy.mockClear()
   })
 
@@ -30,17 +31,7 @@ describe('upgradeCommand', () => {
   })
 
   it('shows up to date when latest version matches current version', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm',
-      latestVersion: '1.0.0',
-      managedRegistry: 'https://registry.npmjs.org',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(createPlan({ targetVersion: '1.0.0' }, 'up-to-date'))
 
     await expect(upgradeCommand()).resolves.toMatchObject({ ok: true })
 
@@ -49,15 +40,7 @@ describe('upgradeCommand', () => {
   })
 
   it('reports check unavailable when latest version cannot be resolved', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(createPlan({}, 'check-unavailable'))
 
     await expect(upgradeCommand({ check: true })).resolves.toMatchObject({
       data: { status: 'check-unavailable' },
@@ -70,17 +53,15 @@ describe('upgradeCommand', () => {
   })
 
   it('treats a lower latest version as stale instead of attempting a downgrade', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '0.15.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm',
-      latestVersion: '0.14.0',
-      managedRegistry: 'https://registry.npmjs.org',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(
+      createPlan(
+        {
+          currentVersion: '0.15.0',
+          targetVersion: '0.14.0',
+        },
+        'up-to-date',
+      ),
+    )
 
     const result = await upgradeCommand()
 
@@ -97,18 +78,16 @@ describe('upgradeCommand', () => {
   })
 
   it('warns when upstream npm is newer than the selected registry', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm',
-      latestVersion: '1.0.0',
-      managedRegistry: 'https://registry.npmmirror.com',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-      upstreamLatestVersion: '1.1.0',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(
+      createPlan(
+        {
+          managedRegistry: 'https://registry.npmmirror.com',
+          targetVersion: '1.0.0',
+          upstreamLatestVersion: '1.1.0',
+        },
+        'up-to-date',
+      ),
+    )
 
     const result = await upgradeCommand()
 
@@ -122,15 +101,16 @@ describe('upgradeCommand', () => {
   })
 
   it('refuses to auto-update from unsupported install sources', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: false,
-      currentVersion: '1.0.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'source',
-      latestVersion: '1.1.0',
-      packageRoot: '/tmp/quantex',
-      updateChannel: 'stable',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(
+      createPlan(
+        {
+          canAutoUpdate: false,
+          installSource: 'source',
+          targetVersion: '1.1.0',
+        },
+        'manual-required',
+      ),
+    )
 
     await expect(upgradeCommand()).resolves.toMatchObject({
       error: {
@@ -144,17 +124,16 @@ describe('upgradeCommand', () => {
   })
 
   it('shows manual recovery for bun installs when self-upgrade fails', async () => {
-    const inspection = {
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/Users/test/.bun/bin/qtx',
-      installSource: 'bun' as const,
-      latestVersion: '1.1.0',
-      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable' as const,
-    }
-    inspectSelfSpy.mockResolvedValue(inspection)
+    const plan = createPlan(
+      {
+        executablePath: '/Users/test/.bun/bin/qtx',
+        installSource: 'bun',
+        packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
+        targetVersion: '1.1.0',
+      },
+      'update-available',
+    )
+    planSelfUpgradeSpy.mockResolvedValue(plan)
     upgradeSelfSpy.mockResolvedValue({
       error: {
         kind: 'unknown',
@@ -179,17 +158,17 @@ describe('upgradeCommand', () => {
   })
 
   it('shows manual recovery for npm installs when self-upgrade fails', async () => {
-    const inspection = {
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/usr/local/bin/qtx',
-      installSource: 'npm' as const,
-      latestVersion: '1.1.0',
-      packageRoot: '/usr/local/lib/node_modules/quantex-cli',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable' as const,
-    }
-    inspectSelfSpy.mockResolvedValue(inspection)
+    planSelfUpgradeSpy.mockResolvedValue(
+      createPlan(
+        {
+          executablePath: '/usr/local/bin/qtx',
+          installSource: 'npm',
+          packageRoot: '/usr/local/lib/node_modules/quantex-cli',
+          targetVersion: '1.1.0',
+        },
+        'update-available',
+      ),
+    )
     upgradeSelfSpy.mockResolvedValue({
       error: {
         kind: 'unknown',
@@ -211,17 +190,17 @@ describe('upgradeCommand', () => {
 
   it('shows manual recovery for binary installs when self-upgrade fails', async () => {
     const executablePath = process.platform === 'win32' ? 'C:\\Program Files\\Quantex\\qtx.exe' : '/usr/local/bin/qtx'
-    const inspection = {
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath,
-      installSource: 'binary' as const,
-      latestVersion: '1.1.0',
-      packageRoot: process.platform === 'win32' ? 'C:\\Program Files\\Quantex' : '/usr/local/bin',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable' as const,
-    }
-    inspectSelfSpy.mockResolvedValue(inspection)
+    planSelfUpgradeSpy.mockResolvedValue(
+      createPlan(
+        {
+          executablePath,
+          installSource: 'binary',
+          packageRoot: process.platform === 'win32' ? 'C:\\Program Files\\Quantex' : '/usr/local/bin',
+          targetVersion: '1.1.0',
+        },
+        'update-available',
+      ),
+    )
     upgradeSelfSpy.mockResolvedValue({
       error: {
         kind: 'permission',
@@ -243,17 +222,17 @@ describe('upgradeCommand', () => {
   })
 
   it('shows a retry hint when another self upgrade already holds the lock', async () => {
-    const inspection = {
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/usr/local/bin/qtx',
-      installSource: 'npm' as const,
-      latestVersion: '1.1.0',
-      packageRoot: '/usr/local/lib/node_modules/quantex-cli',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable' as const,
-    }
-    inspectSelfSpy.mockResolvedValue(inspection)
+    planSelfUpgradeSpy.mockResolvedValue(
+      createPlan(
+        {
+          executablePath: '/usr/local/bin/qtx',
+          installSource: 'npm',
+          packageRoot: '/usr/local/lib/node_modules/quantex-cli',
+          targetVersion: '1.1.0',
+        },
+        'update-available',
+      ),
+    )
     upgradeSelfSpy.mockResolvedValue({
       error: {
         kind: 'locked',
@@ -277,17 +256,8 @@ describe('upgradeCommand', () => {
   })
 
   it('runs self upgrade when a managed source is detected', async () => {
-    const inspection = {
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm' as const,
-      latestVersion: '1.1.0',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable' as const,
-    }
-    inspectSelfSpy.mockResolvedValue(inspection)
+    const plan = createPlan({ targetVersion: '1.1.0' }, 'update-available')
+    planSelfUpgradeSpy.mockResolvedValue(plan)
     upgradeSelfSpy.mockResolvedValue({
       installSource: 'npm',
       success: true,
@@ -295,22 +265,15 @@ describe('upgradeCommand', () => {
 
     await expect(upgradeCommand()).resolves.toMatchObject({ ok: true })
 
-    expect(upgradeSelfSpy).toHaveBeenCalledWith(inspection)
+    expect(upgradeSelfSpy).toHaveBeenCalledWith(plan)
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Upgrading Quantex CLI'))
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('upgraded successfully'))
   })
 
   it('supports --check mode when an update is available', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm',
-      latestVersion: '1.1.0',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'beta',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(
+      createPlan({ targetVersion: '1.1.0', updateChannel: 'beta' }, 'update-available'),
+    )
 
     await expect(upgradeCommand({ check: true, channel: 'beta' })).resolves.toMatchObject({
       exitCode: 1,
@@ -323,16 +286,15 @@ describe('upgradeCommand', () => {
   })
 
   it('treats a lower latest version as up to date in --check mode', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '0.15.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm',
-      latestVersion: '0.14.0',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(
+      createPlan(
+        {
+          currentVersion: '0.15.0',
+          targetVersion: '0.14.0',
+        },
+        'up-to-date',
+      ),
+    )
 
     const result = await upgradeCommand({ check: true })
 
@@ -348,16 +310,7 @@ describe('upgradeCommand', () => {
       outputMode: 'json',
       runId: 'test-run-id',
     })
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm',
-      latestVersion: '1.1.0',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(createPlan({ targetVersion: '1.1.0' }, 'update-available'))
 
     await upgradeCommand({ check: true })
 
@@ -376,16 +329,7 @@ describe('upgradeCommand', () => {
       outputMode: 'json',
       runId: 'dry-run-id',
     })
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '1.0.0',
-      executablePath: '/tmp/quantex',
-      installSource: 'npm',
-      latestVersion: '1.1.0',
-      packageRoot: '/tmp/quantex',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-    })
+    planSelfUpgradeSpy.mockResolvedValue(createPlan({ targetVersion: '1.1.0' }, 'update-available'))
 
     const result = await upgradeCommand()
 
@@ -395,3 +339,40 @@ describe('upgradeCommand', () => {
     expect(upgradeSelfSpy).not.toHaveBeenCalled()
   })
 })
+
+function createPlan(
+  overrides: {
+    canAutoUpdate?: boolean
+    currentVersion?: string
+    executablePath?: string
+    installSource?: 'binary' | 'bun' | 'npm' | 'source' | 'unknown'
+    managedRegistry?: string
+    packageRoot?: string
+    targetVersion?: string
+    updateChannel?: 'beta' | 'stable'
+    upstreamLatestVersion?: string
+  } = {},
+  status: 'check-unavailable' | 'manual-required' | 'up-to-date' | 'update-available' = 'update-available',
+): SelfUpgradePlan {
+  const facts = {
+    canAutoUpdate: overrides.canAutoUpdate ?? true,
+    currentVersion: overrides.currentVersion ?? '1.0.0',
+    executablePath: overrides.executablePath ?? '/tmp/quantex',
+    installSource: overrides.installSource ?? 'npm',
+    packageRoot: overrides.packageRoot ?? '/tmp/quantex',
+    updateChannel: overrides.updateChannel ?? 'stable',
+  } as const
+
+  return {
+    facts,
+    status,
+    target: {
+      managedRegistry: overrides.managedRegistry,
+      packageTag: facts.updateChannel === 'beta' ? ('beta' as const) : ('latest' as const),
+      targetVersion: overrides.targetVersion,
+      upstreamLatestVersion: overrides.upstreamLatestVersion,
+      verificationCommand: [process.execPath, `${facts.packageRoot}/dist/cli.mjs`, '--version'],
+    },
+    updateAvailable: status === 'update-available',
+  }
+}

--- a/test/testing/self-upgrade-sandbox.test.ts
+++ b/test/testing/self-upgrade-sandbox.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildSelfManagedRegistryMetadata,
+  parsePackedTarballName,
+  SEEDED_SELF_VERSION,
+} from '../../src/testing/self-upgrade-sandbox'
+
+describe('buildSelfManagedRegistryMetadata', () => {
+  it('publishes the current version as latest and keeps the seeded older version installable', () => {
+    const metadata = buildSelfManagedRegistryMetadata({
+      latestTarballName: 'quantex-cli-0.15.1.tgz',
+      latestVersion: '0.15.1',
+      origin: 'http://127.0.0.1:4873',
+      packageName: 'quantex-cli',
+      seededTarballName: 'quantex-cli-0.0.0-sandbox-old.tgz',
+    })
+
+    expect(metadata.name).toBe('quantex-cli')
+    expect(metadata['dist-tags'].latest).toBe('0.15.1')
+    expect(metadata.versions[SEEDED_SELF_VERSION]).toEqual({
+      dist: {
+        tarball: 'http://127.0.0.1:4873/quantex-cli-0.0.0-sandbox-old.tgz',
+      },
+      name: 'quantex-cli',
+      version: SEEDED_SELF_VERSION,
+    })
+    expect(metadata.versions['0.15.1']).toEqual({
+      dist: {
+        tarball: 'http://127.0.0.1:4873/quantex-cli-0.15.1.tgz',
+      },
+      name: 'quantex-cli',
+      version: '0.15.1',
+    })
+  })
+})
+
+describe('parsePackedTarballName', () => {
+  it('returns the last non-empty line from npm pack output', () => {
+    expect(parsePackedTarballName('\nquantex-cli-0.15.1.tgz\n')).toBe('quantex-cli-0.15.1.tgz')
+    expect(parsePackedTarballName('npm notice something\nquantex-cli-0.15.1.tgz\n')).toBe('quantex-cli-0.15.1.tgz')
+  })
+
+  it('returns undefined when npm pack output is empty', () => {
+    expect(parsePackedTarballName('\n\n')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Consolidate the in-flight self-upgrade work into one delivery artifact. This PR restructures self-upgrade around an explicit transactional planning model and adds sandbox smoke coverage so managed upgrade flows are planned once, executed against frozen targets, and exercised through the lifecycle smoke harness.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `rearchitect-self-upgrade-transaction`, `add-self-upgrade-sandbox-tests`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- `inspectSelf()` now derives from the same planner that powers `quantex upgrade`, reducing mutable cross-step state and keeping upgrade execution aligned with rendered plan output.
- Managed, binary, bun, npm, and source providers now consume a shared `SelfUpgradePlan` contract instead of ad hoc version probing during execution.
- The lifecycle smoke harness now includes sandbox-managed upgrade scenarios, with matching runbook updates for sandbox and self-upgrade debugging.
