### PR TITLE
ci(sandbox): preserve Bun bin path separators

### DIFF
--- a/src/testing/self-upgrade-sandbox.ts
+++ b/src/testing/self-upgrade-sandbox.ts
@@ -1,4 +1,4 @@
-import { basename, join } from 'node:path'
+import { basename } from 'node:path'
 
 export const SEEDED_SELF_VERSION = '0.0.0-sandbox-old'
 
@@ -64,7 +64,12 @@ export function resolveBunGlobalBinaryPath(options: {
     .filter(Boolean)
     .at(-1)
 
-  return join(resolvedBinDir || options.fallbackBinDir, options.binaryName)
+  return appendPathSegment(resolvedBinDir || options.fallbackBinDir, options.binaryName)
+}
+
+function appendPathSegment(parent: string, child: string): string {
+  const separator = parent.includes('\\') && !parent.includes('/') ? '\\' : '/'
+  return `${parent.replace(/[\\/]+$/, '')}${separator}${child}`
 }
 
 function buildRegistryVersionEntry(

--- a/test/testing/self-upgrade-sandbox.test.ts
+++ b/test/testing/self-upgrade-sandbox.test.ts
@@ -108,4 +108,14 @@ describe('resolveBunGlobalBinaryPath', () => {
       }),
     ).toBe('/tmp/quantex/home/.bun/bin/qtx')
   })
+
+  it('preserves Windows-style Bun bin directories', () => {
+    expect(
+      resolveBunGlobalBinaryPath({
+        binaryName: 'qtx',
+        fallbackBinDir: 'C:\\Users\\runner\\.bun\\bin',
+        pmBinOutput: 'C:\\Program Files\\Bun\\bin\n',
+      }),
+    ).toBe('C:\\Program Files\\Bun\\bin\\qtx')
+  })
 })


### PR DESCRIPTION
## Summary

Fix the Windows CI regression from the Bun global bin path helper by preserving the separator style returned by `bun pm bin -g`.

The previous helper used `node:path.join`, which is platform-dependent. On Windows tests it converted POSIX sandbox paths like `/usr/local/bin` into `\usr\local\bin`, causing assertions to fail even though the Linux sandbox path was correct.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `stabilize-self-managed-sandbox`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [x] `QTX_ISOLATION_SCENARIOS=self-managed QTX_ISOLATION_AGENTS=pi,opencode bun run test:container`
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [x] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This is a narrow cross-platform test helper correction for the already-merged sandbox fix.
