### PR TITLE
fix: stabilize managed agent update state

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Gemini CLI | `qtx gemini` | Google's open-source AI coding assistant CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot command-line tool |
 | Goose | `qtx goose` | Block's open-source extensible AI agent CLI |
-| jcode CLI | `qtx jcode` | High-performance coding agent harness for multi-session workflows |
+| JCode | `qtx jcode` | High-performance coding agent harness for multi-session workflows |
 | Junie CLI | `qtx junie` | JetBrains' AI coding agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
 | Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -185,7 +185,7 @@ qtx upgrade --channel beta
 | Gemini CLI | `qtx gemini` | Google 开源 AI 编程助手 CLI |
 | GitHub Copilot CLI | `qtx copilot` | GitHub Copilot 命令行工具 |
 | Goose | `qtx goose` | Block 开源可扩展 AI Agent CLI |
-| jcode CLI | `qtx jcode` | 面向多 session 工作流的高性能编程 Agent harness |
+| JCode | `qtx jcode` | 面向多 session 工作流的高性能编程 Agent harness |
 | Junie CLI | `qtx junie` | JetBrains 官方 AI 编程 Agent CLI |
 | Kilo CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
 | Kimi Code | `qtx kimi` | Moonshot AI 编程助手 CLI |

--- a/openspec/changes/add-jcode-cli-support/design.md
+++ b/openspec/changes/add-jcode-cli-support/design.md
@@ -20,7 +20,7 @@ Quantex should add `jcode` as a distinct supported lifecycle agent without inven
 
 ## Decisions
 
-- Use `jcode` as both the canonical Quantex slug and executable name because the upstream binary and project branding are both `jcode`.
+- Use `jcode` as both the canonical Quantex slug and executable name, and use `JCode` as the user-facing display name so supported-agent output follows the brand-style naming used by other agents.
 - Use the GitHub repository URL as the homepage because the upstream repository README is the primary published installation reference.
 - Model the macOS Homebrew option as `brew install 1jehuang/jcode/jcode`, which preserves the documented tap source while fitting Quantex's managed Homebrew metadata shape.
 - Model the shell and PowerShell one-liners from the upstream installation docs as script install methods for macOS, Linux, and Windows.

--- a/openspec/changes/add-jcode-cli-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-jcode-cli-support/specs/agent-catalog/spec.md
@@ -10,6 +10,7 @@ Quantex SHALL include `jcode` in the supported agent catalog with lifecycle-focu
 
 - **WHEN** a user or machine consumer looks up the canonical agent name `jcode`
 - **THEN** Quantex returns a supported agent entry for `jcode`
+- **AND** the entry displays the user-facing agent name as `JCode`
 - **AND** the entry identifies `jcode` as the executable binary
 - **AND** the entry identifies `https://github.com/1jehuang/jcode` as the homepage
 

--- a/openspec/changes/add-jcode-cli-support/tasks.md
+++ b/openspec/changes/add-jcode-cli-support/tasks.md
@@ -8,6 +8,7 @@
 - [x] 2.1 Add `src/agents/definitions/jcode.ts` with verified lifecycle metadata
 - [x] 2.2 Register and re-export `jcode` in the agent catalog
 - [x] 2.3 Add tests covering `jcode` lookup, version probing, install methods, and missing self-update metadata
+- [x] 2.4 Align the user-facing `JCode` display name across catalog, tests, docs, and spec delta
 
 ## 3. Validation
 

