### PR TITLE
fix(release): ignore already tagged release commits

### DIFF
--- a/openspec/changes/fix-release-target-resolution/specs/release-workflow/spec.md
+++ b/openspec/changes/fix-release-target-resolution/specs/release-workflow/spec.md
@@ -15,7 +15,15 @@ The Release workflow SHALL evaluate release relevance only after merge-gating CI
 
 - **WHEN** branch history contains a successful protected-branch `chore: release <version>` commit
 - **AND** the corresponding `v<version>` tag does not exist yet
+- **AND** no semver release tag points at that exact commit
 - **THEN** the Release workflow MUST prefer GitHub Release publication for that commit over creating or updating another Release PR
+
+#### Scenario: already tagged release commit has stale title version
+
+- **WHEN** branch history contains a successful protected-branch `chore: release <version>` commit
+- **AND** a semver release tag already points at that exact commit
+- **THEN** the Release workflow MUST treat that commit as already published
+- **AND** it MUST NOT count the stale title version as a pending untagged release commit
 
 #### Scenario: stale successful CI run is older than merged release commit
 

--- a/openspec/changes/fix-release-target-resolution/tasks.md
+++ b/openspec/changes/fix-release-target-resolution/tasks.md
@@ -8,6 +8,7 @@
 - [x] 2.1 Add a typed release-target resolver script that selects publish, Release PR, or skip from successful push-side CI history plus branch state.
 - [x] 2.2 Update `.github/workflows/release.yml` to use the resolver outputs for both `workflow_run` and `workflow_dispatch`.
 - [x] 2.3 Add automated tests that lock the resolver behavior for stale CI runs, pending untagged release commits, and manual recovery.
+- [x] 2.4 Treat release commits that already have a semver release tag on the same SHA as published, even when the commit title contains a stale version.
 
 ## 3. Docs And Validation
 

