### PR TITLE
fix(sandbox): return full self-managed version metadata

### DIFF
--- a/openspec/changes/stabilize-self-managed-sandbox/design.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/design.md
@@ -25,9 +25,9 @@ In practice, Bun uses the version metadata from the registry packument to decide
 
 ## Decisions
 
-### Derive registry version entries from staged package manifests
+### Derive packument and version responses from staged package manifests
 
-The local registry will reuse the staged `package.json` manifests for each tarball and only override the tarball URL under `dist`. This preserves fields such as `bin`, `dependencies`, `type`, and exports without having to maintain a hand-written allowlist.
+The local registry will reuse the staged `package.json` manifests for each tarball and only override the tarball URL under `dist`. This applies both to the root packument response and to `/<pkg>/latest` or `/<pkg>/<version>` lookups. That preserves fields such as `bin`, `dependencies`, `type`, and exports without having to maintain a hand-written allowlist.
 
 Alternative considered: add only `bin` and `dependencies` to the current minimal metadata. Rejected because it still leaves future package-manager-sensitive fields implicit and fragile.
 

--- a/openspec/changes/stabilize-self-managed-sandbox/proposal.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/proposal.md
@@ -6,7 +6,7 @@ The current self-managed smoke setup returns a minimal local-registry packument 
 
 ## What Changes
 
-- Make the sandbox-local registry expose version entries derived from the staged package manifests instead of only `name`, `version`, and tarball URLs.
+- Make the sandbox-local registry expose both packument and version endpoints derived from the staged package manifests instead of only minimal `version` responses.
 - Run the self-managed smoke scenario inside an isolated `HOME` with a real `.bun` layout so Bun-managed self-install detection matches production behavior.
 - Add unit coverage for the richer registry metadata used by the self-managed sandbox harness.
 

--- a/openspec/changes/stabilize-self-managed-sandbox/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/specs/code-quality-tooling/spec.md
@@ -8,7 +8,7 @@ The repository SHALL expose `bun run test:sandbox` and `bun run test:container` 
 
 - **WHEN** the isolated lifecycle smoke script runs the default self-upgrade coverage
 - **THEN** it seeds a Bun-managed Quantex install from a sandbox-local registry at a version older than the current checkout package
-- **AND** that sandbox-local registry publishes version metadata rich enough for Bun to create the global `qtx` entrypoint and link Quantex runtime dependencies
+- **AND** that sandbox-local registry publishes both packument and version-endpoint metadata rich enough for Bun to create the global `qtx` entrypoint and link Quantex runtime dependencies
 - **AND** the seeded install runs under an isolated `HOME` with a `.bun` layout so Quantex detects the install source as Bun-managed
 - **AND** `quantex upgrade --check --no-cache` reports that a newer self version is available from that local registry
 - **AND** `quantex upgrade --no-cache` upgrades the managed install to the current checkout package version

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -529,6 +529,20 @@ async function createSelfManagedRegistry(
 
   const latestTarball = await packSelfManagedPackage('pack latest self-managed package', latestStageDir, registryDir)
   const seededTarball = await packSelfManagedPackage('pack seeded self-managed package', seededStageDir, registryDir)
+  const latestRegistryEntry = buildSelfManagedRegistryMetadata({
+    latestPackageManifest: latestManifest,
+    latestTarballName: latestTarball,
+    origin: 'http://placeholder.invalid',
+    seededPackageManifest: seededManifest,
+    seededTarballName: seededTarball,
+  }).versions[currentPackage.version]
+  const seededRegistryEntry = buildSelfManagedRegistryMetadata({
+    latestPackageManifest: latestManifest,
+    latestTarballName: latestTarball,
+    origin: 'http://placeholder.invalid',
+    seededPackageManifest: seededManifest,
+    seededTarballName: seededTarball,
+  }).versions[SEEDED_SELF_VERSION]
 
   const encodedPackagePath = `/${encodeURIComponent(currentPackage.name)}`
   const encodedLatestPath = `${encodedPackagePath}/latest`
@@ -556,9 +570,30 @@ async function createSelfManagedRegistry(
         )
       }
 
-      if (url.pathname === encodedLatestPath) return Response.json({ version: currentPackage.version })
-      if (url.pathname === encodedSeededPath) return Response.json({ version: SEEDED_SELF_VERSION })
-      if (url.pathname === encodedCurrentPath) return Response.json({ version: currentPackage.version })
+      if (url.pathname === encodedLatestPath) {
+        return Response.json({
+          ...latestRegistryEntry,
+          dist: {
+            tarball: `${origin}/${latestTarball}`,
+          },
+        })
+      }
+      if (url.pathname === encodedSeededPath) {
+        return Response.json({
+          ...seededRegistryEntry,
+          dist: {
+            tarball: `${origin}/${seededTarball}`,
+          },
+        })
+      }
+      if (url.pathname === encodedCurrentPath) {
+        return Response.json({
+          ...latestRegistryEntry,
+          dist: {
+            tarball: `${origin}/${latestTarball}`,
+          },
+        })
+      }
 
       if (url.pathname === `/${seededTarball}`) {
         return new Response(Bun.file(join(registryDir, seededTarball)), {


### PR DESCRIPTION
## Summary

Return full manifest payloads from the sandbox-local `latest` and `<version>` endpoints so Bun 1.3.11 can build the self-managed global `qtx` shim during protected-branch full sandbox runs.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `stabilize-self-managed-sandbox`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - sandbox harness follow-up only; no user-facing CLI change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Additional targeted validation: `QTX_ISOLATION_SCENARIOS=self-managed bun run scripts/lifecycle-smoke.ts` passed locally after this follow-up fix.
