### PR TITLE
docs: sync quantex cli skill agent snapshot

### DIFF
--- a/openspec/changes/sync-quantex-cli-skill-agent-snapshot/.openspec.yaml
+++ b/openspec/changes/sync-quantex-cli-skill-agent-snapshot/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/sync-quantex-cli-skill-agent-snapshot/design.md
+++ b/openspec/changes/sync-quantex-cli-skill-agent-snapshot/design.md
@@ -1,0 +1,16 @@
+## Context
+
+`skills/quantex-cli` is the public agent-facing operation skill. It intentionally mirrors stable user-facing Quantex guidance, while the running CLI remains the source of truth for exact support.
+
+The implemented catalog and README already include `deepseek` and `jcode`. Only the skill command recipe snapshot lagged behind.
+
+## Decision
+
+Keep this as a documentation synchronization change. Do not alter CLI behavior, catalog metadata, command schemas, or runtime workflow.
+
+The skill should continue to say that `quantex capabilities --json` and `quantex commands --json` are authoritative for live environments.
+
+## Validation
+
+- Run the skill smoke check to verify discovery commands and structured envelopes.
+- Run the standard documentation-change validation set from the repository gate.

--- a/openspec/changes/sync-quantex-cli-skill-agent-snapshot/proposal.md
+++ b/openspec/changes/sync-quantex-cli-skill-agent-snapshot/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The user-facing `skills/quantex-cli` command reference drifted behind the implemented agent catalog: the skill snapshot omits `deepseek` and `jcode` even though the current CLI and product README expose both. This can mislead external agents that rely on the skill instead of probing the running binary first.
+
+## What Changes
+
+- Update the `skills/quantex-cli` supported-agent snapshot so it includes every currently implemented catalog agent.
+- Keep the skill guidance that the running binary remains the source of truth for exact command and output support.
+- Add a small product-doc contract delta so the public skill snapshot is kept aligned with the current CLI surface.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `product-readme`: require the user-facing Quantex CLI skill command reference to keep supported-agent snapshots aligned with the current CLI catalog.
+
+## Impact
+
+- `skills/quantex-cli/references/command-recipes.md` - sync the supported-agent snapshot with `quantex capabilities --json`.
+- `openspec/changes/sync-quantex-cli-skill-agent-snapshot/specs/product-readme/spec.md` - record the documentation contract delta.

--- a/openspec/changes/sync-quantex-cli-skill-agent-snapshot/specs/product-readme/spec.md
+++ b/openspec/changes/sync-quantex-cli-skill-agent-snapshot/specs/product-readme/spec.md
@@ -1,0 +1,25 @@
+# product-readme Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: README Distinguishes User Skill From Contributor Runtime
+
+The product README SHALL distinguish the user-facing Quantex CLI skill from the contributor-facing Quantex agent runtime skill.
+
+#### Scenario: User installs a Quantex skill from README
+
+- **WHEN** a user reads the agent quick start or skill installation guidance
+- **THEN** the normal skill installation path points to `skills/quantex-cli`
+- **AND** the documentation does not present `skills/quantex-agent-runtime` as a general user-facing skill
+
+#### Scenario: Contributor starts repository work
+
+- **WHEN** a contributor or coding agent is working inside this repository
+- **THEN** the repository workflow guidance may direct them to `skills/quantex-agent-runtime`
+- **AND** the guidance identifies it as repository development runtime rather than the public Quantex operation skill
+
+#### Scenario: User-facing skill lists supported agents
+
+- **WHEN** `skills/quantex-cli` includes a maintained supported-agent snapshot
+- **THEN** that snapshot matches the current implemented CLI catalog
+- **AND** the skill still directs consumers to the running binary for exact command, flag, and output support

--- a/openspec/changes/sync-quantex-cli-skill-agent-snapshot/tasks.md
+++ b/openspec/changes/sync-quantex-cli-skill-agent-snapshot/tasks.md
@@ -1,0 +1,16 @@
+## 1. Implementation
+
+- [x] Sync `skills/quantex-cli/references/command-recipes.md` with the current supported agent catalog.
+
+## 2. Validation
+
+- [x] Run `skills/quantex-cli/scripts/smoke-check.sh`.
+- [x] Run `bun run lint`.
+- [x] Run `bun run format:check`.
+- [x] Run `bun run typecheck`.
+- [x] Run `bun run openspec:validate`.
+
+## 3. Delivery
+
+- [ ] Commit and push the documentation sync.
+- [ ] Create a PR with a validated body file.

--- a/skills/quantex-cli/references/command-recipes.md
+++ b/skills/quantex-cli/references/command-recipes.md
@@ -15,11 +15,13 @@ This skill snapshot knows about these Quantex agent names:
 - `copilot`
 - `crush`
 - `cursor`
+- `deepseek`
 - `devin`
 - `droid`
 - `forgecode`
 - `gemini`
 - `goose`
+- `jcode`
 - `junie`
 - `kilo`
 - `kimi`


### PR DESCRIPTION
## Summary

Sync the user-facing `skills/quantex-cli` supported-agent snapshot with the current implemented catalog.

- Add `deepseek` and `jcode` to `skills/quantex-cli/references/command-recipes.md`
- Add an OpenSpec follow-up documenting that maintained public skill snapshots should match the current CLI catalog while still directing consumers to live discovery commands

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/sync-quantex-cli-skill-agent-snapshot`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [x] Not run, explained below

Additional validation:

- [x] `skills/quantex-cli/scripts/smoke-check.sh`
- [x] `bun run openspec:validate`
- [x] `bun run openspec:status -- --change sync-quantex-cli-skill-agent-snapshot`

Not run:

- `bun run test` - not run because this is a docs/OpenSpec skill snapshot sync with no runtime behavior change.

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

`quantex capabilities --json` reports 26 supported agents, and the skill snapshot now lists the same 26 names.
