### PR TITLE
feat(agents): add VTCode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Qoder CLI | `qtx qoder` | Qoder's official AI coding assistant CLI |
 | Qwen Code | `qtx qwen` | Qwen's AI coding assistant CLI |
 | Reasonix | `qtx reasonix` | DeepSeek-native terminal coding agent |
+| VTCode | `qtx vtcode` | Open-source terminal coding agent with robust shell safety |
 
 If you prefer the explicit long form, replace `qtx` with `quantex` in the examples above.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -197,6 +197,7 @@ qtx upgrade --channel beta
 | Qoder CLI | `qtx qoder` | Qoder 官方 AI 编程助手 CLI |
 | Qwen Code | `qtx qwen` | Qwen AI 编程助手 CLI |
 | Reasonix | `qtx reasonix` | DeepSeek 原生终端编程 Agent |
+| VTCode | `qtx vtcode` | 开源终端编程 Agent，提供稳健 shell 安全能力 |
 
 如果你更偏好显式长命令，上表里的 `qtx` 都可以直接替换成 `quantex`。
 

--- a/openspec/changes/add-vtcode-support/.openspec.yaml
+++ b/openspec/changes/add-vtcode-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-10

--- a/openspec/changes/add-vtcode-support/design.md
+++ b/openspec/changes/add-vtcode-support/design.md
@@ -1,0 +1,46 @@
+## Context
+
+VTCode is distributed as a standalone Rust CLI named `vtcode`. Upstream documentation identifies the native installers as the recommended path, and also documents `cargo install vtcode`, `brew install vtcode`, standard `--version` support through clap, and a built-in update system under `vtcode update`.
+
+Quantex already represents supported agents as lifecycle-focused catalog metadata. The current main branch also includes Cargo as a managed install type, so VTCode can fit the existing catalog shape without adding new package-manager, execution, inspection, or update-planning behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add VTCode as a supported Quantex lifecycle agent with verified upstream metadata.
+- Expose official native installers, Cargo install metadata, Homebrew install metadata, version probing, and self-update metadata.
+- Keep the implementation limited to the existing agent catalog, README tables, and focused test coverage.
+
+**Non-Goals:**
+
+- Add VTCode-specific runtime integration, prompts, provider configuration, skills, ACP, MCP, or session-management behavior.
+- Model the optional search tools bundle or Ghostty VT runtime setup as separate Quantex install methods.
+- Add special handling for VTCode release channels, version pins, or mirror configuration beyond exposing the base `vtcode update` command.
+
+## Decisions
+
+### 1. Use `vtcode` as the canonical slug and executable
+
+The upstream package, binary, crate, and documented commands all use `vtcode`. Quantex should therefore expose `vtcode` as the canonical agent name and executable target without adding aliases.
+
+### 2. Record the upstream package metadata that Quantex can manage directly
+
+VTCode publishes a Cargo crate named `vtcode`, and Quantex now supports Cargo as a managed install type. The catalog should set `packages.cargo` to `vtcode` and include `cargoInstall()` on Windows, macOS, and Linux. The Homebrew core formula is documented for macOS/Linux, so the catalog should also include `brewInstall('vtcode')` on those platforms.
+
+### 3. Keep native installers as script install methods
+
+The README documents native macOS/Linux and Windows installer scripts. These are executable install guidance but not managed package-manager methods, so they should be modeled with existing `scriptInstall(...)` entries:
+
+- macOS/Linux: `curl -fsSL https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.sh | bash`
+- Windows: `irm https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.ps1 | iex`
+
+### 4. Probe and update through the root dispatcher
+
+The README documents standard `--version` support and the update guide documents `vtcode update` as the check-and-install command. Quantex should use `vtcode --version` for version probes and expose `vtcode update` as the self-update command for installations that support VTCode's built-in updater.
+
+## Risks / Trade-offs
+
+- [Native installers install optional dependencies beyond the core binary] -> Keep only the default documented installer command in Quantex and leave optional search-tool installation to upstream VTCode docs.
+- [Cargo installs may not bundle every runtime asset present in native release archives] -> Still expose Cargo because upstream documents it as an alternative install path and Quantex can manage it through the existing Cargo lifecycle.
+- [VTCode update channels and pinning are richer than Quantex's current self-update field] -> Store only the base `vtcode update` command and do not model channel or pin flags until Quantex needs that level of update intent.

--- a/openspec/changes/add-vtcode-support/proposal.md
+++ b/openspec/changes/add-vtcode-support/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+This request changes supported agent catalog metadata, install methods, update behavior, and product-facing supported-agent documentation, so it requires an OpenSpec-backed change before implementation. VTCode publishes a standalone `vtcode` CLI with documented native installers, Cargo/Homebrew install paths, version probing, and update behavior, but Quantex cannot yet install, inspect, or launch it as a first-class lifecycle agent.
+
+## What Changes
+
+- Add a VTCode agent definition with verified lifecycle metadata: canonical slug, display name, homepage, package metadata, executable name, install methods, version probe, and self-update command.
+- Register VTCode in the built-in agent catalog and root exports so existing lookup, install, ensure, inspect, resolve, exec, and update surfaces can use it.
+- Extend the `agent-catalog` contract with a VTCode requirement that records the supported install methods, version probe, and update command.
+- Refresh the product README supported-agent tables so the documented catalog matches the implemented CLI surface.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Add VTCode as a supported lifecycle agent with verified install, version-probe, and update metadata.
+
+## Impact
+
+- `src/agents/definitions/vtcode.ts` - new VTCode lifecycle metadata definition.
+- `src/agents/index.ts` and `src/index.ts` - register and re-export VTCode.
+- `test/agents.test.ts` and `test/index.test.ts` - verify VTCode metadata, lookup behavior, and root exports.
+- `openspec/changes/add-vtcode-support/specs/agent-catalog/spec.md` - document the VTCode catalog delta.
+- `README.md` and `README.zh-CN.md` - sync supported-agent tables with the current catalog.

--- a/openspec/changes/add-vtcode-support/specs/agent-catalog/spec.md
+++ b/openspec/changes/add-vtcode-support/specs/agent-catalog/spec.md
@@ -1,0 +1,33 @@
+# agent-catalog Spec Delta
+
+## ADDED Requirements
+
+### Requirement: VTCode MUST be a supported lifecycle agent
+
+Quantex SHALL include VTCode in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up VTCode
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `vtcode`
+- **THEN** Quantex returns a supported agent entry for VTCode
+- **AND** the entry identifies `vtcode` as the executable binary
+- **AND** the entry identifies `vtcode` as its Cargo crate metadata
+- **AND** the entry identifies `https://github.com/vinhnx/vtcode` as the homepage
+
+#### Scenario: Installing VTCode through supported methods
+
+- **WHEN** Quantex renders or executes install options for VTCode
+- **THEN** the catalog includes the Cargo managed install method on Windows, macOS, and Linux
+- **AND** macOS and Linux include the official native shell installer (`curl -fsSL https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.sh | bash`)
+- **AND** Windows includes the official native PowerShell installer (`irm https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.ps1 | iex`)
+- **AND** macOS and Linux include the Homebrew formula install method (`vtcode`)
+
+#### Scenario: Probing VTCode version
+
+- **WHEN** Quantex probes the installed version of VTCode
+- **THEN** it runs `vtcode --version` and parses the output
+
+#### Scenario: Planning VTCode updates
+
+- **WHEN** Quantex plans an update for a VTCode installation that supports the built-in updater
+- **THEN** the catalog exposes `vtcode update` as the agent self-update command

--- a/openspec/changes/add-vtcode-support/tasks.md
+++ b/openspec/changes/add-vtcode-support/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: Add VTCode support
+
+## 1. OpenSpec and docs
+
+- [x] 1.1 Add the proposal, design, tasks, and `agent-catalog` spec delta for VTCode support.
+- [x] 1.2 Update the static supported-agent tables in `README.md` and `README.zh-CN.md`.
+
+## 2. Catalog implementation
+
+- [x] 2.1 Create `src/agents/definitions/vtcode.ts` with verified lifecycle metadata.
+- [x] 2.2 Register and re-export VTCode through `src/agents/index.ts` and `src/index.ts`.
+- [x] 2.3 Add test coverage for VTCode install methods, version probe, self-update, and root exports.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run lint`.
+- [x] 3.2 Run `bun run format:check`.
+- [x] 3.3 Run `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run openspec:validate`.
+- [x] 3.6 Run `bun run memory:check`.

--- a/src/agents/definitions/vtcode.ts
+++ b/src/agents/definitions/vtcode.ts
@@ -1,0 +1,34 @@
+import type { AgentDefinition } from '../types'
+import { brewInstall, cargoInstall, scriptInstall } from '../methods'
+
+export const vtcode: AgentDefinition = {
+  name: 'vtcode',
+  displayName: 'VTCode',
+  homepage: 'https://github.com/vinhnx/vtcode',
+  packages: {
+    cargo: 'vtcode',
+  },
+  binaryName: 'vtcode',
+  selfUpdate: {
+    command: ['vtcode', 'update'],
+  },
+  versionProbe: {
+    command: ['vtcode', '--version'],
+  },
+  platforms: {
+    windows: [
+      scriptInstall('irm https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.ps1 | iex'),
+      cargoInstall(),
+    ],
+    macos: [
+      scriptInstall('curl -fsSL https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.sh | bash'),
+      cargoInstall(),
+      brewInstall('vtcode'),
+    ],
+    linux: [
+      scriptInstall('curl -fsSL https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.sh | bash'),
+      cargoInstall(),
+      brewInstall('vtcode'),
+    ],
+  },
+}

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -26,6 +26,7 @@ import { qoder } from './definitions/qoder'
 import { qwen } from './definitions/qwen'
 import { reasonix } from './definitions/reasonix'
 import { vibe } from './definitions/vibe'
+import { vtcode } from './definitions/vtcode'
 
 const agents: AgentDefinition[] = [
   auggie,
@@ -55,6 +56,7 @@ const agents: AgentDefinition[] = [
   qwen,
   reasonix,
   vibe,
+  vtcode,
 ]
 
 export function getAllAgents(): AgentDefinition[] {
@@ -97,6 +99,7 @@ export {
   qwen,
   reasonix,
   vibe,
+  vtcode,
 }
 export type {
   AgentDefinition,

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export {
   qoder,
   reasonix,
   vibe,
+  vtcode,
 } from './agents'
 export type {
   AgentDefinition,

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -22,6 +22,7 @@ import { qoder } from '../src/agents/definitions/qoder'
 import { qwen } from '../src/agents/definitions/qwen'
 import { reasonix } from '../src/agents/definitions/reasonix'
 import { vibe } from '../src/agents/definitions/vibe'
+import { vtcode } from '../src/agents/definitions/vtcode'
 import { formatInstallMethodCommand } from '../src/utils/install'
 
 describe('agent registry', () => {
@@ -723,6 +724,50 @@ describe('vibe', () => {
     }
 
     expect(vibe.platforms.windows!.find(m => m.type === 'script')).toBeUndefined()
+  })
+})
+
+describe('vtcode', () => {
+  it('is registered for lookup by canonical name', () => {
+    expect(getAgentByNameOrAlias('vtcode')).toBe(vtcode)
+  })
+
+  it('has valid structure', () => {
+    validateAgent(vtcode)
+    expect(vtcode.name).toBe('vtcode')
+    expect(vtcode.lookupAliases).toBeUndefined()
+    expect(vtcode.displayName).toBe('VTCode')
+    expect(vtcode.packages?.cargo).toBe('vtcode')
+    expect(vtcode.binaryName).toBe('vtcode')
+    expect(vtcode.homepage).toBe('https://github.com/vinhnx/vtcode')
+    expect(vtcode.selfUpdate?.command).toEqual(['vtcode', 'update'])
+    expect(vtcode.versionProbe?.command).toEqual(['vtcode', '--version'])
+  })
+
+  it('exposes official install methods per platform', () => {
+    expect(
+      vtcode.platforms.windows!.find(
+        m =>
+          m.type === 'script' && m.command.includes('raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.ps1'),
+      ),
+    ).toBeDefined()
+
+    for (const methods of [vtcode.platforms.windows!, vtcode.platforms.macos!, vtcode.platforms.linux!]) {
+      expect(methods.find(m => m.type === 'cargo')).toBeDefined()
+    }
+
+    for (const methods of [vtcode.platforms.macos!, vtcode.platforms.linux!]) {
+      expect(
+        methods.find(
+          m =>
+            m.type === 'script' &&
+            m.command.includes('raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.sh'),
+        ),
+      ).toBeDefined()
+      expect(methods.find(m => m.type === 'brew' && m.packageName === 'vtcode')).toBeDefined()
+    }
+
+    expect(vtcode.platforms.windows!.find(m => m.type === 'brew')).toBeUndefined()
   })
 })
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -22,6 +22,7 @@ import {
   pi,
   qoder,
   reasonix,
+  vtcode,
 } from '../src/index'
 
 describe('agent registry', () => {
@@ -97,6 +98,13 @@ describe('agent registry', () => {
   it('resolves Reasonix by repository-style alias', () => {
     const agent = getAgentByLookupName('deepseek-reasonix')
     expect(agent?.name).toBe('reasonix')
+  })
+
+  it('finds VTCode by name', () => {
+    const agent = getAgentByNameOrAlias('vtcode')
+    expect(agent).toBeDefined()
+    expect(agent!.name).toBe('vtcode')
+    expect(agent!.binaryName).toBe('vtcode')
   })
 })
 
@@ -207,6 +215,15 @@ describe('agent definitions', () => {
     expect(agent!.homepage).toBe('https://github.com/esengine/DeepSeek-Reasonix')
   })
 
+  it('vtcode has correct structure', () => {
+    const agent = getAgentByNameOrAlias('vtcode')
+    expect(agent).toBeDefined()
+    expect(agent!.displayName).toBe('VTCode')
+    expect(agent!.packages?.cargo).toBe('vtcode')
+    expect(agent!.binaryName).toBe('vtcode')
+    expect(agent!.homepage).toBe('https://github.com/vinhnx/vtcode')
+  })
+
   it('re-exports all built-in agents from root index', () => {
     expect(autohand.name).toBe('autohand')
     expect(codebuddy.name).toBe('codebuddy')
@@ -225,6 +242,7 @@ describe('agent definitions', () => {
     expect(pi.name).toBe('pi')
     expect(qoder.name).toBe('qoder')
     expect(reasonix.name).toBe('reasonix')
+    expect(vtcode.name).toBe('vtcode')
   })
 })
 


### PR DESCRIPTION
## Summary

Add VTCode as a first-class supported lifecycle agent in the Quantex catalog.

This records the upstream `vtcode` binary, Cargo crate metadata, native install scripts, Homebrew install path, `vtcode --version` probe, and `vtcode update` self-update command, then syncs tests and supported-agent README tables.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `add-vtcode-support`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run openspec:validate`
- [x] `bun run dev -- inspect vtcode --json`
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing feature

## Docs Updated

- [ ] Not needed
- [x] `README.md`
- [x] `README.zh-CN.md`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge.
- [x] Release is delegated to release automation.

## Notes

Upstream sources used for metadata: `https://github.com/vinhnx/vtcode` and `docs/guides/UPDATE_SYSTEM.md`.
