### PR TITLE
ci(sandbox): resolve Bun global qtx shim path

### DIFF
--- a/openspec/changes/stabilize-self-managed-sandbox/design.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/design.md
@@ -33,7 +33,7 @@ Alternative considered: add only `bin` and `dependencies` to the current minimal
 
 ### Run the scenario under an isolated `HOME` with `.bun`
 
-The self-managed smoke will create `HOME=<sandbox>/home` and `BUN_INSTALL=$HOME/.bun`, then execute the seeded install and upgrade checks through `$HOME/.bun/bin/qtx`. That matches the layout already assumed by self-install detection and by the broader isolation workflow.
+The self-managed smoke will create `HOME=<sandbox>/home` and `BUN_INSTALL=$HOME/.bun`, then resolve the runnable `qtx` shim from `bun pm bin -g` after the seeded install. Some Bun runtimes, including the Linux sandbox image, install package state under the isolated `.bun` home while linking global binaries into a runtime-level bin directory such as `/usr/local/bin`; the smoke must follow Bun's reported bin directory instead of assuming `$BUN_INSTALL/bin/qtx`.
 
 Alternative considered: broaden Bun install-source detection to arbitrary custom roots. Rejected because the smoke harness should mimic production first; widening detection would change product behavior for a test-only workaround.
 

--- a/openspec/changes/stabilize-self-managed-sandbox/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/specs/code-quality-tooling/spec.md
@@ -10,6 +10,7 @@ The repository SHALL expose `bun run test:sandbox` and `bun run test:container` 
 - **THEN** it seeds a Bun-managed Quantex install from a sandbox-local registry at a version older than the current checkout package
 - **AND** that sandbox-local registry publishes both packument and version-endpoint metadata rich enough for Bun to create the global `qtx` entrypoint and link Quantex runtime dependencies
 - **AND** the seeded install runs under an isolated `HOME` with a `.bun` layout so Quantex detects the install source as Bun-managed
+- **AND** the smoke executes `qtx` from Bun's reported global bin directory instead of assuming the entrypoint is always under `$BUN_INSTALL/bin`
 - **AND** `quantex upgrade --check --no-cache` reports that a newer self version is available from that local registry
 - **AND** `quantex upgrade --no-cache` upgrades the managed install to the current checkout package version
 - **AND** the upgraded sandbox `qtx --version` output matches that current checkout package version

--- a/openspec/changes/stabilize-self-managed-sandbox/tasks.md
+++ b/openspec/changes/stabilize-self-managed-sandbox/tasks.md
@@ -1,3 +1,4 @@
 - [x] Return staged package manifest metadata from the self-managed sandbox registry helper instead of hand-written minimal version entries.
 - [x] Run the self-managed smoke scenario inside an isolated `.bun` home layout so Bun-managed self-install detection matches production.
 - [x] Add unit coverage for the richer sandbox registry metadata and verify the targeted self-managed smoke path locally.
