### PR TITLE
ci(release): skip alias sync without token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,11 @@ jobs:
             exit 1
           fi
 
+          if [ -z "${QUANTEX_SYNC_TOKEN}" ]; then
+            echo "::notice title=Alias sync skipped::QUANTEX_SYNC_TOKEN is not configured; skipping Drswith/quantex repository_dispatch."
+            exit 0
+          fi
+
           npm_tag="latest"
           if [[ "${version}" == *-* ]]; then
             npm_tag="next"

--- a/openspec/changes/sync-alias-package-after-release/proposal.md
+++ b/openspec/changes/sync-alias-package-after-release/proposal.md
@@ -9,6 +9,7 @@ Quantex publishes `quantex-cli` as the primary npm package while `quantex` is an
 - Send `npm_tag=latest` for stable releases and `npm_tag=next` for prereleases.
 - Keep alias package publishing owned by the `quantex` repository; `quantex-cli` only sends the notification.
 - Use the `QUANTEX_SYNC_TOKEN` secret for the GitHub API call.
+- Skip the alias synchronization dispatch without failing the release when `QUANTEX_SYNC_TOKEN` is not configured.
 
 ## Capabilities
 
@@ -24,4 +25,4 @@ None.
 
 - Affected workflow: `.github/workflows/release.yml`.
 - Affected docs/specs: `openspec/specs/release-workflow/spec.md` via this change delta.
-- External dependency: repository secret `QUANTEX_SYNC_TOKEN` with sufficient permission to dispatch events to `Drswith/quantex`.
+- External dependency: optional repository secret `QUANTEX_SYNC_TOKEN` with sufficient permission to dispatch events to `Drswith/quantex`.

--- a/openspec/changes/sync-alias-package-after-release/specs/release-workflow/spec.md
+++ b/openspec/changes/sync-alias-package-after-release/specs/release-workflow/spec.md
@@ -2,11 +2,12 @@
 
 ### Requirement: Release Workflow Dispatches Alias Package Sync After Npm Publish
 
-The Release workflow SHALL notify the `Drswith/quantex` alias package repository after `quantex-cli` is successfully published to npm, and it MUST NOT publish the alias package directly from the `quantex-cli` repository.
+The Release workflow SHALL notify the `Drswith/quantex` alias package repository after `quantex-cli` is successfully published to npm when `QUANTEX_SYNC_TOKEN` is configured, and it MUST NOT publish the alias package directly from the `quantex-cli` repository.
 
 #### Scenario: Stable release dispatches latest alias sync
 
 - **WHEN** the Release workflow successfully publishes `quantex-cli` version `0.18.0` to npm
+- **AND** `QUANTEX_SYNC_TOKEN` is configured
 - **THEN** it MUST send a `repository_dispatch` event to `Drswith/quantex`
 - **AND** the event type MUST be `sync-quantex-cli-release`
 - **AND** the client payload version MUST be `0.18.0`
@@ -15,9 +16,17 @@ The Release workflow SHALL notify the `Drswith/quantex` alias package repository
 #### Scenario: Prerelease dispatches next alias sync
 
 - **WHEN** the Release workflow successfully publishes `quantex-cli` version `0.18.0-beta.1` to npm
+- **AND** `QUANTEX_SYNC_TOKEN` is configured
 - **THEN** it MUST send a `repository_dispatch` event to `Drswith/quantex`
 - **AND** the client payload version MUST be `0.18.0-beta.1`
 - **AND** the client payload `npm_tag` MUST be `next`
+
+#### Scenario: Alias dispatch token is not configured
+
+- **WHEN** the Release workflow successfully publishes `quantex-cli` to npm
+- **AND** `QUANTEX_SYNC_TOKEN` is not configured
+- **THEN** it MUST skip the alias package synchronization dispatch
+- **AND** the Release workflow MUST complete successfully so GitHub Release artifacts and npm publication are not marked failed by missing optional cross-repository credentials
 
 #### Scenario: Npm publish does not succeed
 

--- a/openspec/changes/sync-alias-package-after-release/tasks.md
+++ b/openspec/changes/sync-alias-package-after-release/tasks.md
@@ -2,6 +2,7 @@
 
 - [x] 1.1 Add a post-npm-publish `repository_dispatch` step in `.github/workflows/release.yml`.
 - [x] 1.2 Derive the alias dispatch payload version without a leading `v` and map prerelease versions to `npm_tag=next`.
+- [x] 1.3 Skip the alias synchronization dispatch without failing the release when `QUANTEX_SYNC_TOKEN` is not configured.
 
 ## 2. Validation
 


### PR DESCRIPTION
## Summary

Keep the release workflow green when the optional `QUANTEX_SYNC_TOKEN` secret is not configured. The alias package dispatch still runs when the token exists, but missing cross-repository credentials now produce an explicit notice and skip only that handoff.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/sync-alias-package-after-release`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

`bun run test` was not required for this workflow-only credential guard. The changed behavior is covered by the workflow script branch and OpenSpec validation.

## Release Intent

- [x] Release: not applicable - release workflow credential fallback, no runtime package change
- [ ] Release: patch - bug fix
- [ ] Release: minor - user-facing feature
- [ ] Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This is a CI/release hardening fix for the failed Release run after `v0.18.1`: npm publish and GitHub Release creation succeeded, then the optional alias dispatch failed with 401 because `QUANTEX_SYNC_TOKEN` was empty.