--- a/openspec/changes/fix-managed-bun-update-state/.openspec.yaml
+++ b/openspec/changes/fix-managed-bun-update-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/fix-managed-bun-update-state/design.md
+++ b/openspec/changes/fix-managed-bun-update-state/design.md
@@ -1,0 +1,33 @@
+## Context
+
+Managed package updates are planned by comparing an agent inspection's installed version with the latest package version. For Bun-managed agents, the installed version can be missing or stale when the agent binary does not expose a package-aligned `--version` output. The batch update then runs `bun update -g` repeatedly and reports successful updates every time.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prefer the installed managed package version when an agent has recorded managed install state and package metadata.
+- Keep binary version probing as the fallback for unmanaged installs and managed installers whose package version cannot be inspected.
+- Ensure repeated managed Bun updates report `up-to-date` after the installed package version matches latest.
+- Recover stale lifecycle locks created by older or interrupted Quantex processes.
+
+**Non-Goals:**
+
+- Do not add a new workflow/orchestration layer for updates.
+- Do not change install source selection or package manager update commands.
+- Do not broaden the fix to untracked `PATH` installs.
+
+## Decisions
+
+- Add managed package version inspection behind the package-manager abstraction.
+  This keeps installer-specific commands in `src/package-manager/` and lets inspection use the same recorded install source that update planning already trusts.
+- Use Bun global package listing output for Bun-managed package versions.
+  Bun does not currently provide a stable JSON output for this command in the supported runtime, so the parser should be narrow: find the requested package line and extract the version after the package name.
+- Use npm's global JSON listing for npm-managed package versions.
+  This is a straightforward parity path for the same lifecycle category and avoids making the inspection behavior Bun-only.
+
+## Risks / Trade-offs
+
+- [Bun output format changes] -> The parser is focused on package-name-plus-version tokens and falls back to binary probing when it cannot parse a version.
+- [Package version and binary version intentionally differ] -> Recorded managed installs are updated through package-manager metadata, so package version is the more relevant comparison for whether `quantex update` should run again.
+- [Lock recovery races with another process] -> Lock recovery only treats a lock as active when the recorded owner PID is alive, then recreates the lock directory atomically and still reports a lock conflict if another process wins the race.

--- a/openspec/changes/fix-managed-bun-update-state/proposal.md
+++ b/openspec/changes/fix-managed-bun-update-state/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`quantex update --all` can repeatedly report managed Bun agents such as GitHub Copilot CLI and Pi as updated even after Bun has already installed the latest package version. This makes the batch summary noisy and hides the real update state.
+
+## What Changes
+
+- Ensure managed Bun update results refresh or persist the installed package/version state after a successful update.
+- Ensure later `quantex update --all` runs compare against the refreshed state so already-current managed Bun agents report as up to date.
+- Recover stale lifecycle locks left behind by interrupted Quantex processes so a later update run is not permanently blocked.
+- Cover the regression with focused tests for managed Bun agents whose package manager updates to a newer version.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: Managed Bun updates must not keep reporting an agent as updated after the requested package is already at the installed latest version.
+
+## Impact
+
+- Affected specs: `openspec/specs/agent-update/spec.md`.
+- Affected code: agent update planning/execution, install-state persistence around managed Bun package updates, and lifecycle lock acquisition.
+- Affected tests: focused agent update tests for repeated managed Bun update runs and stale lock recovery.

--- a/openspec/changes/fix-managed-bun-update-state/specs/agent-update/spec.md
+++ b/openspec/changes/fix-managed-bun-update-state/specs/agent-update/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Managed package versions MUST drive managed update comparisons when available
+
+For agents with recorded managed install state and a known package name, Quantex SHALL inspect the installed managed package version and use it as the installed version for update planning when that package version is available.
+
+#### Scenario: Repeated Bun-managed batch update reports up to date
+
+- **GIVEN** an agent is recorded as installed through Bun with package name `@example/agent`
+- **AND** the installed Bun global package version is `2.0.0`
+- **AND** the latest package version is `2.0.0`
+- **WHEN** the user runs `quantex update --all`
+- **THEN** Quantex reports the agent as up to date
+- **AND** it does not execute a managed Bun update for that agent
+
+#### Scenario: Managed package version falls back to binary probing when unavailable
+
+- **GIVEN** an agent is recorded as installed through a managed package source
+- **AND** Quantex cannot determine the installed managed package version
+- **WHEN** Quantex inspects the agent for an update
+- **THEN** Quantex falls back to the agent binary version probe
+
+### Requirement: Agent lifecycle locks MUST recover from stale owners
+
+Quantex SHALL prevent concurrent agent lifecycle operations with a resource lock, and it MUST recover a lock left behind by an owner process that is no longer running.
+
+#### Scenario: Recovering a stale lifecycle lock
+
+- **GIVEN** an agent lifecycle lock exists
+- **AND** the lock owner process is no longer running
+- **WHEN** a later agent lifecycle command acquires the same lock
+- **THEN** Quantex removes the stale lock
+- **AND** the later command can continue
+
+#### Scenario: Preserving a live lifecycle lock
+
+- **GIVEN** an agent lifecycle lock exists
+- **AND** the lock owner process is still running
+- **WHEN** another agent lifecycle command tries to acquire the same lock
+- **THEN** Quantex reports a lock conflict
+- **AND** it does not remove the live lock

