### PR TITLE
ci(sandbox): stabilize self-managed upgrade smoke

### DIFF
--- a/openspec/changes/stabilize-self-managed-sandbox/.openspec.yaml
+++ b/openspec/changes/stabilize-self-managed-sandbox/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/stabilize-self-managed-sandbox/design.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/design.md
@@ -1,0 +1,56 @@
+## Context
+
+Quantex keeps the expensive `self-managed` self-upgrade scenario in the protected-branch Modal workflow, not in the merge-gating PR profile. That scenario stages two local package tarballs, serves them from a sandbox-local registry, installs the older version through Bun, and verifies that `qtx upgrade` reaches the current checkout version.
+
+The current harness makes two unrealistic assumptions:
+
+- The mocked registry can publish only `name`, `version`, and tarball URLs.
+- A Bun-managed install rooted at an arbitrary `bun-global` directory behaves the same as a real `$HOME/.bun` install.
+
+In practice, Bun uses the version metadata from the registry packument to decide whether to create global shims and link runtime dependencies. The incomplete packument therefore installs `quantex-cli` without a runnable `qtx`. Even after that is fixed, Quantex would mis-detect the install source because its Bun detection logic expects `/.bun/install/global/` in the package root.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the sandbox-local registry resemble a real published package closely enough for Bun global installs to be runnable.
+- Make the self-managed smoke environment match Quantex's Bun install-source detection rules.
+- Preserve the current seeded-version and upgrade-check behavior of the scenario.
+
+**Non-Goals:**
+
+- Expanding the PR merge-gating sandbox profile.
+- Changing production self-upgrade provider logic.
+- Reworking Modal transport or non-self-managed lifecycle scenarios.
+
+## Decisions
+
+### Derive registry version entries from staged package manifests
+
+The local registry will reuse the staged `package.json` manifests for each tarball and only override the tarball URL under `dist`. This preserves fields such as `bin`, `dependencies`, `type`, and exports without having to maintain a hand-written allowlist.
+
+Alternative considered: add only `bin` and `dependencies` to the current minimal metadata. Rejected because it still leaves future package-manager-sensitive fields implicit and fragile.
+
+### Run the scenario under an isolated `HOME` with `.bun`
+
+The self-managed smoke will create `HOME=<sandbox>/home` and `BUN_INSTALL=$HOME/.bun`, then execute the seeded install and upgrade checks through `$HOME/.bun/bin/qtx`. That matches the layout already assumed by self-install detection and by the broader isolation workflow.
+
+Alternative considered: broaden Bun install-source detection to arbitrary custom roots. Rejected because the smoke harness should mimic production first; widening detection would change product behavior for a test-only workaround.
+
+## Risks / Trade-offs
+
+- [Risk] Reusing most staged package manifest fields makes the mocked registry payload larger. → Mitigation: the payload stays local to the sandbox and is simpler than maintaining a partial schema by hand.
+- [Risk] Future `package.json` changes could add fields that a mocked packument does not need. → Mitigation: that is acceptable; the goal is realism, and unit tests will cover the fields the harness depends on.
+- [Risk] The isolated `.bun` home could expose additional Bun-specific issues. → Mitigation: that is desirable for the protected-branch full sandbox profile.
+
+## Migration Plan
+
+1. Update the self-managed sandbox metadata helper and its unit tests.
+2. Update the lifecycle smoke harness to return staged manifests and run the Bun-managed scenario under an isolated `.bun` home.
+3. Re-run the targeted self-managed smoke locally, then the normal repository validation suite.
+
+No data migration is required. Rollback would be a straightforward revert of the harness and helper changes.
+
+## Open Questions
+
+- None.

--- a/openspec/changes/stabilize-self-managed-sandbox/proposal.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/proposal.md
@@ -1,0 +1,17 @@
+## Why
+
+The post-merge `Sandbox Tests` workflow still fails in the full `self-managed` scenario even after the PR gate was narrowed. The failure is not in Modal transport; it is in the sandbox harness itself.
+
+The current self-managed smoke setup returns a minimal local-registry packument and installs Quantex into an ad hoc `bun-global` root. Bun accepts that install, but it does not generate the `qtx` shim or link runtime dependencies because the mocked registry metadata omits fields Bun needs for a real global install. The custom install root also diverges from Quantex's real Bun-install detection rules.
+
+## What Changes
+
+- Make the sandbox-local registry expose version entries derived from the staged package manifests instead of only `name`, `version`, and tarball URLs.
+- Run the self-managed smoke scenario inside an isolated `HOME` with a real `.bun` layout so Bun-managed self-install detection matches production behavior.
+- Add unit coverage for the richer registry metadata used by the self-managed sandbox harness.
+
+## Impact
+
+- The post-merge full sandbox workflow regains stable `self-managed` coverage.
+- Self-managed smoke better reflects how published Bun installs behave in production.
+- The merge-gating PR sandbox profile remains unchanged; this only stabilizes the protected-branch full profile.

