### PR TITLE
feat: add Reasonix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Pi | `qtx pi` | Minimal and extensible terminal coding agent |
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |
 | Qwen Code | `qtx qwen` | Qwen's AI coding assistant CLI |
+| Reasonix | `qtx reasonix` | DeepSeek-native terminal coding agent |
 
 If you prefer the explicit long form, replace `qtx` with `quantex` in the examples above.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -196,6 +196,7 @@ qtx upgrade --channel beta
 | Pi | `qtx pi` | 极简可扩展的终端编程 Agent |
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |
 | Qwen Code | `qtx qwen` | Qwen AI 编程助手 CLI |
+| Reasonix | `qtx reasonix` | DeepSeek 原生终端编程 Agent |
 
 如果你更偏好显式长命令，上表里的 `qtx` 都可以直接替换成 `quantex`。
 

--- a/openspec/changes/add-reasonix-support/.openspec.yaml
+++ b/openspec/changes/add-reasonix-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/add-reasonix-support/design.md
+++ b/openspec/changes/add-reasonix-support/design.md
@@ -1,0 +1,48 @@
+## Context
+
+Reasonix is the current upstream product name, but the public GitHub repository is still `esengine/DeepSeek-Reasonix`, and the package metadata points at `esengine/reasonix`, which redirects to that repository. Upstream documentation currently verifies four lifecycle facts that matter to Quantex:
+
+- the npm package name is `reasonix`
+- the executable name is `reasonix`
+- the CLI supports `--version` through Commander
+- the documented self-update entrypoint is `reasonix update`
+
+Quantex already represents agent support as lifecycle-focused catalog metadata without provider-specific code paths. Reasonix should fit that model without adding new installer types or execution semantics.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add Reasonix as a supported Quantex lifecycle agent with verified upstream metadata.
+- Keep the catalog minimal and aligned to documented upstream install and update behavior.
+- Preserve discoverability for users who know the project by its repository name as well as its current product name.
+
+**Non-Goals:**
+
+- Add Reasonix-specific runtime integrations, prompts, or config handling.
+- Model `npx reasonix code` as a special install strategy distinct from Quantex's managed-install surface.
+- Add Bun, Homebrew, or script installers that upstream does not currently document as a supported packaged path.
+
+## Decisions
+
+### 1. Use `reasonix` as the canonical slug, binary, and npm package identifier
+
+Upstream package metadata, the documented CLI commands, and the visible product branding all use `reasonix`. Quantex should therefore expose `reasonix` as the canonical agent name and executable target instead of carrying forward the older repository name as the primary identifier.
+
+### 2. Accept `deepseek-reasonix` as a lookup alias
+
+The GitHub repository and website path still use `DeepSeek-Reasonix`, and the user requested support via that repository URL. Quantex should accept `deepseek-reasonix` as a lookup alias so users can resolve the agent by either the current product name or the repository-derived name without changing the canonical slug.
+
+### 3. Expose npm managed install on all platforms
+
+Upstream documents `npx reasonix code` as the recommended first-run path and `reasonix update` as the path that installs the global binary for daily use. Quantex's install surface is about durable installed CLIs on `PATH`, so the closest verified lifecycle mapping is the npm-managed global install method on Windows, macOS, and Linux.
+
+### 4. Probe and update via the root `reasonix` dispatcher
+
+The CLI source wires Commander `.version(VERSION)` on the root program and defines an `update` subcommand on the same dispatcher. Quantex should therefore use `reasonix --version` for version probes and `reasonix update` for self-update planning.
+
+## Risks / Trade-offs
+
+- [Upstream still prefers `npx` for first-time use] -> Keep Quantex scoped to durable installed CLI management and document only the managed install path in the catalog.
+- [Repository naming may change again] -> Use `reasonix` as canonical and keep the repository-derived alias limited to lookup convenience.
+- [Reasonix may add more install channels later] -> Start with the verified npm path and extend in a future OpenSpec change if upstream documents new supported installers.