--- a/openspec/changes/fix-managed-bun-update-state/tasks.md
+++ b/openspec/changes/fix-managed-bun-update-state/tasks.md
@@ -1,0 +1,15 @@
+## 1. Managed Version Inspection
+
+- [x] 1.1 Add package-manager helpers to inspect installed managed package versions for Bun and npm.
+- [x] 1.2 Update agent inspection to prefer recorded managed package versions when available and fall back to binary version probes.
+
+## 2. Regression Coverage
+
+- [x] 2.1 Add focused tests for Bun global package version parsing.
+- [x] 2.2 Add update command coverage showing a repeated Bun-managed batch update reports up to date and does not execute Bun update.
+- [x] 2.3 Add resource-lock coverage for stale lifecycle lock recovery.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run openspec:status -- --change fix-managed-bun-update-state` and `bun run openspec:validate`.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run test`.

--- a/src/agents/definitions/jcode.ts
+++ b/src/agents/definitions/jcode.ts
@@ -3,7 +3,7 @@ import { brewInstall, scriptInstall } from '../methods'
 
 export const jcode: AgentDefinition = {
   name: 'jcode',
-  displayName: 'jcode CLI',
+  displayName: 'JCode',
   homepage: 'https://github.com/1jehuang/jcode',
   binaryName: 'jcode',
   versionProbe: {

--- a/src/inspection/agents.ts
+++ b/src/inspection/agents.ts
@@ -1,6 +1,6 @@
 import type { AgentDefinition, InstallMethod } from '../agents/types'
 import type { InstalledAgentState } from '../state'
-import { getOrderedInstallMethods } from '../package-manager'
+import { getManagedInstalledPackageVersion, getOrderedInstallMethods } from '../package-manager'
 import { getInstalledAgentState } from '../state'
 import { isBinaryInPath } from '../utils/detect'
 import {
@@ -8,6 +8,7 @@ import {
   formatUpdateManagement,
   getInstallLifecycle,
   getLatestVersionPackage,
+  isManagedInstallType,
 } from '../utils/install'
 import { getBinaryPath, getInstalledVersion, getLatestVersion, getResolvedBinaryPath } from '../utils/version'
 
@@ -33,7 +34,7 @@ export async function inspectAgent(agent: AgentDefinition): Promise<AgentInspect
   ])
 
   const [installedVersion, binaryPath, latestVersion] = await Promise.all([
-    inPath ? getInstalledVersion(agent.binaryName, agent.versionProbe) : Promise.resolve(undefined),
+    inPath ? getAgentInstalledVersion(agent, installedState) : Promise.resolve(undefined),
     inPath ? getBinaryPath(agent.binaryName) : Promise.resolve(undefined),
     getLatestVersionForAgent(agent, installedState, methods),
   ])
@@ -56,6 +57,23 @@ export async function inspectAgent(agent: AgentDefinition): Promise<AgentInspect
 
 export async function inspectAllAgents(agents: AgentDefinition[]): Promise<AgentInspection[]> {
   return Promise.all(agents.map(inspectAgent))
+}
+
+async function getAgentInstalledVersion(
+  agent: AgentDefinition,
+  installedState: InstalledAgentState | undefined,
+): Promise<string | undefined> {
+  if (installedState && isManagedInstallType(installedState.installType) && installedState.packageName) {
+    const managedPackageVersion = await getManagedInstalledPackageVersion(
+      installedState.installType,
+      installedState.packageName,
+      installedState.packageTargetKind,
+    )
+
+    if (managedPackageVersion) return managedPackageVersion
+  }
+
+  return getInstalledVersion(agent.binaryName, agent.versionProbe)
 }
 
 async function getLatestVersionForAgent(

--- a/src/package-manager/bun.ts
+++ b/src/package-manager/bun.ts
@@ -65,6 +65,35 @@ export async function uninstall(packageName: string): Promise<boolean> {
   }
 }
 
+export async function getInstalledVersion(packageName: string): Promise<string | undefined> {
+  try {
+    const proc = spawnCommand(['bun', 'pm', '-g', 'ls'], {
+      stdio: createPipedStdio(),
+    })
+    const { exitCode, stdout } = await readProcessOutput(proc)
+
+    if (exitCode !== 0) return undefined
+
+    return parseGlobalPackageVersion(stdout, packageName)
+  } catch {
+    return undefined
+  }
+}
+
+export function parseGlobalPackageVersion(output: string, packageName: string): string | undefined {
+  const marker = `${packageName}@`
+
+  for (const line of output.split('\n')) {
+    const packageToken = line.trim().split(/\s+/).at(-1)
+    if (!packageToken?.startsWith(marker)) continue
+
+    const version = packageToken.slice(marker.length)
+    if (version) return version
+  }
+
+  return undefined
+}
+
 async function runGlobalBunCommandWithTrust(command: string[], packageNames: string[]): Promise<boolean> {
   const exitCode = await waitForSpawnedCommand(spawnWithQuantexStdio(command))
 

--- a/src/package-manager/index.ts
+++ b/src/package-manager/index.ts
@@ -208,6 +208,18 @@ export async function updateAgentsByType(type: ManagedInstallType, packages: Man
   })
 }
 
