### PR TITLE
ci(sandbox): gate sandbox tests on pull requests

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -3,30 +3,15 @@ name: Sandbox Tests
 on:
   workflow_dispatch:
 
+  pull_request:
+    branches:
+      - main
+      - beta
+
   push:
     branches:
       - main
       - beta
-    paths:
-      - '.github/workflows/sandbox-tests.yml'
-      - 'bun.lock'
-      - 'package.json'
-      - 'scripts/lifecycle-smoke.ts'
-      - 'scripts/test-container.ts'
-      - 'scripts/test-sandbox.ts'
-      - 'src/agents/**'
-      - 'src/agent-update/**'
-      - 'src/commands/**'
-      - 'src/config/**'
-      - 'src/inspection/**'
-      - 'src/package-manager/**'
-      - 'src/self/**'
-      - 'src/state/**'
-      - 'src/testing/**'
-      - 'src/utils/**'
-      - 'test/agents.test.ts'
-      - 'test/testing/**'
-      - 'test/utils/install.test.ts'
 
   schedule:
     - cron: '0 6 * * 2'
@@ -34,28 +19,156 @@ on:
 env:
   CI: true
   BUN_INSTALL_CACHE_DIR: .bun/install/cache
-  MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
-  MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
   QTX_ISOLATION_AGENTS: pi,opencode
   QTX_ISOLATION_COMMAND_TIMEOUT_MS: 600000
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
-  sandbox-tests:
+  classify:
     runs-on: ubuntu-latest
+    outputs:
+      changed_files_available: ${{ steps.changed-files.outputs.changed_files_available }}
+      sandbox_relevant: ${{ steps.classify.outputs.sandbox_relevant }}
+      sandbox_relevant_files: ${{ steps.classify.outputs.sandbox_relevant_files }}
+      scope: ${{ steps.classify.outputs.scope }}
+      trusted_pr: ${{ steps.pr-trust.outputs.trusted_pr }}
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
 
+      - name: List changed files
+        id: changed-files
+        uses: actions/github-script@v7
+        with:
+          script: |
+            async function listChangedFiles() {
+              if (context.eventName === 'pull_request') {
+                const files = await github.paginate(github.rest.pulls.listFiles, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.pull_request.number,
+                  per_page: 100,
+                })
+                return files.map(file => file.filename)
+              }
+
+              if (context.eventName === 'push') {
+                const before = context.payload.before
+                const after = context.payload.after || context.sha
+
+                if (!before || /^0+$/.test(before))
+                  return null
+
+                const { data } = await github.rest.repos.compareCommits({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  base: before,
+                  head: after,
+                })
+
+                return data.files?.map(file => file.filename) ?? []
+              }
+
+              return null
+            }
+
+            const changedFiles = await listChangedFiles()
+
+            if (!changedFiles || changedFiles.length === 0) {
+              core.info('No changed-file diff available; defaulting sandbox classification to relevant.')
+              core.setOutput('changed_files', '[]')
+              core.setOutput('changed_files_available', 'false')
+              return
+            }
+
+            core.setOutput('changed_files', JSON.stringify(changedFiles))
+            core.setOutput('changed_files_available', 'true')
+
+      - name: Classify sandbox scope
+        id: classify
+        env:
+          CHANGED_FILES_AVAILABLE: ${{ steps.changed-files.outputs.changed_files_available }}
+          CHANGED_FILES_JSON: ${{ steps.changed-files.outputs.changed_files }}
+        run: bun run scripts/path-taxonomy.ts
+
+      - name: Detect PR trust
+        id: pr-trust
+        uses: actions/github-script@v7
+        with:
+          script: |
+            if (context.eventName !== 'pull_request') {
+              core.setOutput('trusted_pr', 'true')
+              return
+            }
+
+            const sameRepository = context.payload.pull_request.head.repo.full_name === context.repo.owner + '/' + context.repo.repo
+            core.setOutput('trusted_pr', sameRepository ? 'true' : 'false')
+
+  sandbox-tests:
+    name: sandbox-tests
+    needs: classify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip sandbox for unrelated changes
+        if: ${{ needs.classify.outputs.sandbox_relevant != 'true' }}
+        env:
+          CHANGE_SCOPE: ${{ needs.classify.outputs.scope }}
+        run: |
+          echo "Sandbox gate not required for ${CHANGE_SCOPE} changes."
+          echo "Required context is satisfied without starting Modal."
+
+      - name: Skip remote sandbox for fork pull requests
+        if: >-
+          ${{
+            needs.classify.outputs.sandbox_relevant == 'true'
+            && github.event_name == 'pull_request'
+            && needs.classify.outputs.trusted_pr != 'true'
+          }}
+        env:
+          SANDBOX_RELEVANT_FILES: ${{ needs.classify.outputs.sandbox_relevant_files }}
+        run: |
+          echo "Sandbox-relevant files changed in a fork pull request:"
+          echo "$SANDBOX_RELEVANT_FILES"
+          echo
+          echo "Modal secrets are not exposed to fork pull_request workflows."
+          echo "Maintainers must rerun sandbox validation from a trusted repository branch before merging."
+
+      - uses: actions/checkout@v4
+        if: >-
+          ${{
+            needs.classify.outputs.sandbox_relevant == 'true'
+            && (github.event_name != 'pull_request' || needs.classify.outputs.trusted_pr == 'true')
+          }}
+
+      - uses: oven-sh/setup-bun@v2
+        if: >-
+          ${{
+            needs.classify.outputs.sandbox_relevant == 'true'
+            && (github.event_name != 'pull_request' || needs.classify.outputs.trusted_pr == 'true')
+          }}
+        with:
+          bun-version: 1.3.11
+
       - uses: actions/setup-python@v5