--- a/openspec/changes/add-reasonix-support/proposal.md
+++ b/openspec/changes/add-reasonix-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+This request changes supported agent catalog metadata and user-facing supported-agent documentation, so it requires an OpenSpec-backed change before implementation. Reasonix now publishes a maintained npm package and CLI with documented install, version, and self-update surfaces, but Quantex cannot currently install, inspect, or launch it as a first-class lifecycle agent.
+
+## What Changes
+
+- Add a Reasonix agent definition with verified lifecycle metadata: canonical slug, display name, homepage, npm package metadata, executable name, install method, version probe, and self-update command.
+- Register Reasonix in the built-in agent catalog and root exports so lookup, inspection, resolution, execution, and update planning surfaces can use it.
+- Extend the `agent-catalog` capability with a Reasonix requirement that records the supported lookup names, install path, version probe, and self-update command.
+- Refresh product README agent tables so documented support matches the implemented catalog.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: add Reasonix as a supported lifecycle agent with verified install, version-probe, and self-update metadata
+
+## Impact
+
+- `src/agents/definitions/reasonix.ts` - new Reasonix catalog entry
+- `src/agents/index.ts` and `src/index.ts` - register and re-export Reasonix
+- `test/agents.test.ts` and `test/index.test.ts` - verify Reasonix metadata, lookup behavior, and root exports
+- `openspec/changes/add-reasonix-support/specs/agent-catalog/spec.md` - document the Reasonix requirement
+- `README.md` and `README.zh-CN.md` - sync supported-agent tables with implemented support

--- a/openspec/changes/add-reasonix-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-reasonix-support/specs/agent-catalog/spec.md
@@ -1,0 +1,30 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Reasonix MUST be a supported lifecycle agent
+
+Quantex SHALL include Reasonix in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Reasonix
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `reasonix` or the alias `deepseek-reasonix`
+- **THEN** Quantex returns a supported agent entry for Reasonix
+- **AND** the entry identifies `reasonix` as the executable binary
+- **AND** the entry identifies `reasonix` as its npm package metadata
+- **AND** the entry identifies `https://github.com/esengine/DeepSeek-Reasonix` as the homepage
+
+#### Scenario: Installing Reasonix through supported methods
+
+- **WHEN** Quantex renders or executes install options for Reasonix
+- **THEN** the catalog includes the npm-compatible managed install method on Windows, macOS, and Linux
+
+#### Scenario: Probing Reasonix version
+
+- **WHEN** Quantex probes the installed version of Reasonix
+- **THEN** it runs `reasonix --version` and parses the output
+
+#### Scenario: Planning Reasonix updates
+
+- **WHEN** Quantex plans an update for a Reasonix installation that supports self-update
+- **THEN** the catalog exposes `reasonix update` as the agent self-update command

--- a/openspec/changes/add-reasonix-support/tasks.md
+++ b/openspec/changes/add-reasonix-support/tasks.md
@@ -1,0 +1,19 @@
+## 1. Catalog Support
+
+- [x] 1.1 Add the Reasonix agent definition with verified lifecycle metadata.
+- [x] 1.2 Register and re-export Reasonix from the built-in agent catalog surfaces.
+- [x] 1.3 Add the Reasonix requirement to the `agent-catalog` spec delta.
+
+## 2. Tests And Docs
+
+- [x] 2.1 Add or update automated tests for Reasonix metadata, alias lookup, and root exports.
+- [x] 2.2 Sync `README.md` and `README.zh-CN.md` supported-agent tables with implemented support.
+
+## 3. Validation And Delivery
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.
+- [x] 3.6 Commit, push, and create the implementation PR.