+- [x] Resolve the self-managed smoke `qtx` entrypoint from Bun's reported global bin directory.

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -1,4 +1,4 @@
-import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { access, cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -7,6 +7,7 @@ import { resolveManagedSelfUpdateRegistry } from '../src/self'
 import {
   buildSelfManagedRegistryMetadata,
   parsePackedTarballName,
+  resolveBunGlobalBinaryPath,
   SEEDED_SELF_VERSION,
 } from '../src/testing/self-upgrade-sandbox'
 
@@ -205,7 +206,7 @@ async function smokeManagedSelfUpgradeLifecycle(): Promise<void> {
       const sandboxHome = join(sandboxRoot, 'home')
       const bunInstallDir = join(sandboxHome, '.bun')
       const managedBinDir = join(bunInstallDir, 'bin')
-      const managedQtx = join(managedBinDir, 'qtx')
+      let managedQtx = join(managedBinDir, 'qtx')
       const managedEnv = {
         HOME: sandboxHome,
         BUN_INSTALL: bunInstallDir,
@@ -218,6 +219,19 @@ async function smokeManagedSelfUpgradeLifecycle(): Promise<void> {
         'install seeded Bun-managed Quantex',
         ['bun', 'add', '-g', `${currentPackage.name}@${SEEDED_SELF_VERSION}`, '--registry', registry.registryUrl],
         { env: managedEnv },
+      )
+      const pmBin = await runText('resolve Bun global bin dir', ['bun', 'pm', 'bin', '-g'], {
+        env: managedEnv,
+      })
+      managedQtx = resolveBunGlobalBinaryPath({
+        binaryName: 'qtx',
+        fallbackBinDir: managedBinDir,
+        pmBinOutput: pmBin.stdout,
+      })
+      await assertFileExists(
+        managedQtx,
+        `Bun-managed qtx shim was not created at ${managedQtx} after installing seeded Quantex.`,
+        sandboxRoot,
       )
 
       const seededVersion = await runText('seeded Bun-managed qtx version', [managedQtx, '--version'], {
@@ -668,6 +682,20 @@ async function packSelfManagedPackage(label: string, packageDir: string, registr
   if (!tarballName) throw new Error(`${label} did not report a tarball filename.`)
 
   return tarballName
+}
+
+async function assertFileExists(path: string, message: string, debugRoot: string): Promise<void> {
+  try {
+    await access(path)
+  } catch (error) {
+    await dumpDirectoryTree(debugRoot)
+    throw new Error(message, { cause: error })
+  }
+}
+
+async function dumpDirectoryTree(root: string): Promise<void> {
+  const output = await runCommand('debug self-managed sandbox tree', ['find', root, '-maxdepth', '5', '-print'])
+  process.stderr.write(`[self-managed sandbox tree]\n${output.stdout}`)
 }
 
 async function resolveSelfManagedDependencyRegistry(): Promise<string> {

--- a/src/testing/self-upgrade-sandbox.ts
+++ b/src/testing/self-upgrade-sandbox.ts
@@ -1,4 +1,4 @@
-import { basename } from 'node:path'
+import { basename, join } from 'node:path'
 
 export const SEEDED_SELF_VERSION = '0.0.0-sandbox-old'
 
@@ -50,6 +50,21 @@ export function parsePackedTarballName(output: string): string | undefined {
     .at(-1)
 
   return lastLine ? basename(lastLine) : undefined
+}
+
+export function resolveBunGlobalBinaryPath(options: {
+  binaryName: string
+  fallbackBinDir: string
+  pmBinOutput: string
+}): string {
+  const resolvedBinDir = options.pmBinOutput
+    .trim()
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .at(-1)
+
+  return join(resolvedBinDir || options.fallbackBinDir, options.binaryName)
 }
 
 function buildRegistryVersionEntry(

--- a/test/testing/self-upgrade-sandbox.test.ts
+++ b/test/testing/self-upgrade-sandbox.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildSelfManagedRegistryMetadata,
   parsePackedTarballName,
+  resolveBunGlobalBinaryPath,
   SEEDED_SELF_VERSION,
 } from '../../src/testing/self-upgrade-sandbox'
 
@@ -84,5 +85,27 @@ describe('parsePackedTarballName', () => {
 
   it('returns undefined when pack output is empty', () => {
     expect(parsePackedTarballName('\n\n')).toBeUndefined()
+  })
+})
+
+describe('resolveBunGlobalBinaryPath', () => {
+  it('uses the actual Bun global bin directory reported by bun pm bin -g', () => {
+    expect(
+      resolveBunGlobalBinaryPath({
+        binaryName: 'qtx',
+        fallbackBinDir: '/tmp/quantex/home/.bun/bin',
+        pmBinOutput: '/usr/local/bin\n',
+      }),
+    ).toBe('/usr/local/bin/qtx')
+  })
+
+  it('falls back to the isolated BUN_INSTALL bin directory when Bun reports no bin path', () => {
+    expect(
+      resolveBunGlobalBinaryPath({
+        binaryName: 'qtx',
+        fallbackBinDir: '/tmp/quantex/home/.bun/bin',
+        pmBinOutput: '\n',
+      }),
+    ).toBe('/tmp/quantex/home/.bun/bin/qtx')
   })
 })


### PR DESCRIPTION
## Summary

Fix the protected-branch self-managed sandbox smoke by resolving the runnable `qtx` shim from `bun pm bin -g` after the seeded Bun install.

The failed run installed `quantex-cli` into the isolated Bun package state, but Bun 1.3.11 in the Linux sandbox linked global binaries under `/usr/local/bin` instead of `$BUN_INSTALL/bin`. The smoke then tried to spawn `$HOME/.bun/bin/qtx` and failed with `ENOENT`.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `stabilize-self-managed-sandbox`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [x] `QTX_ISOLATION_SCENARIOS=self-managed QTX_ISOLATION_AGENTS=pi,opencode bun run test:container`
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This keeps the isolated `.bun` package layout so Quantex still detects the self install as Bun-managed, but follows Bun's actual global executable directory for the smoke entrypoint.
