### PR TITLE
fix(git): strip cursor attribution trailers locally

### DIFF
--- a/openspec/changes/strip-cursor-attribution-locally/.openspec.yaml
+++ b/openspec/changes/strip-cursor-attribution-locally/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-12

--- a/openspec/changes/strip-cursor-attribution-locally/design.md
+++ b/openspec/changes/strip-cursor-attribution-locally/design.md
@@ -1,0 +1,20 @@
+## Summary
+
+Implement the local mitigation at the `commit-msg` stage using the repository's existing `simple-git-hooks` installation path.
+
+## Decision
+
+Use a repository-owned Bun/TypeScript script invoked from `simple-git-hooks` `commit-msg` rather than a shell-only one-liner.
+
+## Rationale
+
+- portability: one Bun script works the same on macOS, Linux, and Windows shells used by contributors
+- versioned behavior: the exact strip rule lives in the repo and can be tested with Vitest
+- narrow scope: the script can intentionally remove only Cursor's known local attribution trailer formats, avoiding accidental policy drift from the broader CI validator
+
+## Non-Goals
+
+- replacing CI or PR governance checks with a local hook
+- stripping arbitrary non-Cursor `Co-authored-by:` trailers from local commits
+- stripping arbitrary non-Cursor branding or provenance trailers beyond Cursor's known local formats
+- fixing hosted cloud-agent server-side metadata injection that happens outside local Git hook execution

--- a/openspec/changes/strip-cursor-attribution-locally/proposal.md
+++ b/openspec/changes/strip-cursor-attribution-locally/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+Quantex already has remote governance that rejects prohibited `Co-authored-by:` trailers and risky pull-request commit metadata before merge. That protects protected branches, but it does not stop local developer workflows from repeatedly generating Cursor-specific co-author trailers that then have to be removed by hand before every commit or fixed after CI failures.
+
+The local problem is narrower than the remote policy:
+
+- local IDE, CLI, and generated commit-message flows can inject a known Cursor co-author trailer
+- the existing remote governance intentionally stays broader than Cursor and must not be weakened to a tool-specific rule
+- contributors want a repository-native fix that travels with the repo through `simple-git-hooks`
+
+## What Changes
+
+- add a versioned repository `commit-msg` hook through `simple-git-hooks`
+- implement a repository script that strips Cursor's known local attribution trailers (`Co-authored-by: Cursor Agent <cursoragent@cursor.com>` and `Made-with: Cursor`) from the commit message file before commit creation
+- document in OpenSpec that the local hook is Cursor-specific while CI governance remains generic
+
+## Impact
+
+- local commits created from clones with hooks installed stop carrying Cursor's co-author trailer by default
+- CI and PR governance remain the final generic enforcement layer for non-Cursor `Co-authored-by:` trailers and risky author metadata
+- cloud-hosted agent flows that inject metadata after local hooks are still governed remotely rather than by this local hook

--- a/openspec/changes/strip-cursor-attribution-locally/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/strip-cursor-attribution-locally/specs/code-quality-tooling/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Local commit-msg hook MUST remove Cursor attribution trailers before commit creation
+
+The repository SHALL enforce a versioned `commit-msg` hook through `simple-git-hooks` that strips the exact Cursor-injected attribution trailer lines from the commit message file before Git finalizes a local commit. This local hook MUST target Cursor's known local attribution formats only and MUST NOT narrow or replace the broader remote co-author governance enforced by CI.
+
+#### Scenario: Local commit message contains a Cursor co-author trailer
+
+- **GIVEN** a local IDE, CLI agent, or commit-message generator writes `Co-authored-by: Cursor Agent <cursoragent@cursor.com>` into the commit message file
+- **WHEN** the repository `commit-msg` hook runs
+- **THEN** the hook removes that trailer line before Git creates the commit
+- **AND** the contributor does not need to hand-edit the generated message to satisfy local authorship policy
+
+#### Scenario: Local commit message contains a Cursor made-with trailer
+
+- **GIVEN** a local IDE, CLI agent, or commit-message generator writes `Made-with: Cursor` into the commit message file
+- **WHEN** the repository `commit-msg` hook runs
+- **THEN** the hook removes that trailer line before Git creates the commit
+- **AND** the contributor does not need to hand-edit the generated message to satisfy local authorship policy
+
+#### Scenario: Local commit message contains a non-Cursor co-author trailer
+
+- **GIVEN** a local commit message contains a `Co-authored-by:` trailer for an identity other than Cursor's known trailer identity
+- **WHEN** the repository `commit-msg` hook runs
+- **THEN** the hook leaves that trailer untouched
+- **AND** the existing CI and PR governance checks remain responsible for rejecting prohibited non-Cursor co-author metadata before merge

