### PR TITLE
fix(agents): correct Cloud VM bun PATH instructions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,7 @@ bun run release:artifacts
 
 ## Cursor Cloud specific instructions
 
-- 运行时为 Bun v1.3.11，通过 `~/.bun/bin` 提供。Cloud VM 启动脚本已配置 `bun install`。
+- 运行时为 Bun（通过 `~/.bun/bin` 提供）。update script 会在 PATH 中找不到 bun 时自动安装，然后运行 `bun install`。非交互式 shell 中 `~/.bashrc` 不会自动 source，因此脚本和命令需显式 `export PATH="$HOME/.bun/bin:$PATH"`。
 - 这是一个纯 CLI 项目，无需启动后台服务、数据库或 Docker。
 - 开发模式运行：`bun run dev` （等价于 `bun run src/cli.ts`），后接 CLI 参数，如 `bun run dev -- list`。
 - 验证命令参考 AGENTS.md 的 Validation 节；核心四件套：`bun run lint`、`bun run format:check`、`bun run typecheck`、`bun run test`。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix incorrect Cloud VM instructions in `AGENTS.md`. The previous text stated bun v1.3.11 was pre-installed via `~/.bun/bin`, but in practice bun may not exist on fresh VMs and `~/.bashrc` is not sourced in non-interactive shells. Updated to document the auto-install fallback in the update script and the explicit `PATH` export requirement.

Also updated the VM update script to:
1. Export `BUN_INSTALL` and `PATH` explicitly (non-interactive shells don't source `~/.bashrc`)
2. Auto-install bun if not found
3. Run `bun install`

## Linked Artifacts

- Issue: N/A (environment setup fix)
- ADR: N/A
- OpenSpec: N/A (no behavior/contract change)
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (471 tests passed)

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [x] Not needed (only AGENTS.md cloud instructions corrected)

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-674e0025-ce20-476c-9c9a-a7c5a33e51f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-674e0025-ce20-476c-9c9a-a7c5a33e51f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