+export async function getManagedInstalledPackageVersion(
+  type: ManagedInstallType,
+  packageName: string,
+  packageTargetKind?: InstalledAgentState['packageTargetKind'],
+): Promise<string | undefined> {
+  const installer = getManagedInstaller(type)
+  if (!installer.getInstalledVersion) return undefined
+  if (!(await installer.isAvailable())) return undefined
+
+  return installer.getInstalledVersion(packageName, packageTargetKind)
+}
+
 export async function uninstallAgent(agent: AgentDefinition): Promise<boolean> {
   return withResourceLock(lifecycleLock, async () => {
     const installedState = await getInstalledAgentState(agent.name)

--- a/src/package-manager/installers.ts
+++ b/src/package-manager/installers.ts
@@ -17,6 +17,7 @@ export interface ManagedInstallerUpdateOptions {
 
 export interface ManagedInstaller {
   type: ManagedInstallType
+  getInstalledVersion?: (packageName: string, packageTargetKind?: PackageTargetKind) => Promise<string | undefined>
   isAvailable: () => Promise<boolean>
   install: (packageName: string, packageTargetKind?: PackageTargetKind) => Promise<boolean>
   uninstall: (packageName: string, packageTargetKind?: PackageTargetKind) => Promise<boolean>
@@ -39,6 +40,7 @@ const managedInstallers: Record<ManagedInstallType, ManagedInstaller> = {
   },
   bun: {
     type: 'bun',
+    getInstalledVersion: async packageName => bunPm.getInstalledVersion(packageName),
     isAvailable: async () => isBunAvailable(),
     install: async packageName => bunPm.install(packageName),
     uninstall: async packageName => bunPm.uninstall(packageName),
@@ -52,6 +54,7 @@ const managedInstallers: Record<ManagedInstallType, ManagedInstaller> = {
   },
   npm: {
     type: 'npm',
+    getInstalledVersion: async packageName => npmPm.getInstalledVersion(packageName),
     isAvailable: async () => isNpmAvailable(),
     install: async packageName => npmPm.install(packageName),
     uninstall: async packageName => npmPm.uninstall(packageName),

--- a/src/package-manager/npm.ts
+++ b/src/package-manager/npm.ts
@@ -1,5 +1,5 @@
 import type { RegistryUpdateStrategy } from './bun'
-import { spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
+import { readProcessOutput, spawnCommand, spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
 import { normalizeRegistryUrl } from '../utils/registry'
 
 export async function install(packageName: string, distTag?: string, registry?: string): Promise<boolean> {
@@ -77,4 +77,28 @@ export async function uninstall(packageName: string): Promise<boolean> {
   } catch {
     return false
   }
+}
+
+export async function getInstalledVersion(packageName: string): Promise<string | undefined> {
+  try {
+    const proc = spawnCommand(['npm', 'list', '-g', '--depth=0', '--json'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    const { exitCode, stdout } = await readProcessOutput(proc)
+
+    if (exitCode !== 0) return undefined
+
+    return parseGlobalPackageVersion(stdout, packageName)
+  } catch {
+    return undefined
+  }
+}
+
+export function parseGlobalPackageVersion(output: string, packageName: string): string | undefined {
+  const data = JSON.parse(output) as {
+    dependencies?: Record<string, { version?: unknown }>
+  }
+  const version = data.dependencies?.[packageName]?.version
+
+  return typeof version === 'string' ? version : undefined
 }

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -1,5 +1,6 @@
-import { mkdir, rm } from 'node:fs/promises'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
+import process from 'node:process'
 import { getConfigDir } from '../config'
 
 interface ResourceLockOptions {
@@ -44,18 +45,78 @@ export async function acquireResourceLock(options: ResourceLockOptions): Promise
   const lockPath = getResourceLockPath(options.scope)
   await mkdir(dirname(lockPath), { recursive: true })
 
-  try {
-    await mkdir(lockPath, { recursive: false })
-  } catch (error) {
-    if (typeof error === 'object' && error && 'code' in error && (error as { code?: unknown }).code === 'EEXIST')
-      throw new ResourceLockError(options.resource, lockPath)
-
-    throw error
-  }
+  await createLockDirectory(options.resource, lockPath)
+  await writeLockOwner(lockPath)
 
   return async () => {
     await rm(lockPath, { force: true, recursive: true })
   }
+}
+
+async function createLockDirectory(resource: string, lockPath: string): Promise<void> {
+  try {
+    await mkdir(lockPath, { recursive: false })
+    return
+  } catch (error) {
+    if (!isFileExistsError(error)) throw error
+  }
+
+  if (!(await removeStaleLock(lockPath))) throw new ResourceLockError(resource, lockPath)
+
+  try {
+    await mkdir(lockPath, { recursive: false })
+  } catch (error) {
+    if (isFileExistsError(error)) throw new ResourceLockError(resource, lockPath)
+
+    throw error
+  }
+}
+
+async function writeLockOwner(lockPath: string): Promise<void> {
+  await writeFile(
+    join(lockPath, 'owner.json'),
+    `${JSON.stringify({
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+    })}\n`,
+    'utf8',
+  )
+}
+
+async function removeStaleLock(lockPath: string): Promise<boolean> {
+  const owner = await readLockOwner(lockPath)
+
+  if (owner && isProcessAlive(owner.pid)) return false
+
+  await rm(lockPath, { force: true, recursive: true })
+  return true
+}
+
+async function readLockOwner(lockPath: string): Promise<{ pid: number } | undefined> {
+  try {
+    const owner = JSON.parse(await readFile(join(lockPath, 'owner.json'), 'utf8')) as { pid?: unknown }
+    return typeof owner.pid === 'number' && Number.isInteger(owner.pid) && owner.pid > 0
+      ? { pid: owner.pid }
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    const code = typeof error === 'object' && error && 'code' in error ? (error as { code?: unknown }).code : undefined
+    return code === 'EPERM'
+  }
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return (
+    typeof error === 'object' && error !== null && 'code' in error && (error as { code?: unknown }).code === 'EEXIST'
+  )
 }
 
 export async function withResourceLock<T>(options: ResourceLockOptions, run: () => Promise<T>): Promise<T> {

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -423,7 +423,7 @@ describe('jcode', () => {
     validateAgent(jcode)
     expect(jcode.name).toBe('jcode')
     expect(jcode.lookupAliases).toBeUndefined()
-    expect(jcode.displayName).toBe('jcode CLI')
+    expect(jcode.displayName).toBe('JCode')
     expect(jcode.packages).toBeUndefined()
     expect(jcode.binaryName).toBe('jcode')
     expect(jcode.homepage).toBe('https://github.com/1jehuang/jcode')

--- a/test/commands/update.test.ts
+++ b/test/commands/update.test.ts
@@ -1,3 +1,4 @@
+import type { ManagedInstallType } from '../../src/package-manager'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as agents from '../../src/agents'
 import { resetCliContext, setCliContext } from '../../src/cli-context'
@@ -12,6 +13,7 @@ const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
 const allAgentsSpy = vi.spyOn(agents, 'getAllAgents')
 const updateSpy = vi.spyOn(pm, 'updateAgent')
 const updateAgentsByTypeSpy = vi.spyOn(pm, 'updateAgentsByType')
+const managedInstalledVersionSpy = vi.spyOn(pm, 'getManagedInstalledPackageVersion')
 const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
 const installedVerSpy = vi.spyOn(version, 'getInstalledVersion')
 const latestVerSpy = vi.spyOn(version, 'getLatestVersion')
@@ -22,6 +24,7 @@ afterAll(() => {
   allAgentsSpy.mockRestore()
   updateSpy.mockRestore()
   updateAgentsByTypeSpy.mockRestore()
+  managedInstalledVersionSpy.mockRestore()
   binaryInPathSpy.mockRestore()
   installedVerSpy.mockRestore()
   latestVerSpy.mockRestore()
@@ -54,6 +57,8 @@ describe('updateCommand', () => {
     allAgentsSpy.mockClear()
     updateSpy.mockClear()
     updateAgentsByTypeSpy.mockClear()
+    managedInstalledVersionSpy.mockClear()
+    managedInstalledVersionSpy.mockResolvedValue(undefined)
     binaryInPathSpy.mockClear()
     installedVerSpy.mockClear()
     latestVerSpy.mockClear()
@@ -137,6 +142,58 @@ describe('updateCommand', () => {
     expect(output).toContain('Agent 2: manual action required.')
     expect(output).toContain('detected in PATH but not tracked as a Quantex-managed install')
     expect(output).toContain('Summary: updated 1, manual 1')
+  })
+
+  it('reports tracked Bun agents as up to date when installed package versions match latest', async () => {
+    const piAgent = {
+      ...testAgent,
+      name: 'pi',
+      binaryName: 'pi',
+      packages: { npm: '@mariozechner/pi-coding-agent' },
+      displayName: 'Pi',
+    }
+
+    allAgentsSpy.mockReturnValue([testAgent, piAgent])
+    binaryInPathSpy.mockResolvedValue(true)
+    installedVerSpy.mockResolvedValue(undefined)
+    latestVerSpy.mockImplementation(async (packageName: string) => {
+      if (packageName === 'test-pkg') return '1.0.43'
+      if (packageName === '@mariozechner/pi-coding-agent') return '0.73.1'
+      return undefined
+    })
+    installedStateSpy.mockImplementation(async (name: string) => {
+      if (name === 'test-agent') {
+        return {
+          agentName: 'test-agent',
+          installType: 'bun',
+          packageName: 'test-pkg',
+        }
+      }
+
+      if (name === 'pi') {
+        return {
+          agentName: 'pi',
+          installType: 'bun',
+          packageName: '@mariozechner/pi-coding-agent',
+        }
+      }
+
+      return undefined
+    })
+    managedInstalledVersionSpy.mockImplementation(async (_type: ManagedInstallType, packageName: string) =>
+      packageName === 'test-pkg' ? '1.0.43' : packageName === '@mariozechner/pi-coding-agent' ? '0.73.1' : undefined,
+    )
+
+    await updateCommand(undefined, true)
+
+    expect(updateAgentsByTypeSpy).not.toHaveBeenCalled()
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(installedVerSpy).not.toHaveBeenCalled()
+
+    const output = stdoutWriteSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
+    expect(output).toContain('Test Agent is up to date (1.0.43)')
+    expect(output).toContain('Pi is up to date (0.73.1)')
+    expect(output).toContain('Summary: up to date 2')
   })
 
   it('skips detected PATH installs without auto-update support for --all', async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -170,7 +170,7 @@ describe('agent definitions', () => {
   it('jcode has correct structure', () => {
     const agent = getAgentByNameOrAlias('jcode')
     expect(agent).toBeDefined()
-    expect(agent!.displayName).toBe('jcode CLI')
+    expect(agent!.displayName).toBe('JCode')
     expect(agent!.binaryName).toBe('jcode')
     expect(agent!.homepage).toBe('https://github.com/1jehuang/jcode')
     expect(agent!.selfUpdate).toBeUndefined()

--- a/test/package-manager/bun.test.ts
+++ b/test/package-manager/bun.test.ts
@@ -172,6 +172,23 @@ describe('parseUntrustedPackages', () => {
   })
 })
 
+describe('parseGlobalPackageVersion', () => {
+  it('parses scoped and unscoped packages from Bun global list output', async () => {
+    const { parseGlobalPackageVersion } = await import('../../src/package-manager/bun')
+    const output = [
+      '/Users/test/.bun/install/global node_modules (534)',
+      '├── @github/copilot@1.0.43',
+      '├── @mariozechner/pi-coding-agent@0.73.1',
+      '└── quantex-cli@0.16.2',
+    ].join('\n')
+
+    expect(parseGlobalPackageVersion(output, '@github/copilot')).toBe('1.0.43')
+    expect(parseGlobalPackageVersion(output, '@mariozechner/pi-coding-agent')).toBe('0.73.1')
+    expect(parseGlobalPackageVersion(output, 'quantex-cli')).toBe('0.16.2')
+    expect(parseGlobalPackageVersion(output, 'missing-package')).toBeUndefined()
+  })
+})
+
 describe('bun uninstall', () => {
   it('returns true on success', async () => {
     const { uninstall } = await import('../../src/package-manager/bun')

--- a/test/self.test.ts
+++ b/test/self.test.ts
@@ -288,6 +288,7 @@ describe('self helpers', () => {
     const lockPath = getSelfUpgradeLockPath()
 
     await mkdir(lockPath, { recursive: true })
+    await writeFile(join(lockPath, 'owner.json'), `${JSON.stringify({ pid: process.pid })}\n`, 'utf8')
 
     try {
       const result = await upgradeSelf({

--- a/test/utils/lock.test.ts
+++ b/test/utils/lock.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, rmSync } from 'node:fs'
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -37,6 +37,35 @@ describe('resource locks', () => {
       name: 'ResourceLockError',
       resource: 'agent lifecycle',
     })
+
+    await release()
+  })
+
+  it('removes stale lock directories without live owner processes', async () => {
+    const lockPath = getResourceLockPath(['agent-lifecycle'])
+    mkdirSync(lockPath, { recursive: true })
+    writeFileSync(join(lockPath, 'owner.json'), `${JSON.stringify({ pid: 9_999_999 })}\n`, 'utf8')
+
+    const release = await acquireResourceLock({
+      resource: 'agent lifecycle',
+      scope: ['agent-lifecycle'],
+    })
+
+    expect(existsSync(join(lockPath, 'owner.json'))).toBe(true)
+
+    await release()
+  })
+
+  it('removes legacy empty lock directories as stale locks', async () => {
+    const lockPath = getResourceLockPath(['agent-lifecycle'])
+    mkdirSync(lockPath, { recursive: true })
+
+    const release = await acquireResourceLock({
+      resource: 'agent lifecycle',
+      scope: ['agent-lifecycle'],
+    })
+
+    expect(existsSync(join(lockPath, 'owner.json'))).toBe(true)
 
     await release()
   })


### PR DESCRIPTION
## Summary

Fixes repeated managed Bun updates by comparing tracked Bun/npm agents against their installed package versions, and recovers stale lifecycle locks left by interrupted runs. Also aligns jcode's user-facing display name to `JCode`.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `fix-managed-bun-update-state`, `add-jcode-cli-support`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is delegated to release automation.

## Notes

OpenSpec archive closure remains pending until the implementation PR merges.