--- a/openspec/changes/strip-cursor-attribution-locally/tasks.md
+++ b/openspec/changes/strip-cursor-attribution-locally/tasks.md
@@ -1,0 +1,4 @@
+- [x] 1. Add a repository-owned `commit-msg` sanitizer script that removes Cursor's known local attribution trailers from local commit messages.
+- [x] 2. Wire the sanitizer into the repository `simple-git-hooks` configuration and keep the existing pre-commit and pre-push hooks intact.
+- [x] 3. Add automated tests for the sanitizer behavior, including preserving non-Cursor co-author trailers.
+- [x] 4. Update the code-quality tooling spec to document the local Cursor-specific hook and its boundary against broader CI governance.

--- a/openspec/specs/code-quality-tooling/spec.md
+++ b/openspec/specs/code-quality-tooling/spec.md
@@ -85,6 +85,31 @@ The repository SHALL enforce lint and format on staged files before each commit 
 - **THEN** the hook does not route that file through an unsupported `oxfmt` invocation
 - **AND** the commit is not blocked solely because the formatter cannot handle that file type in the current repository configuration
 
+### Requirement: Local commit-msg hook MUST remove Cursor attribution trailers before commit creation
+
+The repository SHALL enforce a versioned `commit-msg` hook through `simple-git-hooks` that strips the exact Cursor-injected attribution trailer lines from the commit message file before Git finalizes a local commit. This local hook MUST target Cursor's known local attribution formats only and MUST NOT narrow or replace the broader remote co-author governance enforced by CI.
+
+#### Scenario: Local commit message contains a Cursor co-author trailer
+
+- **GIVEN** a local IDE, CLI agent, or commit-message generator writes `Co-authored-by: Cursor Agent <cursoragent@cursor.com>` into the commit message file
+- **WHEN** the repository `commit-msg` hook runs
+- **THEN** the hook removes that trailer line before Git creates the commit
+- **AND** the contributor does not need to hand-edit the generated message to satisfy local authorship policy
+
+#### Scenario: Local commit message contains a Cursor made-with trailer
+
+- **GIVEN** a local IDE, CLI agent, or commit-message generator writes `Made-with: Cursor` into the commit message file
+- **WHEN** the repository `commit-msg` hook runs
+- **THEN** the hook removes that trailer line before Git creates the commit
+- **AND** the contributor does not need to hand-edit the generated message to satisfy local authorship policy
+
+#### Scenario: Local commit message contains a non-Cursor co-author trailer
+
+- **GIVEN** a local commit message contains a `Co-authored-by:` trailer for an identity other than Cursor's known trailer identity
+- **WHEN** the repository `commit-msg` hook runs
+- **THEN** the hook leaves that trailer untouched
+- **AND** the existing CI and PR governance checks remain responsible for rejecting prohibited non-Cursor co-author metadata before merge
+
 ### Requirement: CI lint and format gate
 
 CI workflows that gate merges to `main` or `beta` (such as `ci.yml`, `release.yml`, and `release-verify.yml`) SHALL run both `bun run lint` and `bun run format:check`. CI MUST fail when either command exits non-zero.
@@ -223,4 +248,3 @@ The repository SHALL keep a root `.editorconfig` that declares LF line endings, 
 
 - **WHEN** a contributor or coding agent inspects repository formatting and line-ending configuration
 - **THEN** `.editorconfig`, `.gitattributes`, and `.oxfmtrc.json` all declare LF as the repository text line-ending policy