--- a/openspec/changes/stabilize-self-managed-sandbox/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/specs/code-quality-tooling/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: Optional isolation validation commands
+
+The repository SHALL expose `bun run test:sandbox` and `bun run test:container` as optional maintainer-facing validation commands for running real Quantex agent lifecycle smoke checks inside isolated Bun environments. These commands MUST complement rather than replace the canonical local `bun run test` workflow.
+
+#### Scenario: Isolation smoke includes Bun-managed self-upgrade
+
+- **WHEN** the isolated lifecycle smoke script runs the default self-upgrade coverage
+- **THEN** it seeds a Bun-managed Quantex install from a sandbox-local registry at a version older than the current checkout package
+- **AND** that sandbox-local registry publishes version metadata rich enough for Bun to create the global `qtx` entrypoint and link Quantex runtime dependencies
+- **AND** the seeded install runs under an isolated `HOME` with a `.bun` layout so Quantex detects the install source as Bun-managed
+- **AND** `quantex upgrade --check --no-cache` reports that a newer self version is available from that local registry
+- **AND** `quantex upgrade --no-cache` upgrades the managed install to the current checkout package version
+- **AND** the upgraded sandbox `qtx --version` output matches that current checkout package version

--- a/openspec/changes/stabilize-self-managed-sandbox/tasks.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/tasks.md
@@ -1,0 +1,3 @@
+- [x] Return staged package manifest metadata from the self-managed sandbox registry helper instead of hand-written minimal version entries.
+- [x] Run the self-managed smoke scenario inside an isolated `.bun` home layout so Bun-managed self-install detection matches production.
+- [x] Add unit coverage for the richer sandbox registry metadata and verify the targeted self-managed smoke path locally.

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -2,6 +2,8 @@ import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/pr
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
+import { loadConfig } from '../src/config'
+import { resolveManagedSelfUpdateRegistry } from '../src/self'
 import {
   buildSelfManagedRegistryMetadata,
   parsePackedTarballName,
@@ -200,10 +202,12 @@ async function smokeManagedSelfUpgradeLifecycle(): Promise<void> {
     const registry = await createSelfManagedRegistry(sandboxRoot, currentPackage)
 
     try {
-      const bunInstallDir = join(sandboxRoot, 'bun-global')
+      const sandboxHome = join(sandboxRoot, 'home')
+      const bunInstallDir = join(sandboxHome, '.bun')
       const managedBinDir = join(bunInstallDir, 'bin')
       const managedQtx = join(managedBinDir, 'qtx')
       const managedEnv = {
+        HOME: sandboxHome,
         BUN_INSTALL: bunInstallDir,
         PATH: `${managedBinDir}:${process.env.PATH ?? ''}`,
         QTX_SELF_UPDATE_REGISTRY: registry.registryUrl,
@@ -520,8 +524,8 @@ async function createSelfManagedRegistry(
   const seededStageDir = join(sandboxRoot, 'seeded-package')
 
   await mkdir(registryDir, { recursive: true })
-  await stageSelfManagedPackage(latestStageDir, currentPackage.version)
-  await stageSelfManagedPackage(seededStageDir, SEEDED_SELF_VERSION)
+  const latestManifest = await stageSelfManagedPackage(latestStageDir, currentPackage.version)
+  const seededManifest = await stageSelfManagedPackage(seededStageDir, SEEDED_SELF_VERSION)
 
   const latestTarball = await packSelfManagedPackage('pack latest self-managed package', latestStageDir, registryDir)
   const seededTarball = await packSelfManagedPackage('pack seeded self-managed package', seededStageDir, registryDir)
@@ -530,6 +534,7 @@ async function createSelfManagedRegistry(
   const encodedLatestPath = `${encodedPackagePath}/latest`
   const encodedSeededPath = `${encodedPackagePath}/${encodeURIComponent(SEEDED_SELF_VERSION)}`
   const encodedCurrentPath = `${encodedPackagePath}/${encodeURIComponent(currentPackage.version)}`
+  const dependencyRegistryOrigin = await resolveSelfManagedDependencyRegistry()
 
   let server: ReturnType<typeof Bun.serve>
   server = Bun.serve({
@@ -542,10 +547,10 @@ async function createSelfManagedRegistry(
       if (url.pathname === encodedPackagePath || url.pathname === `/${currentPackage.name}`) {
         return Response.json(
           buildSelfManagedRegistryMetadata({
+            latestPackageManifest: latestManifest,
             latestTarballName: latestTarball,
-            latestVersion: currentPackage.version,
             origin,
-            packageName: currentPackage.name,
+            seededPackageManifest: seededManifest,
             seededTarballName: seededTarball,
           }),
         )
@@ -571,7 +576,7 @@ async function createSelfManagedRegistry(
         })
       }
 
-      return new Response('not found', { status: 404 })
+      return Response.redirect(`${dependencyRegistryOrigin}${url.pathname}${url.search}`, 302)
     },
   })
 
@@ -581,7 +586,10 @@ async function createSelfManagedRegistry(
   }
 }
 
-async function stageSelfManagedPackage(stageDir: string, targetVersion: string): Promise<void> {
+async function stageSelfManagedPackage(
+  stageDir: string,
+  targetVersion: string,
+): Promise<Record<string, unknown> & { name: string; version: string }> {
   await mkdir(stageDir, { recursive: true })
   await cp(DIST_DIR, join(stageDir, DIST_DIR), { recursive: true })
   await cp(ROOT_PACKAGE_JSON_PATH, join(stageDir, ROOT_PACKAGE_JSON_PATH))
@@ -589,13 +597,18 @@ async function stageSelfManagedPackage(stageDir: string, targetVersion: string):
   const packageJsonPath = join(stageDir, ROOT_PACKAGE_JSON_PATH)
   const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as Record<string, unknown>
   const currentVersion = typeof packageJson.version === 'string' ? packageJson.version : undefined
+  const packageName = typeof packageJson.name === 'string' ? packageJson.name : undefined
 
-  if (!currentVersion) throw new Error('The root package.json must define version for the self-managed smoke scenario.')
+  if (!currentVersion || !packageName) {
+    throw new Error('The root package.json must define name and version for the self-managed smoke scenario.')
+  }
 
   packageJson.version = targetVersion
   await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`, 'utf8')
 
-  if (targetVersion === currentVersion) return
+  if (targetVersion === currentVersion) {
+    return packageJson as Record<string, unknown> & { name: string; version: string }
+  }
 
   const distFiles = await readdir(join(stageDir, DIST_DIR))
   for (const fileName of distFiles) {
@@ -605,6 +618,8 @@ async function stageSelfManagedPackage(stageDir: string, targetVersion: string):
     const content = await readFile(filePath, 'utf8')
     await writeFile(filePath, content.replaceAll(currentVersion, targetVersion), 'utf8')
   }
+
+  return packageJson as Record<string, unknown> & { name: string; version: string }
 }
 
 async function packSelfManagedPackage(label: string, packageDir: string, registryDir: string): Promise<string> {
@@ -618,4 +633,22 @@ async function packSelfManagedPackage(label: string, packageDir: string, registr
   if (!tarballName) throw new Error(`${label} did not report a tarball filename.`)
 
   return tarballName
+}
+
+async function resolveSelfManagedDependencyRegistry(): Promise<string> {
+  const envOverride = process.env.QTX_SELF_MANAGED_DEPENDENCY_REGISTRY?.trim()
+  if (envOverride) return envOverride.replace(/\/+$/, '')
+
+  const config = await loadConfig()
+  const resolution = await resolveManagedSelfUpdateRegistry(
+    'bun',
+    config,
+    {
+      ...process.env,
+      QTX_SELF_UPDATE_REGISTRY: '',
+    },
+    process.cwd(),
+  )
+
+  return resolution?.registry ?? 'https://registry.npmjs.org'
 }

--- a/src/testing/self-upgrade-sandbox.ts
+++ b/src/testing/self-upgrade-sandbox.ts
@@ -2,49 +2,41 @@ import { basename } from 'node:path'
 
 export const SEEDED_SELF_VERSION = '0.0.0-sandbox-old'
 
+export interface SelfManagedRegistryPackageManifest extends Record<string, unknown> {
+  name: string
+  version: string
+}
+
 export function buildSelfManagedRegistryMetadata(options: {
-  latestTarballName: string
-  latestVersion: string
+  latestPackageManifest: SelfManagedRegistryPackageManifest
   origin: string
-  packageName: string
+  seededPackageManifest: SelfManagedRegistryPackageManifest
+  latestTarballName: string
   seededTarballName: string
-  seededVersion?: string
 }): {
   'dist-tags': { latest: string }
   name: string
-  versions: Record<
-    string,
-    {
-      dist: {
-        tarball: string
-      }
-      name: string
-      version: string
-    }
-  >
+  versions: Record<string, SelfManagedRegistryPackageManifest & { dist: { tarball: string } }>
 } {
-  const seededVersion = options.seededVersion ?? SEEDED_SELF_VERSION
+  const latestVersion = options.latestPackageManifest.version
+  const seededVersion = options.seededPackageManifest.version
 
   return {
     'dist-tags': {
-      latest: options.latestVersion,
+      latest: latestVersion,
     },
-    name: options.packageName,
+    name: options.latestPackageManifest.name,
     versions: {
-      [seededVersion]: {
-        dist: {
-          tarball: `${options.origin}/${options.seededTarballName}`,
-        },
-        name: options.packageName,
-        version: seededVersion,
-      },
-      [options.latestVersion]: {
-        dist: {
-          tarball: `${options.origin}/${options.latestTarballName}`,
-        },
-        name: options.packageName,
-        version: options.latestVersion,
-      },
+      [seededVersion]: buildRegistryVersionEntry(
+        options.seededPackageManifest,
+        options.origin,
+        options.seededTarballName,
+      ),
+      [latestVersion]: buildRegistryVersionEntry(
+        options.latestPackageManifest,
+        options.origin,
+        options.latestTarballName,
+      ),
     },
   }
 }
@@ -58,4 +50,17 @@ export function parsePackedTarballName(output: string): string | undefined {
     .at(-1)
 
   return lastLine ? basename(lastLine) : undefined
+}
+
+function buildRegistryVersionEntry(
+  manifest: SelfManagedRegistryPackageManifest,
+  origin: string,
+  tarballName: string,
+): SelfManagedRegistryPackageManifest & { dist: { tarball: string } } {
+  return {
+    ...manifest,
+    dist: {
+      tarball: `${origin}/${tarballName}`,
+    },
+  }
 }

--- a/test/testing/self-upgrade-sandbox.test.ts
+++ b/test/testing/self-upgrade-sandbox.test.ts
@@ -8,27 +8,65 @@ import {
 describe('buildSelfManagedRegistryMetadata', () => {
   it('publishes the current version as latest and keeps the seeded older version installable', () => {
     const metadata = buildSelfManagedRegistryMetadata({
+      latestPackageManifest: {
+        bin: {
+          qtx: './dist/cli.mjs',
+          quantex: './dist/cli.mjs',
+        },
+        dependencies: {
+          commander: '^14.0.3',
+        },
+        name: 'quantex-cli',
+        type: 'module',
+        version: '0.15.1',
+      },
       latestTarballName: 'quantex-cli-0.15.1.tgz',
-      latestVersion: '0.15.1',
       origin: 'http://127.0.0.1:4873',
-      packageName: 'quantex-cli',
+      seededPackageManifest: {
+        bin: {
+          qtx: './dist/cli.mjs',
+          quantex: './dist/cli.mjs',
+        },
+        dependencies: {
+          commander: '^14.0.3',
+        },
+        name: 'quantex-cli',
+        type: 'module',
+        version: SEEDED_SELF_VERSION,
+      },
       seededTarballName: 'quantex-cli-0.0.0-sandbox-old.tgz',
     })
 
     expect(metadata.name).toBe('quantex-cli')
     expect(metadata['dist-tags'].latest).toBe('0.15.1')
     expect(metadata.versions[SEEDED_SELF_VERSION]).toEqual({
+      bin: {
+        qtx: './dist/cli.mjs',
+        quantex: './dist/cli.mjs',
+      },
+      dependencies: {
+        commander: '^14.0.3',
+      },
       dist: {
         tarball: 'http://127.0.0.1:4873/quantex-cli-0.0.0-sandbox-old.tgz',
       },
       name: 'quantex-cli',
+      type: 'module',
       version: SEEDED_SELF_VERSION,
     })
     expect(metadata.versions['0.15.1']).toEqual({
+      bin: {
+        qtx: './dist/cli.mjs',
+        quantex: './dist/cli.mjs',
+      },
+      dependencies: {
+        commander: '^14.0.3',
+      },
       dist: {
         tarball: 'http://127.0.0.1:4873/quantex-cli-0.15.1.tgz',
       },
       name: 'quantex-cli',
+      type: 'module',
       version: '0.15.1',
     })
   })


### PR DESCRIPTION
## Summary

Stabilize the full sandbox `self-managed` smoke by serving richer local-registry metadata, redirecting dependency resolution to the configured upstream registry, and running the Bun-managed install under a real `.bun` home layout.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `stabilize-self-managed-sandbox`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - sandbox harness and CI validation only; no user-facing CLI behavior change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Additional targeted validation: `QTX_ISOLATION_SCENARIOS=self-managed bun run scripts/lifecycle-smoke.ts` passed locally after the harness changes.