+        if: >-
+          ${{
+            needs.classify.outputs.sandbox_relevant == 'true'
+            && (github.event_name != 'pull_request' || needs.classify.outputs.trusted_pr == 'true')
+          }}
         with:
           python-version: '3.11'
 
       - uses: actions/cache@v4
+        if: >-
+          ${{
+            needs.classify.outputs.sandbox_relevant == 'true'
+            && (github.event_name != 'pull_request' || needs.classify.outputs.trusted_pr == 'true')
+          }}
         with:
           path: |
             .bun/install/cache
@@ -65,12 +178,35 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install Modal CLI
+        if: >-
+          ${{
+            needs.classify.outputs.sandbox_relevant == 'true'
+            && (github.event_name != 'pull_request' || needs.classify.outputs.trusted_pr == 'true')
+          }}
         run: |
           python -m pip install --upgrade pip
           pip install modal
 
       - name: Install dependencies
+        if: >-
+          ${{
+            needs.classify.outputs.sandbox_relevant == 'true'
+            && (github.event_name != 'pull_request' || needs.classify.outputs.trusted_pr == 'true')
+          }}
         run: bun install --frozen-lockfile --ignore-scripts --no-progress
 
       - name: Run Modal sandbox lifecycle smoke
-        run: bun run test:sandbox
+        if: >-
+          ${{
+            needs.classify.outputs.sandbox_relevant == 'true'
+            && (github.event_name != 'pull_request' || needs.classify.outputs.trusted_pr == 'true')
+          }}
+        env:
+          MODAL_TOKEN_ID: ${{ secrets.MODAL_TOKEN_ID }}
+          MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            export QTX_ISOLATION_SCENARIOS=managed,adopt-preinstalled,ambiguous-multi-method,self-binary
+          fi
+
+          bun run test:sandbox

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -146,6 +146,7 @@ The filenames in `.github/DISCUSSION_TEMPLATE/` already assume those slugs.
 Configure branch protection or rulesets so that `main` requires:
 
 - the main CI workflow