--- a/scripts/release-target-resolution.ts
+++ b/scripts/release-target-resolution.ts
@@ -34,10 +34,12 @@ export interface ReleaseTargetResolution {
 
 export interface SelectReleaseCandidateOptions {
   commitsBySha: Record<string, CommitReleaseIntent>
+  publishedReleaseShas: Set<string>
   publishedTags: Set<string>
   runs: SuccessfulCiRun[]
 }
 
+const releaseTagPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 const releaseCommitPattern = /^chore: release (?<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/
 const releaseWorthyPattern = /^(feat|fix|perf)(\(.+\))?!?:/
 
@@ -55,6 +57,7 @@ export function classifyCommitReleaseIntent(message: string): CommitReleaseInten
 
 export function selectReleaseCandidate({
   commitsBySha,
+  publishedReleaseShas,
   publishedTags,
   runs,
 }: SelectReleaseCandidateOptions): ReleaseTargetResolution {
@@ -62,7 +65,12 @@ export function selectReleaseCandidate({
 
   const pendingReleaseRuns = newestRuns.filter(run => {
     const commit = commitsBySha[run.headSha]
-    return commit?.isReleaseCommit && commit.releaseVersion && !publishedTags.has(`v${commit.releaseVersion}`)
+    return (
+      commit?.isReleaseCommit &&
+      commit.releaseVersion &&
+      !publishedTags.has(`v${commit.releaseVersion}`) &&
+      !publishedReleaseShas.has(run.headSha)
+    )
   })
 
   if (pendingReleaseRuns.length > 1) {
@@ -168,9 +176,13 @@ async function resolveReleaseTargetFromEnvironment(): Promise<ReleaseTargetResol
       .filter((version): version is string => Boolean(version))
       .filter(version => tagExists(`v${version}`)),
   )
+  const publishedReleaseShas = new Set(
+    reachableRuns.filter(run => releaseTagPointsAtCommit(run.headSha)).map(run => run.headSha),
+  )
 
   const resolution = selectReleaseCandidate({
     commitsBySha,
+    publishedReleaseShas,
     publishedTags: new Set([...publishedTags].map(version => `v${version}`)),
     runs: reachableRuns,
   })
@@ -299,6 +311,16 @@ function tagExists(tagName: string): boolean {
   try {
     execFileSyncCompatible('git', ['rev-parse', '--verify', '--quiet', `refs/tags/${tagName}`])
     return true
+  } catch {
+    return false
+  }
+}
+
+function releaseTagPointsAtCommit(sha: string): boolean {
+  try {
+    return execFileSyncCompatible('git', ['tag', '--points-at', sha, '--list', 'v*'])
+      .split('\n')
+      .some(tag => releaseTagPattern.test(tag.trim()))
   } catch {
     return false
   }

--- a/test/release-target-resolution.test.ts
+++ b/test/release-target-resolution.test.ts
@@ -26,6 +26,7 @@ describe('release target resolution', () => {
         rel123: commit('chore: release 0.16.4'),
         fix111: commit('fix(lock): close owner-less acquisition race'),
       },
+      publishedReleaseShas: new Set<string>(),
       publishedTags: new Set<string>(),
       runs: [
         run(30, 'docs999', '2026-05-09T07:10:00Z'),
@@ -45,6 +46,7 @@ describe('release target resolution', () => {
         docs999: commit('docs: sync runbook wording'),
         fix111: commit('fix(lock): close owner-less acquisition race'),
       },
+      publishedReleaseShas: new Set<string>(),
       publishedTags: new Set<string>(),
       runs: [run(30, 'docs999', '2026-05-09T07:10:00Z'), run(10, 'fix111', '2026-05-09T07:00:00Z')],
     })
@@ -59,6 +61,7 @@ describe('release target resolution', () => {
         docs999: commit('docs: sync runbook wording'),
         chore111: commit('chore: archive openspec deltas'),
       },
+      publishedReleaseShas: new Set<string>(),
       publishedTags: new Set<string>(),
       runs: [run(30, 'docs999', '2026-05-09T07:10:00Z'), run(10, 'chore111', '2026-05-09T07:00:00Z')],
     })
@@ -74,9 +77,26 @@ describe('release target resolution', () => {
           rel200: commit('chore: release 0.16.5'),
           rel100: commit('chore: release 0.16.4'),
         },
+        publishedReleaseShas: new Set<string>(),
         publishedTags: new Set<string>(),
         runs: [run(20, 'rel200', '2026-05-09T07:10:00Z'), run(10, 'rel100', '2026-05-09T07:00:00Z')],
       }),
     ).toThrow(/Multiple successful untagged release commits/)
+  })
+
+  it('does not treat a tagged release commit as pending when its title version is stale', () => {
+    const resolution = selectReleaseCandidate({
+      commitsBySha: {
+        rel164: commit('chore: release 0.16.4'),
+        rel060: commit('chore: release 0.5.1'),
+      },
+      publishedReleaseShas: new Set<string>(['rel060']),
+      publishedTags: new Set<string>(),
+      runs: [run(20, 'rel164', '2026-05-09T07:10:00Z'), run(10, 'rel060', '2026-04-29T19:00:00Z')],
+    })
+
+    expect(resolution.mode).toBe('publish')
+    expect(resolution.targetSha).toBe('rel164')
+    expect(resolution.reason).toContain('pending untagged release commit 0.16.4')
   })
 })


### PR DESCRIPTION
## Summary

Fix the Release workflow resolver so a `chore: release ...` commit is treated as already published when a semver release tag already points at that exact commit.

This addresses the failed Release run after #229. The resolver was counting an old main-branch commit titled `chore: release 0.5.1` as pending even though the commit was already published as `v0.6.0`; after this fix the resolver selects the real remaining pending release commit, `0.16.4`, instead of failing closed on two pending versions.

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: `openspec/changes/fix-release-target-resolution`
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Additional validation:

- [x] `bun test test/release-target-resolution.test.ts`
- [x] `bun run openspec:validate`
- [x] `GITHUB_REPOSITORY=Drswith/quantex-cli GH_TOKEN="$(gh auth token)" RELEASE_TARGET_BRANCH=main bun run scripts/release-target-resolution.ts`

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The failed run was `Release` job `75250984265` in run `25637157331`. It failed in `Resolve release target` with `Multiple successful untagged release commits are pending publication (0.16.4, 0.5.1)`.