--- a/src/agents/definitions/reasonix.ts
+++ b/src/agents/definitions/reasonix.ts
@@ -1,0 +1,24 @@
+import type { AgentDefinition } from '../types'
+import { npmInstall } from '../methods'
+
+export const reasonix: AgentDefinition = {
+  name: 'reasonix',
+  lookupAliases: ['deepseek-reasonix'],
+  displayName: 'Reasonix',
+  homepage: 'https://github.com/esengine/DeepSeek-Reasonix',
+  packages: {
+    npm: 'reasonix',
+  },
+  binaryName: 'reasonix',
+  selfUpdate: {
+    command: ['reasonix', 'update'],
+  },
+  versionProbe: {
+    command: ['reasonix', '--version'],
+  },
+  platforms: {
+    windows: [npmInstall()],
+    macos: [npmInstall()],
+    linux: [npmInstall()],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -24,6 +24,7 @@ import { openhands } from './definitions/openhands'
 import { pi } from './definitions/pi'
 import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
+import { reasonix } from './definitions/reasonix'
 import { vibe } from './definitions/vibe'
 
 const agents: AgentDefinition[] = [
@@ -52,6 +53,7 @@ const agents: AgentDefinition[] = [
   pi,
   qoder,
   qwen,
+  reasonix,
   vibe,
 ]
 
@@ -93,6 +95,7 @@ export {
   pi,
   qoder,
   qwen,
+  reasonix,
   vibe,
 }
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export {
   opencode,
   pi,
   qoder,
+  reasonix,
   vibe,
 } from './agents'
 export type {

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -20,6 +20,7 @@ import { openhands } from '../src/agents/definitions/openhands'
 import { pi } from '../src/agents/definitions/pi'
 import { qoder } from '../src/agents/definitions/qoder'
 import { qwen } from '../src/agents/definitions/qwen'
+import { reasonix } from '../src/agents/definitions/reasonix'
 import { vibe } from '../src/agents/definitions/vibe'
 import { formatInstallMethodCommand } from '../src/utils/install'
 
@@ -252,6 +253,31 @@ describe('copilot', () => {
     expect(copilot.platforms.macos!.find(m => m.type === 'brew' && m.packageName === 'copilot-cli')).toBeDefined()
     expect(copilot.platforms.linux!.find(m => m.type === 'brew' && m.packageName === 'copilot-cli')).toBeDefined()
     expect(copilot.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
+  })
+})
+
+describe('reasonix', () => {
+  it('is registered for lookup by canonical name and repository-style alias', () => {
+    expect(getAgentByNameOrAlias('reasonix')).toBe(reasonix)
+    expect(getAgentByLookupName('deepseek-reasonix')).toBe(reasonix)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(reasonix)
+    expect(reasonix.name).toBe('reasonix')
+    expect(reasonix.lookupAliases).toEqual(['deepseek-reasonix'])
+    expect(reasonix.displayName).toBe('Reasonix')
+    expect(reasonix.packages?.npm).toBe('reasonix')
+    expect(reasonix.binaryName).toBe('reasonix')
+    expect(reasonix.homepage).toBe('https://github.com/esengine/DeepSeek-Reasonix')
+    expect(reasonix.selfUpdate?.command).toEqual(['reasonix', 'update'])
+    expect(reasonix.versionProbe?.command).toEqual(['reasonix', '--version'])
+  })
+
+  it('supports npm installs on all platforms', () => {
+    expect(reasonix.platforms.windows!.find(m => m.type === 'npm')).toBeDefined()
+    expect(reasonix.platforms.macos!.find(m => m.type === 'npm')).toBeDefined()
+    expect(reasonix.platforms.linux!.find(m => m.type === 'npm')).toBeDefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,6 +21,7 @@ import {
   opencode,
   pi,
   qoder,
+  reasonix,
 } from '../src/index'
 
 describe('agent registry', () => {
@@ -91,6 +92,11 @@ describe('agent registry', () => {
   it('resolves Qoder by executable alias', () => {
     const agent = getAgentByLookupName('qodercli')
     expect(agent?.name).toBe('qoder')
+  })
+
+  it('resolves Reasonix by repository-style alias', () => {
+    const agent = getAgentByLookupName('deepseek-reasonix')
+    expect(agent?.name).toBe('reasonix')
   })
 })
 
@@ -192,6 +198,15 @@ describe('agent definitions', () => {
     expect(agent!.binaryName).toBe('qodercli')
   })
 
+  it('reasonix has correct structure', () => {
+    const agent = getAgentByNameOrAlias('reasonix')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('Reasonix')
+    expect(agent!.packages?.npm).toBe('reasonix')
+    expect(agent!.binaryName).toBe('reasonix')
+    expect(agent!.homepage).toBe('https://github.com/esengine/DeepSeek-Reasonix')
+  })
+
   it('re-exports all built-in agents from root index', () => {
     expect(autohand.name).toBe('autohand')
     expect(codebuddy.name).toBe('codebuddy')
@@ -209,6 +224,7 @@ describe('agent definitions', () => {
     expect(opencode.name).toBe('opencode')
     expect(pi.name).toBe('pi')
     expect(qoder.name).toBe('qoder')
+    expect(reasonix.name).toBe('reasonix')
   })
 })
 


### PR DESCRIPTION
## Summary

Add Reasonix to the supported Quantex agent catalog with verified npm install, `reasonix --version` probing, `reasonix update` self-update metadata, and a repository-style lookup alias. Sync the OpenSpec change and product README tables so the documented support surface matches the implementation.

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `openspec/changes/add-reasonix-support/`
- Discussion: none

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Canonical support uses `reasonix`, while `deepseek-reasonix` is accepted as a lookup alias for users who know the upstream repository name.