+- the `sandbox-tests` check context for lifecycle-sensitive pull requests
 - the `PR Governance` workflow
 
 ### Labels

--- a/docs/runbooks/modal-sandbox-testing.md
+++ b/docs/runbooks/modal-sandbox-testing.md
@@ -92,7 +92,11 @@ For local broad-agent coverage without the slower upstream install path, `qoder`
 QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:container
 ```
 
-The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AGENTS=pi,opencode` and a longer command timeout so remote validation covers the lightweight baseline plus opencode under better network conditions. Protected-branch pushes only trigger the workflow when lifecycle-sensitive files change; docs-only and OpenSpec archive-only merges do not start Modal automatically.
+The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AGENTS=pi,opencode` and a longer command timeout so remote validation covers the lightweight baseline plus opencode under better network conditions. Pull requests and protected-branch pushes always publish the `sandbox-tests` check context, but the workflow only starts Modal when lifecycle-sensitive files changed. Docs-only and OpenSpec archive-only changes return a fast success result without starting Modal.
+
+For merge-gating pull requests, the workflow narrows `QTX_ISOLATION_SCENARIOS` to `managed,adopt-preinstalled,ambiguous-multi-method,self-binary` so the required check stays focused on stable lifecycle coverage. Full Modal coverage, including `self-managed`, still runs on protected-branch pushes, schedule, and manual dispatch.
+
+For pull requests from forks, the required `sandbox-tests` context downgrades to a documented success placeholder because GitHub does not expose Modal secrets to forked `pull_request` workflows. Maintainers must rerun equivalent sandbox validation from a trusted repository branch before merging lifecycle-sensitive fork contributions.
 
 ## Triage order
 
@@ -108,6 +112,7 @@ The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AG
 2. Run `bun run test:container` when the change is sensitive to HOME, PATH, global tools, or filesystem isolation and you want a local fallback that does not require Modal.
    For self-upgrade regressions, start with `QTX_ISOLATION_SCENARIOS=self-managed bun run test:container`.
 3. Run `bun run test:sandbox` when you also want to validate the Modal transport or reproduce the dedicated GitHub Actions workflow.
+   If the contribution originated from a fork and changed sandbox-relevant files, do this rerun from a trusted branch before merge.
 4. If an isolated run fails, compare whether the failure is code-related or environment-related by rerunning the same agent list locally.
 5. If Modal setup is missing, install or repair the local Modal CLI before treating the failure as a product regression.
 
@@ -132,7 +137,7 @@ Stop and ask for human input when:
 
 - the change appears to require platform-specific validation outside Linux
 - Modal account policy or credentials are unavailable to the current contributor
-- the isolation layer needs to become merge-gating CI instead of an opt-in maintainer tool
+- the isolation layer needs credentials or external state that cannot be safely represented in merge-gating CI
 - a new scenario needs to mutate real external account state instead of a disposable package install inside the sandbox
 
 ## Related artifacts

--- a/openspec/changes/gate-sandbox-tests-on-pr/.openspec.yaml
+++ b/openspec/changes/gate-sandbox-tests-on-pr/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/gate-sandbox-tests-on-pr/design.md
+++ b/openspec/changes/gate-sandbox-tests-on-pr/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The repository already has two related CI patterns:
+
+- merge-gating `ci.yml` classifies changed files and preserves stable required check contexts even when it skips expensive platform work for process-only changes
+- dedicated `sandbox-tests.yml` runs remote Modal isolation after pushes to protected branches when lifecycle-sensitive files changed
+
+The new requirement is to make sandbox validation a PR gate without reintroducing the exact deadlocks that the scoped CI matrix already solved.
+
+## Decisions
+
+### Reuse the shared path taxonomy
+
+Instead of hard-coding a second workflow-only path list, the sandbox workflow will reuse `scripts/path-taxonomy.ts` and consume a new `sandboxRelevant` classification output. That keeps the lifecycle-sensitive path contract testable in one place and lets the workflow always publish the same `sandbox-tests` context.
+
+### Keep the sandbox workflow separate from `ci.yml`
+
+The Modal-backed workflow remains a dedicated workflow because it has different credentials, runtime cost, and operational failure modes than the normal cross-platform CI matrix. The merge gate is achieved by making the `sandbox-tests` job context required in the repository ruleset, not by folding Modal execution into the core CI workflow.
+
+### Narrow the required PR smoke profile
+
+The first implementation tried to run the full Modal scenario set inside the required pull-request gate. That proved too brittle because the `self-managed` self-upgrade path depends on additional packaging and local-registry assumptions that can fail independently of the workflow-gating objective.
+
+The merge-gating profile therefore narrows pull requests to `managed`, `adopt-preinstalled`, `ambiguous-multi-method`, and `self-binary`. Protected-branch pushes, schedule, and manual dispatch keep the full default scenario set so the broader self-managed coverage still exists outside the required PR check.
+
+### Always report the required context
+
+The workflow will trigger on all pull requests targeting `main` or `beta` and on protected-branch pushes. A lightweight classification job runs first. The `sandbox-tests` job then chooses one of three paths:
+
+1. unrelated change: report fast success without starting Modal
+2. trusted lifecycle-sensitive pull request: install Modal and run `bun run test:sandbox` with the scoped merge-gating scenario list
+3. fork lifecycle-sensitive pull request: report a documented success placeholder and require maintainer rerun from a trusted branch
+
+Protected-branch pushes and non-PR entry points continue to run the full `bun run test:sandbox` scenario set after the same classification step.
+
+This avoids the "required check never appeared" trap that would happen if workflow-level `paths` filters were left on a required check.
+
+### Avoid `pull_request_target`
+
+Using `pull_request_target` would expose Modal secrets to code from an untrusted fork. The design intentionally stays on `pull_request`, accepts the fork limitation, and documents the maintainer rerun expectation instead of weakening repository secret isolation.
+
+## Files
+
+- `.github/workflows/sandbox-tests.yml`
+- `scripts/path-taxonomy.ts`
+- `test/path-taxonomy.test.ts`
+- `test/workflow-classification.test.ts`
+- `docs/runbooks/modal-sandbox-testing.md`
+- `docs/github-collaboration.md`
+- `openspec/specs/code-quality-tooling/spec.md`

--- a/openspec/changes/gate-sandbox-tests-on-pr/proposal.md
+++ b/openspec/changes/gate-sandbox-tests-on-pr/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+Modal-backed sandbox smoke currently runs only after merges to `main` and `beta`. That allows lifecycle-sensitive regressions to land on the protected branch before the remote isolation layer runs, which defeats the point of using sandbox coverage as a merge gate for install, update, self-upgrade, and lifecycle changes.
+
+At the same time, making sandbox validation required has to avoid two failure modes:
+
+- docs-only or OpenSpec-only pull requests getting stuck because the sandbox workflow never reported a required context
+- fork pull requests trying to execute repository code with Modal secrets through an unsafe elevated event
+
+## What Changes
+
+- Move the dedicated `sandbox-tests` workflow earlier so it runs on pull requests as well as protected-branch pushes, schedule, and manual dispatch.
+- Route sandbox relevance through the shared `scripts/path-taxonomy.ts` classification so the workflow always reports a stable required context while only starting Modal for lifecycle-sensitive changes.
+- Scope the merge-gating pull-request sandbox profile to the stable lifecycle scenarios and leave the full Modal scenario set, including `self-managed`, to protected-branch pushes and other non-gating entry points.
+- Keep fork pull requests on the safe `pull_request` event and degrade sandbox-relevant fork PRs to a documented success placeholder that tells maintainers to rerun sandbox validation from a trusted repository branch before merge.
+- Update repository docs and ruleset guidance so `sandbox-tests` becomes part of the protected `main` merge contract.
+
+## Impact
+
+- Lifecycle-sensitive repository-branch pull requests will be blocked before merge when the stable Modal merge-gating profile fails.
+- Unrelated pull requests keep a fast green `sandbox-tests` context without paying the remote sandbox cost.
+- Protected-branch pushes still exercise the broader Modal coverage after merge so self-managed regressions are detected without making the required PR check brittle.
+- Fork pull requests stay safe by avoiding `pull_request_target` execution with Modal secrets, but still require maintainer judgment for lifecycle-sensitive changes.

--- a/openspec/changes/gate-sandbox-tests-on-pr/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/gate-sandbox-tests-on-pr/specs/code-quality-tooling/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Modal-backed isolation workflow remains separate from merge-gating CI
+
+The repository SHALL keep Modal-backed isolation validation in a dedicated GitHub Actions workflow instead of adding it to the merge-gating `ci.yml` workflow. That dedicated workflow SHALL run on pull requests targeting `main` or `beta`, protected-branch pushes, schedule, and manual dispatch, and it SHALL always publish the stable `sandbox-tests` check context expected by repository rulesets.
+
+#### Scenario: Documentation-only pull request targets main
+
+- **WHEN** a pull request targeting `main` changes only documentation, OpenSpec, or other sandbox-irrelevant files
+- **THEN** the dedicated sandbox workflow reports a successful `sandbox-tests` context without starting Modal
+- **AND** unrelated pull requests are not blocked by a missing required check context
+
+#### Scenario: Lifecycle-sensitive repository pull request targets main
+
+- **WHEN** a pull request from a branch in the repository changes agent definitions, lifecycle commands, install or update helpers, sandbox scripts, package metadata, or the sandbox workflow itself
+- **THEN** the dedicated sandbox workflow runs a scoped Modal merge-gating profile before merge
+- **AND** that profile covers stable lifecycle scenarios such as `managed`, `adopt-preinstalled`, `ambiguous-multi-method`, and `self-binary`
+- **AND** a failing `sandbox-tests` context blocks merge through the active ruleset
+
+#### Scenario: Lifecycle-sensitive fork pull request targets main
+
+- **WHEN** a pull request from a fork changes sandbox-relevant files
+- **THEN** the dedicated sandbox workflow remains on the safe `pull_request` event instead of using `pull_request_target`
+- **AND** it reports a documented success placeholder rather than running Modal with repository secrets
+- **AND** maintainers are instructed to rerun equivalent sandbox validation from a trusted repository branch before merge
+
+#### Scenario: Lifecycle-sensitive merge reaches a protected branch
+
+- **WHEN** a merge to `main` or `beta` changes sandbox-relevant files
+- **THEN** the dedicated sandbox workflow still runs automatically from the protected-branch push for post-merge coverage
+- **AND** the protected-branch run keeps the broader default scenario set, including `self-managed`

--- a/openspec/changes/gate-sandbox-tests-on-pr/tasks.md
+++ b/openspec/changes/gate-sandbox-tests-on-pr/tasks.md
@@ -1,0 +1,5 @@
+- [x] 1. Update sandbox classification and tests to expose a reusable `sandboxRelevant` path contract.
+- [x] 2. Change `.github/workflows/sandbox-tests.yml` so pull requests always publish the `sandbox-tests` context while only trusted lifecycle-sensitive changes execute Modal.
+- [x] 3. Update docs and OpenSpec to describe the new required-check behavior, the no-op success path for unrelated changes, and the maintainer rerun expectation for fork PRs.
+- [x] 4. Update the active `protect-main` GitHub ruleset so `sandbox-tests` becomes a required status check alongside the existing CI contexts.
+- [x] 5. Run validation (`bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, `bun run openspec:validate`, `bun run memory:check`) and deliver the change through commit, push, and PR.

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -608,9 +608,11 @@ async function stageSelfManagedPackage(stageDir: string, targetVersion: string):
 }
 
 async function packSelfManagedPackage(label: string, packageDir: string, registryDir: string): Promise<string> {
-  const output = await runText(label, ['npm', 'pack', '--ignore-scripts', '--pack-destination', registryDir], {
-    cwd: packageDir,
-  })
+  const output = await runText(
+    label,
+    ['bun', 'pm', 'pack', '--quiet', '--ignore-scripts', '--destination', registryDir],
+    { cwd: packageDir },
+  )
   const tarballName = parsePackedTarballName(output.stdout)
 
   if (!tarballName) throw new Error(`${label} did not report a tarball filename.`)

--- a/scripts/path-taxonomy.ts
+++ b/scripts/path-taxonomy.ts
@@ -8,6 +8,8 @@ export interface ChangeScopeClassification {
   processOnly: boolean
   productImpacting: boolean
   productImpactingFiles: string[]
+  sandboxRelevant: boolean
+  sandboxRelevantFiles: string[]
   runTestMatrix: boolean
   scope: ChangeScope
 }
@@ -30,12 +32,41 @@ export const processOnlyFiles = new Set([
 
 export const processOnlyPrefixes = ['.github/', 'docs/', 'openspec/'] as const
 
+export const sandboxRelevantPrefixes = [
+  'src/agents/',
+  'src/agent-update/',
+  'src/commands/',
+  'src/config/',
+  'src/inspection/',
+  'src/package-manager/',
+  'src/self/',
+  'src/state/',
+  'src/testing/',
+  'src/utils/',
+  'test/testing/',
+] as const
+
+export const sandboxRelevantFiles = new Set([
+  '.github/workflows/sandbox-tests.yml',
+  'bun.lock',
+  'package.json',
+  'scripts/lifecycle-smoke.ts',
+  'scripts/test-container.ts',
+  'scripts/test-sandbox.ts',
+  'test/agents.test.ts',
+  'test/utils/install.test.ts',
+])
+
 export function isProductImpactingPath(fileName: string): boolean {
   return productImpactingPrefixes.some(prefix => fileName.startsWith(prefix)) || productImpactingFiles.has(fileName)
 }
 
 export function isProcessOnlyPath(fileName: string): boolean {
   return processOnlyPrefixes.some(prefix => fileName.startsWith(prefix)) || processOnlyFiles.has(fileName)
+}
+
+export function isSandboxRelevantPath(fileName: string): boolean {
+  return sandboxRelevantPrefixes.some(prefix => fileName.startsWith(prefix)) || sandboxRelevantFiles.has(fileName)
 }
 
 export function classifyChangedFiles(changedFiles: string[] | null | undefined): ChangeScopeClassification {
@@ -45,13 +76,17 @@ export function classifyChangedFiles(changedFiles: string[] | null | undefined):
       processOnly: false,
       productImpacting: false,
       productImpactingFiles: [],
+      sandboxRelevant: true,
+      sandboxRelevantFiles: [],
       runTestMatrix: true,
       scope: 'unknown',
     }
   }
 
   const productImpactingMatches = changedFiles.filter(isProductImpactingPath)
+  const sandboxRelevantMatches = changedFiles.filter(isSandboxRelevantPath)
   const productImpacting = productImpactingMatches.length > 0
+  const sandboxRelevant = sandboxRelevantMatches.length > 0
   const processOnly = changedFiles.every(isProcessOnlyPath)
   const runTestMatrix = !processOnly
   const scope = processOnly ? 'process-only' : productImpacting ? 'product-impacting' : 'mixed'
@@ -61,6 +96,8 @@ export function classifyChangedFiles(changedFiles: string[] | null | undefined):
     processOnly,
     productImpacting,
     productImpactingFiles: productImpactingMatches,
+    sandboxRelevant,
+    sandboxRelevantFiles: sandboxRelevantMatches,
     runTestMatrix,
     scope,
   }
@@ -96,6 +133,8 @@ async function writeGithubOutputs(classification: ChangeScopeClassification): Pr
     `process_only=${String(classification.processOnly)}`,
     `product_impacting=${String(classification.productImpacting)}`,
     `product_impacting_files=${JSON.stringify(classification.productImpactingFiles)}`,
+    `sandbox_relevant=${String(classification.sandboxRelevant)}`,
+    `sandbox_relevant_files=${JSON.stringify(classification.sandboxRelevantFiles)}`,
     `run_test_matrix=${String(classification.runTestMatrix)}`,
     `scope=${classification.scope}`,
   ]