-

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "vitest": "^4.1.3"
   },
   "simple-git-hooks": {
+    "commit-msg": "bun run scripts/strip-cursor-coauthor.ts \"$1\"",
     "pre-commit": "bun install --frozen-lockfile && npx lint-staged",
     "pre-push": "bun run format:check && bun run typecheck && bun run openspec:validate && bun run memory:check"
   },

--- a/scripts/strip-cursor-coauthor.ts
+++ b/scripts/strip-cursor-coauthor.ts
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import process from 'node:process'
+
+const cursorCoAuthorPattern = /^Co-authored-by:\s*Cursor(?: Agent)? <cursoragent@cursor\.com>\s*$/i
+const cursorMadeWithPattern = /^Made-with:\s*Cursor\s*$/i
+
+export function stripCursorAttributionTrailers(message: string): string {
+  const lines = message.split('\n')
+  const filteredLines = lines.filter(line => {
+    const trimmedLine = line.trim()
+    return !cursorCoAuthorPattern.test(trimmedLine) && !cursorMadeWithPattern.test(trimmedLine)
+  })
+
+  return filteredLines.join('\n')
+}
+
+if (import.meta.main) {
+  const messageFilePath = process.argv[2]
+
+  if (!messageFilePath) {
+    console.error('Expected the commit message file path as the first argument.')
+    process.exit(1)
+  }
+
+  const originalMessage = readFileSync(messageFilePath, 'utf8')
+  const sanitizedMessage = stripCursorAttributionTrailers(originalMessage)
+
+  if (sanitizedMessage !== originalMessage) {
+    writeFileSync(messageFilePath, sanitizedMessage, 'utf8')
+    console.log('Removed Cursor attribution trailer from commit message.')
+  }
+}

--- a/test/strip-cursor-coauthor.test.ts
+++ b/test/strip-cursor-coauthor.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { stripCursorAttributionTrailers } from '../scripts/strip-cursor-coauthor'
+
+describe('stripCursorAttributionTrailers', () => {
+  it('removes the Cursor co-author trailer', () => {
+    expect(
+      stripCursorAttributionTrailers(
+        [
+          'fix(schema): align doctor JSON schema with Cargo installer field',
+          '',
+          'Co-authored-by: Cursor Agent <cursoragent@cursor.com>',
+          '',
+        ].join('\n'),
+      ),
+    ).toBe(['fix(schema): align doctor JSON schema with Cargo installer field', '', ''].join('\n'))
+  })
+
+  it('leaves other co-author trailers untouched', () => {
+    const message = ['docs: note authorship', '', 'Co-authored-by: Example Person <person@example.com>', ''].join('\n')
+
+    expect(stripCursorAttributionTrailers(message)).toBe(message)
+  })
+
+  it('accepts the shorter Cursor name variant case-insensitively', () => {
+    expect(
+      stripCursorAttributionTrailers(
+        ['chore: example', '', 'co-authored-by: cursor <cursoragent@cursor.com>'].join('\n'),
+      ),
+    ).toBe(['chore: example', ''].join('\n'))
+  })
+
+  it('removes the Made-with Cursor trailer', () => {
+    expect(stripCursorAttributionTrailers(['feat: example', '', 'Made-with: Cursor', ''].join('\n'))).toBe(
+      ['feat: example', '', ''].join('\n'),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Add a repository-owned `simple-git-hooks` `commit-msg` sanitizer that strips Cursor's local attribution trailers before Git finalizes a local commit. The hook removes both `Co-authored-by: Cursor Agent <cursoragent@cursor.com>` and `Made-with: Cursor`, while keeping the existing remote CI / PR-governance policy generic rather than narrowing it to Cursor only.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/strip-cursor-attribution-locally`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - local git workflow fix that prevents Cursor attribution trailers from leaking into commits

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The new local hook is intentionally narrower than CI:

- it strips Cursor's known local attribution formats before commit creation
- it does not replace the broader remote `Co-authored-by:` and risky-author governance
- `Made-with: Cursor` is removed locally, but is not yet a dedicated remote merge-gating failure condition
