### PR TITLE
ci(release-governance): validate release PR trust before exemptions

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -60,9 +60,40 @@ jobs:
           CHANGED_FILES_JSON: ${{ steps.changed-files.outputs.changed_files }}
         run: bun run scripts/path-taxonomy.ts
 
+      - name: Read base package version for release PR validation
+        id: base-version
+        if: startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const packageJson = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'package.json',
+              ref: context.payload.pull_request.base.sha,
+            })
+
+            const basePackageJson = JSON.parse(Buffer.from(packageJson.data.content, 'base64').toString('utf8'))
+            core.setOutput('base_version', basePackageJson.version)
+
+      - name: Validate release PR policy
+        id: release-pr
+        if: startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
+        env:
+          CHANGED_FILES_JSON: ${{ steps.classify.outputs.changed_files }}
+          PR_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+          PR_BASE_VERSION: ${{ steps.base-version.outputs.base_version }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          bun run scripts/release-pr-policy.js
+          echo "validated=true" >> "$GITHUB_OUTPUT"
+
       - name: Validate PR body
         env:
           CHANGED_FILES_JSON: ${{ steps.classify.outputs.changed_files }}
+          PR_IS_VALIDATED_RELEASE_PR: ${{ steps.release-pr.outputs.validated == 'true' }}
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -71,4 +102,5 @@ jobs:
       - name: Validate PR merge commit policy
         env:
           PR_COMMITS_JSON: ${{ steps.commits.outputs.commits_json }}
+          PR_IS_VALIDATED_RELEASE_PR: ${{ steps.release-pr.outputs.validated == 'true' }}
         run: bun run scripts/pr-merge-commit-policy.ts

--- a/openspec/changes/fix-release-bot-merge-policy/.openspec.yaml
+++ b/openspec/changes/fix-release-bot-merge-policy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/fix-release-bot-merge-policy/design.md
+++ b/openspec/changes/fix-release-bot-merge-policy/design.md
@@ -1,0 +1,60 @@
+## Context
+
+Quantex uses two governance lanes for pull requests:
+
+- `PR Governance` runs on every pull request and validates body requirements plus squash-merge safety.
+- `Release PR Automerge` runs on `pull_request_target` for release-please branches and validates release-specific scope before enabling auto-merge.
+
+Today these lanes disagree. `Release PR Automerge` trusts the repository GitHub App release bot and merges the release PR, while `PR Governance` rejects the same PR because its single generated commit uses a bot noreply identity that matches the generic risky-author blocklist.
+
+At the same time, `PR body` governance currently exempts any branch whose name starts with `release-please--branches--`, which is broader than the actual trusted release flow.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make release PR trust decisions come from one explicit validation path.
+- Allow the repository release bot identity only when the pull request is a validated release PR.
+- Keep generic bot-author and multi-commit squash protections unchanged for ordinary PRs.
+
+**Non-Goals:**
+
+- Changing release-please file scope, title, or version semantics.
+- Relaxing co-author trailer protections for non-release PRs.
+- Stabilizing the separate post-merge `self-managed` sandbox failures.
+
+## Decisions
+
+### Reuse the shared release PR validator inside PR Governance
+
+`PR Governance` will run `scripts/release-pr-policy.js` for branches that claim to be release-please branches. This makes release exceptions depend on the same branch, body marker, file scope, and version progression rules already used by release automation.
+
+Alternative considered: allow the release bot identity directly inside `pr-merge-commit-policy.ts`. Rejected because a bot allowlist without release PR validation would let branch naming or author spoofing bypass unrelated governance checks.
+
+### Propagate a validated release PR flag into local governance scripts
+
+After `PR Governance` validates a release PR, it will pass `PR_IS_VALIDATED_RELEASE_PR=true` into both local governance scripts. The scripts remain locally executable and do not need to embed GitHub API logic.
+
+Alternative considered: duplicate release PR validation logic in `pr-body-policy.ts` and `pr-merge-commit-policy.ts`. Rejected because it would fragment policy and drift from release automation.
+
+### Keep the bot exemption exact and narrow
+
+`pr-merge-commit-policy.ts` will continue to block generic bot noreply authors. It will exempt only the exact repository release bot identity, and only when `validatedReleasePr` is true. Direct `Co-authored-by:` trailers and multi-commit PRs remain failures.
+
+## Risks / Trade-offs
+
+- [Risk] `PR Governance` becomes slightly more complex because it now evaluates release PR shape before body/merge checks. → Mitigation: reuse the existing shared validator and pass only a boolean into downstream scripts.
+- [Risk] The repository release bot identity could change in the future. → Mitigation: keep the trusted identity centralized in one helper and cover it with unit tests so drift is obvious.
+- [Risk] A broken release PR now fails earlier in `PR Governance` instead of only in release auto-merge. → Mitigation: this is intentional; it surfaces invalid release PRs before merge gates disagree.
+
+## Migration Plan
+
+1. Add the release PR validation step and base-version lookup to `PR Governance`.
+2. Gate release-specific body and merge-policy exceptions on the validated release PR flag.
+3. Add unit and workflow contract tests for the new signal.
+
+No data migration or rollback tooling is required. If rollback is needed, the workflow and script changes can be reverted together.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/fix-release-bot-merge-policy/proposal.md
+++ b/openspec/changes/fix-release-bot-merge-policy/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+`PR Governance` currently blocks the repository GitHub App release bot because `scripts/pr-merge-commit-policy.ts` treats all bot noreply authors as squash-merge trailer risks. That conflicts with the existing release flow, where release-please PRs already have dedicated scope validation and are auto-merged by trusted automation.
+
+The current branch-name-only release-please carveout in `scripts/pr-body-policy.ts` is also too weak as a trust signal. A release-shaped exception should be granted only after the PR has passed the shared release PR validator.
+
+## What Changes
+
+- Validate release-please PRs inside `PR Governance` with the shared `release-pr-policy.js` contract before any release-specific exception is granted.
+- Pass that validated release PR status into PR body and PR merge commit governance.
+- Allow the repository release bot identity only for validated release PRs while keeping generic bot/co-author protections in place.
+
+## Impact
+
+- Release PR governance becomes internally consistent with release automation.
+- Non-release PRs cannot bypass release-intent or merge-commit checks by only mimicking the release-please branch naming pattern.
+- Protected-branch squash merge safeguards remain in force for ordinary bot-authored or multi-commit PRs.

--- a/openspec/changes/fix-release-bot-merge-policy/specs/release-governance/spec.md
+++ b/openspec/changes/fix-release-bot-merge-policy/specs/release-governance/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Release PRs Keep Dedicated Validation
+
+Release-please generated Release PRs SHALL remain governed by the dedicated Release PR validator instead of the product-impacting release-intent check. PR Governance MUST run the shared Release PR validator for release-please branches before granting any release-specific exception in other local governance checks.
+
+#### Scenario: Release-please PR opens
+
+- **WHEN** a pull request comes from a release-please branch
+- **THEN** PR Governance does not require product-impacting release intent for the version-file changes
+- **AND** PR Governance MUST first validate the branch, title, generated marker, changed file scope, and version progression with the shared Release PR validator
+- **AND** Release PR Automerge validates the release branch, title, generated marker, and changed file scope
+- **AND** it rejects a generated Release PR whose proposed semantic version is less than or equal to the current version on the protected base branch
+
+### Requirement: Protected-branch CI MUST reject prohibited co-author trailers in new commits
+
+Repository CI SHALL reject newly introduced commits on pull requests and protected-branch pushes when their commit messages contain `Co-authored-by:` trailers. PR Governance SHALL also reject pull requests before merge when their commit metadata is likely to make GitHub synthesize prohibited co-author trailers into the final squash merge commit. The merge commit policy validator SHALL fail when no commit metadata is supplied so the check cannot pass silently. A single generated commit authored by the repository release bot SHALL be allowed only when PR Governance has already validated that pull request as a release-please Release PR.
+
+#### Scenario: Pull request introduces co-author trailer
+
+- **WHEN** CI evaluates the commits introduced by a pull request targeting a protected branch
+- **AND** any of those commit messages contains a `Co-authored-by:` trailer
+- **THEN** CI fails before merge
+- **AND** it reports the offending commit SHA and trailer line
+
+#### Scenario: Pull request would generate co-author trailer on squash merge
+
+- **WHEN** PR Governance evaluates a pull request targeting a protected branch
+- **AND** its commit shape is unsafe for GitHub squash merge under the no-co-author-trailer policy
+- **THEN** PR Governance fails before merge
+- **AND** it explains how to pre-squash or re-author the pull request commits before retrying
+
+#### Scenario: Validated release PR uses trusted release bot author
+
+- **WHEN** PR Governance has already validated a release-please Release PR with the shared Release PR validator
+- **AND** the pull request contains exactly one generated commit authored by the repository release bot identity
+- **AND** that commit message does not contain a `Co-authored-by:` trailer
+- **THEN** the PR merge commit policy allows that author identity
+- **AND** other merge-shape failures such as multiple commits still remain blocking
+
+#### Scenario: PR merge commit policy receives no commit metadata
+
+- **WHEN** PR Governance runs the merge commit policy validator
+- **AND** no pull request commit metadata is supplied
+- **THEN** PR Governance fails before merge
+- **AND** it reports that the check cannot run without commit metadata
+
+#### Scenario: Protected-branch push introduces co-author trailer
+
+- **WHEN** CI evaluates the commits introduced by a direct push to a protected branch
+- **AND** any of those commit messages contains a `Co-authored-by:` trailer
+- **THEN** CI fails before downstream release automation treats the push as releasable history
+- **AND** it reports the offending commit SHA and trailer line

--- a/openspec/changes/fix-release-bot-merge-policy/tasks.md
+++ b/openspec/changes/fix-release-bot-merge-policy/tasks.md
@@ -1,0 +1,3 @@
+- [x] Validate release-please PR shape inside `PR Governance` and expose a validated release PR flag to downstream checks.
+- [x] Gate PR body release exceptions on the validated release PR flag instead of branch-name matching alone.
+- [x] Allow the trusted repository release bot identity only for validated release PRs in merge commit policy tests and implementation.

--- a/scripts/pr-body-policy.ts
+++ b/scripts/pr-body-policy.ts
@@ -7,6 +7,7 @@ export interface PrBodyPolicyInput {
   changedFiles?: string[]
   headBranch?: string
   title?: string
+  validatedReleasePr?: boolean
 }
 
 export const requiredPrBodyHeadings = [
@@ -23,8 +24,8 @@ const placeholderValues = new Set(['', 'n/a', 'none', 'not applicable', 'tbd', '
 
 export function validatePrBodyPolicy(input: PrBodyPolicyInput): string[] {
   const body = input.body || ''
-  const headBranch = input.headBranch || ''
   const title = input.title || ''
+  const validatedReleasePr = input.validatedReleasePr === true
   const issues: string[] = []
 
   const missingHeadings = requiredPrBodyHeadings.filter(heading => !body.includes(heading))
@@ -57,11 +58,9 @@ export function validatePrBodyPolicy(input: PrBodyPolicyInput): string[] {
     )
   }
 
-  const releasePleaseBranch = headBranch.startsWith('release-please--branches--')
-
   if (
     classification.productImpacting &&
-    !releasePleaseBranch &&
+    !validatedReleasePr &&
     !releaseWorthyMetadata &&
     !hasMeaningfulNoReleaseReason(body)
   ) {
@@ -121,13 +120,14 @@ if (import.meta.main) {
   const body = options.bodyFile ? readFileSync(options.bodyFile, 'utf8') : process.env.PR_BODY || ''
   const title = options.title ?? process.env.PR_TITLE ?? ''
   const headBranch = options.headBranch ?? process.env.PR_HEAD_BRANCH ?? ''
+  const validatedReleasePr = parseBooleanFlag(options.validatedReleasePr ?? process.env.PR_IS_VALIDATED_RELEASE_PR)
   const changedFiles = options.changedFilesJson
     ? parseChangedFiles(options.changedFilesJson)
     : process.env.CHANGED_FILES_JSON
       ? parseChangedFiles(process.env.CHANGED_FILES_JSON)
       : undefined
 
-  const issues = validatePrBodyPolicy({ body, changedFiles, headBranch, title })
+  const issues = validatePrBodyPolicy({ body, changedFiles, headBranch, title, validatedReleasePr })
 
   if (issues.length > 0) {
     console.error('PR body policy check failed:\n')
@@ -143,12 +143,14 @@ function parseArgs(args: string[]): {
   changedFilesJson?: string
   headBranch?: string
   title?: string
+  validatedReleasePr?: string
 } {
   const options: {
     bodyFile?: string
     changedFilesJson?: string
     headBranch?: string
     title?: string
+    validatedReleasePr?: string
   } = {}
 
   for (let index = 0; index < args.length; index += 1) {
@@ -167,6 +169,9 @@ function parseArgs(args: string[]): {
     } else if (arg === '--title' && nextValue) {
       options.title = nextValue
       index += 1
+    } else if (arg === '--validated-release-pr' && nextValue) {
+      options.validatedReleasePr = nextValue
+      index += 1
     } else {
       throw new Error(`Unknown or incomplete argument: ${arg}`)
     }
@@ -182,4 +187,9 @@ function parseChangedFiles(rawValue: string): string[] {
   }
 
   return parsedValue
+}
+
+function parseBooleanFlag(rawValue: string | undefined): boolean {
+  if (!rawValue) return false
+  return ['1', 'true', 'yes'].includes(rawValue.trim().toLowerCase())
 }

--- a/scripts/pr-merge-commit-policy.ts
+++ b/scripts/pr-merge-commit-policy.ts
@@ -9,13 +9,17 @@ export interface PullRequestCommitMetadata {
 
 export interface PullRequestMergeCommitPolicyInput {
   commits: PullRequestCommitMetadata[]
+  validatedReleasePr?: boolean
 }
 
 const prohibitedTrailerPattern = /^co-authored-by:\s*/i
 const riskyAuthorPatterns = [/cursoragent@cursor\.com/i, /^cursor agent$/i, /\[bot\]@users\.noreply\.github\.com$/i]
+const trustedReleaseBotEmailPattern = /^279595574\+quantex-cli-release-bot\[bot\]@users\.noreply\.github\.com$/i
+const trustedReleaseBotNamePattern = /^quantex-cli-release-bot\[bot\]$/i
 
 export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeCommitPolicyInput): string[] {
   const commits = input.commits
+  const validatedReleasePr = input.validatedReleasePr === true
   const issues: string[] = []
 
   if (commits.length === 0) {
@@ -49,6 +53,8 @@ export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeComm
   }
 
   for (const commit of commits) {
+    if (validatedReleasePr && isTrustedReleaseBotAuthor(commit)) continue
+
     const authorValues = [commit.authorEmail, commit.authorName].filter(Boolean) as string[]
     if (!authorValues.some(value => riskyAuthorPatterns.some(pattern => pattern.test(value)))) continue
 
@@ -66,7 +72,8 @@ export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeComm
 
 if (import.meta.main) {
   const commits = parseCommits(process.argv.slice(2), process.env.PR_COMMITS_JSON)
-  const issues = validatePullRequestMergeCommitPolicy({ commits })
+  const validatedReleasePr = parseBooleanFlag(process.env.PR_IS_VALIDATED_RELEASE_PR)
+  const issues = validatePullRequestMergeCommitPolicy({ commits, validatedReleasePr })
 
   if (issues.length > 0) {
     console.error('PR merge commit policy check failed:\n')
@@ -126,4 +133,16 @@ function formatSha(sha: string): string {
 function formatAuthor(commit: PullRequestCommitMetadata): string {
   if (commit.authorName && commit.authorEmail) return `${commit.authorName} <${commit.authorEmail}>`
   return commit.authorEmail ?? commit.authorName ?? '<unknown>'
+}
+
+function isTrustedReleaseBotAuthor(commit: PullRequestCommitMetadata): boolean {
+  return (
+    trustedReleaseBotEmailPattern.test(commit.authorEmail ?? '') &&
+    trustedReleaseBotNamePattern.test(commit.authorName ?? '')
+  )
+}
+
+function parseBooleanFlag(rawValue: string | undefined): boolean {
+  if (!rawValue) return false
+  return ['1', 'true', 'yes'].includes(rawValue.trim().toLowerCase())
 }

--- a/test/pr-body-policy.test.ts
+++ b/test/pr-body-policy.test.ts
@@ -90,13 +90,34 @@ describe('PR body policy', () => {
   })
 
   it('keeps release-please branches on dedicated release validation', () => {
+    const body = validBody.replace(
+      'Release: not applicable - docs/process/test-only change',
+      'Release: not applicable - n/a',
+    )
+
     expect(
       validatePrBodyPolicy({
-        body: validBody,
+        body,
         changedFiles: ['package.json'],
-        headBranch: 'release-please--branches--main--components--quantex-cli',
         title: 'chore: release 1.2.3',
+        validatedReleasePr: true,
       }),
     ).toEqual([])
+  })
+
+  it('does not trust release-please branch naming without validated release policy', () => {
+    const body = validBody.replace(
+      'Release: not applicable - docs/process/test-only change',
+      'Release: not applicable - n/a',
+    )
+
+    const issues = validatePrBodyPolicy({
+      body,
+      changedFiles: ['package.json'],
+      headBranch: 'release-please--branches--main--components--quantex-cli',
+      title: 'chore: release 1.2.3',
+    })
+
+    expect(issues.join('\n')).toContain('Product-impacting PRs must not silently skip release automation.')
   })
 })

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -53,6 +53,13 @@ describe('pr governance release intent', () => {
     expect(prGovernanceWorkflow).toContain('Validate PR merge commit policy')
     expect(prGovernanceWorkflow).toContain('bun run scripts/pr-merge-commit-policy.ts')
     expect(prGovernanceWorkflow).toContain('PR_COMMITS_JSON')
+    expect(prGovernanceWorkflow).toContain('PR_IS_VALIDATED_RELEASE_PR')
     expect(prMergeCommitPolicyScript).toContain('GitHub squash merge')
+  })
+
+  it('validates release-please PRs before granting release-specific exemptions', () => {
+    expect(prGovernanceWorkflow).toContain('Validate release PR policy')
+    expect(prGovernanceWorkflow).toContain('bun run scripts/release-pr-policy.js')
+    expect(prGovernanceWorkflow).toContain('PR_BASE_VERSION')
   })
 })

--- a/test/pr-merge-commit-policy.test.ts
+++ b/test/pr-merge-commit-policy.test.ts
@@ -63,6 +63,38 @@ describe('pr merge commit policy', () => {
     expect(issues).toContainEqual(expect.stringContaining('Re-author the commit'))
   })
 
+  it('rejects the release bot author on unvalidated pull requests', () => {
+    const issues = validatePullRequestMergeCommitPolicy({
+      commits: [
+        {
+          authorEmail: '279595574+quantex-cli-release-bot[bot]@users.noreply.github.com',
+          authorName: 'quantex-cli-release-bot[bot]',
+          message: 'chore: release 0.16.0',
+          sha: '88261fb1b9c4fbe11e2a5b883fc84a8bcb62f1f1',
+        },
+      ],
+    })
+
+    expect(issues).toContainEqual(expect.stringContaining('88261fb1b9c4'))
+    expect(issues).toContainEqual(expect.stringContaining('Re-author the commit'))
+  })
+
+  it('accepts the trusted release bot author for validated release PRs', () => {
+    expect(
+      validatePullRequestMergeCommitPolicy({
+        commits: [
+          {
+            authorEmail: '279595574+quantex-cli-release-bot[bot]@users.noreply.github.com',
+            authorName: 'quantex-cli-release-bot[bot]',
+            message: 'chore: release 0.16.0',
+            sha: '88261fb1b9c4fbe11e2a5b883fc84a8bcb62f1f1',
+          },
+        ],
+        validatedReleasePr: true,
+      }),
+    ).toEqual([])
+  })
+
   it('rejects direct co-author trailers in PR commit messages', () => {
     const issues = validatePullRequestMergeCommitPolicy({
       commits: [


### PR DESCRIPTION
## Summary

Align PR Governance with the trusted release-please lane so release bot commits are only exempt after the shared release PR policy passes.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `fix-release-bot-merge-policy`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - CI and governance-only change; no user-facing behavior delta
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This handles only the release-bot versus PR merge policy conflict. The post-merge `self-managed` sandbox instability remains split into a separate change.