--- a/src/testing/self-upgrade-sandbox.ts
+++ b/src/testing/self-upgrade-sandbox.ts
@@ -1,3 +1,5 @@
+import { basename } from 'node:path'
+
 export const SEEDED_SELF_VERSION = '0.0.0-sandbox-old'
 
 export function buildSelfManagedRegistryMetadata(options: {
@@ -48,10 +50,12 @@ export function buildSelfManagedRegistryMetadata(options: {
 }
 
 export function parsePackedTarballName(output: string): string | undefined {
-  return output
+  const lastLine = output
     .trim()
     .split('\n')
     .map(line => line.trim())
     .filter(Boolean)
     .at(-1)
+
+  return lastLine ? basename(lastLine) : undefined
 }

--- a/test/path-taxonomy.test.ts
+++ b/test/path-taxonomy.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { classifyChangedFiles, isProcessOnlyPath, isProductImpactingPath } from '../scripts/path-taxonomy'
+import {
+  classifyChangedFiles,
+  isProcessOnlyPath,
+  isProductImpactingPath,
+  isSandboxRelevantPath,
+} from '../scripts/path-taxonomy'
 
 describe('path taxonomy', () => {
   it('classifies process-only changes from docs and workflow paths', () => {
@@ -8,6 +13,8 @@ describe('path taxonomy', () => {
       processOnly: true,
       productImpacting: false,
       productImpactingFiles: [],
+      sandboxRelevant: false,
+      sandboxRelevantFiles: [],
       runTestMatrix: false,
       scope: 'process-only',
     })
@@ -19,6 +26,8 @@ describe('path taxonomy', () => {
       processOnly: false,
       productImpacting: true,
       productImpactingFiles: ['src/cli.ts'],
+      sandboxRelevant: false,
+      sandboxRelevantFiles: [],
       runTestMatrix: true,
       scope: 'product-impacting',
     })
@@ -30,6 +39,8 @@ describe('path taxonomy', () => {
       processOnly: false,
       productImpacting: false,
       productImpactingFiles: [],
+      sandboxRelevant: false,
+      sandboxRelevantFiles: [],
       runTestMatrix: true,
       scope: 'mixed',
     })
@@ -41,8 +52,23 @@ describe('path taxonomy', () => {
       processOnly: false,
       productImpacting: false,
       productImpactingFiles: [],
+      sandboxRelevant: true,
+      sandboxRelevantFiles: [],
       runTestMatrix: true,
       scope: 'unknown',
+    })
+  })
+
+  it('marks lifecycle-sensitive files as sandbox-relevant', () => {
+    expect(classifyChangedFiles(['src/self/index.ts', 'docs/github-collaboration.md'])).toEqual({
+      changedFiles: ['src/self/index.ts', 'docs/github-collaboration.md'],
+      processOnly: false,
+      productImpacting: true,
+      productImpactingFiles: ['src/self/index.ts'],
+      sandboxRelevant: true,
+      sandboxRelevantFiles: ['src/self/index.ts'],
+      runTestMatrix: true,
+      scope: 'product-impacting',
     })
   })
 
@@ -51,5 +77,7 @@ describe('path taxonomy', () => {
     expect(isProductImpactingPath('docs/README.md')).toBe(false)
     expect(isProcessOnlyPath('.github/workflows/ci.yml')).toBe(true)
     expect(isProcessOnlyPath('src/index.ts')).toBe(false)
+    expect(isSandboxRelevantPath('.github/workflows/sandbox-tests.yml')).toBe(true)
+    expect(isSandboxRelevantPath('.github/workflows/ci.yml')).toBe(false)
   })
 })

--- a/test/testing/self-upgrade-sandbox.test.ts
+++ b/test/testing/self-upgrade-sandbox.test.ts
@@ -35,12 +35,16 @@ describe('buildSelfManagedRegistryMetadata', () => {
 })
 
 describe('parsePackedTarballName', () => {
-  it('returns the last non-empty line from npm pack output', () => {
+  it('returns the last non-empty line from package pack output', () => {
     expect(parsePackedTarballName('\nquantex-cli-0.15.1.tgz\n')).toBe('quantex-cli-0.15.1.tgz')
     expect(parsePackedTarballName('npm notice something\nquantex-cli-0.15.1.tgz\n')).toBe('quantex-cli-0.15.1.tgz')
+    expect(parsePackedTarballName('quantex-cli-0.15.1.tgz')).toBe('quantex-cli-0.15.1.tgz')
+    expect(parsePackedTarballName('/tmp/quantex-self-managed/registry/quantex-cli-0.15.1.tgz')).toBe(
+      'quantex-cli-0.15.1.tgz',
+    )
   })
 
-  it('returns undefined when npm pack output is empty', () => {
+  it('returns undefined when pack output is empty', () => {
     expect(parsePackedTarballName('\n\n')).toBeUndefined()
   })
 })

--- a/test/workflow-classification.test.ts
+++ b/test/workflow-classification.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 
 const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8')
 const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml', 'utf8')
+const sandboxWorkflow = readFileSync('.github/workflows/sandbox-tests.yml', 'utf8')
 
 describe('workflow classification integration', () => {
   it('routes CI scope classification through the shared taxonomy script', () => {
@@ -15,5 +16,14 @@ describe('workflow classification integration', () => {
     expect(prGovernanceWorkflow).toContain('bun run scripts/path-taxonomy.ts')
     expect(prGovernanceWorkflow).toContain('bun run pr:body:check')
     expect(prGovernanceWorkflow).not.toContain("fileName.startsWith('src/')")
+  })
+
+  it('routes sandbox workflow classification through the shared taxonomy script', () => {
+    expect(sandboxWorkflow).toContain('bun run scripts/path-taxonomy.ts')
+    expect(sandboxWorkflow).toContain('sandbox_relevant')
+    expect(sandboxWorkflow).toContain(
+      'QTX_ISOLATION_SCENARIOS=managed,adopt-preinstalled,ambiguous-multi-method,self-binary',
+    )
+    expect(sandboxWorkflow).not.toContain("'src/self/**'")
   })
 })


### PR DESCRIPTION
## Summary

Gate Modal sandbox validation before merge without turning every pull request into a remote smoke run. This change makes `sandbox-tests` a required pull-request check for `main`, routes sandbox relevance through the shared path taxonomy, runs real Modal smoke only for trusted lifecycle-sensitive changes, and returns a fast success placeholder for unrelated changes and fork PRs that cannot safely access Modal secrets.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `gate-sandbox-tests-on-pr`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - CI gating, ruleset, and maintainer workflow behavior only

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- `scripts/path-taxonomy.ts` now exposes `sandboxRelevant` so the sandbox workflow and tests share one lifecycle-sensitive path contract.
- `.github/workflows/sandbox-tests.yml` always publishes the `sandbox-tests` context on PRs and protected-branch pushes, but only starts Modal for trusted sandbox-relevant changes.
- The active `protect-main` GitHub ruleset was updated during this rollout so `sandbox-tests` is now a required status check alongside the existing CI contexts.
