### PR TITLE
test: add uv sandbox lifecycle smoke

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -206,7 +206,7 @@ jobs:
           MODAL_TOKEN_SECRET: ${{ secrets.MODAL_TOKEN_SECRET }}
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            export QTX_ISOLATION_SCENARIOS=managed,adopt-preinstalled,ambiguous-multi-method,self-binary
+            export QTX_ISOLATION_SCENARIOS=managed,uv-managed,adopt-preinstalled,ambiguous-multi-method,self-binary
           fi
 
           bun run test:sandbox

--- a/docs/runbooks/modal-sandbox-testing.md
+++ b/docs/runbooks/modal-sandbox-testing.md
@@ -37,6 +37,7 @@ The default local lifecycle smoke agents are `pi,qoder`.
 Default scenarios:
 
 - `managed`: Quantex installs, inspects, resolves, ensures, updates, uninstalls, and re-inspects the agent.
+- `uv-managed`: the sandbox places a fake `uv` executable in PATH, then verifies Quantex routes a uv-managed test agent through `uv tool install`, `uv tool list`, `uv tool upgrade`, and `uv tool uninstall` while preserving package install arguments.
 - `adopt-preinstalled`: the sandbox preinstalls the agent outside Quantex first, then verifies `quantex install <agent>` adopts and tracks that existing install.
 - `ambiguous-multi-method`: the sandbox places a fake multi-install-method agent binary in PATH and verifies Quantex does not guess an install source.
 - `self-binary`: the sandbox builds a Linux standalone Quantex binary, installs it into the isolated HOME, then verifies binary-entrypoint command discovery, agent inspection, and `upgrade --check` self-inspection.
@@ -79,6 +80,7 @@ To limit scenarios, set `QTX_ISOLATION_SCENARIOS`:
 
 ```bash
 QTX_ISOLATION_SCENARIOS=managed,adopt-preinstalled bun run test:container
+QTX_ISOLATION_SCENARIOS=uv-managed bun run test:container
 QTX_ISOLATION_SCENARIOS=self-binary bun run test:container
 QTX_ISOLATION_SCENARIOS=self-managed bun run test:container
 QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:container
@@ -94,7 +96,7 @@ QTX_ISOLATION_SCENARIOS=managed QTX_ISOLATION_AGENTS=qoder bun run test:containe
 
 The dedicated GitHub Actions workflow runs the Modal path with `QTX_ISOLATION_AGENTS=pi,opencode` and a longer command timeout so remote validation covers the lightweight baseline plus opencode under better network conditions. Pull requests and protected-branch pushes always publish the `sandbox-tests` check context, but the workflow only starts Modal when lifecycle-sensitive files changed. Docs-only and OpenSpec archive-only changes return a fast success result without starting Modal.
 
-For merge-gating pull requests, the workflow narrows `QTX_ISOLATION_SCENARIOS` to `managed,adopt-preinstalled,ambiguous-multi-method,self-binary` so the required check stays focused on stable lifecycle coverage. Full Modal coverage, including `self-managed`, still runs on protected-branch pushes, schedule, and manual dispatch.
+For merge-gating pull requests, the workflow narrows `QTX_ISOLATION_SCENARIOS` to `managed,uv-managed,adopt-preinstalled,ambiguous-multi-method,self-binary` so the required check stays focused on stable lifecycle coverage. Full Modal coverage, including `self-managed`, still runs on protected-branch pushes, schedule, and manual dispatch.
 
 For pull requests from forks, the required `sandbox-tests` context downgrades to a documented success placeholder because GitHub does not expose Modal secrets to forked `pull_request` workflows. Maintainers must rerun equivalent sandbox validation from a trusted repository branch before merging lifecycle-sensitive fork contributions.
 

--- a/openspec/changes/add-uv-sandbox-smoke/.openspec.yaml
+++ b/openspec/changes/add-uv-sandbox-smoke/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-22

--- a/openspec/changes/add-uv-sandbox-smoke/design.md
+++ b/openspec/changes/add-uv-sandbox-smoke/design.md
@@ -1,0 +1,26 @@
+## Context
+
+The uv managed installer implementation already has unit coverage for `uv tool install`, `uv tool upgrade`, `uv tool uninstall`, `uv tool list` parsing, managed state recording, update grouping, capability reporting, and catalog metadata. The gap is the optional isolation layer: `scripts/lifecycle-smoke.ts` can exercise generic managed installs through real catalog agents and has a fake Cargo package-manager scenario, but it has no uv-specific fake smoke.
+
+The sandbox layer should validate Quantex's lifecycle contract with enough realism to catch command-shape or state-routing regressions, without depending on public package availability, upstream agent behavior, Python version installation, or network speed.
+
+## Decisions
+
+### Add a fake uv scenario instead of installing a real uv-distributed agent
+
+The new `uv-managed` scenario will place a fake `uv` executable ahead of the normal `PATH`, then run a small lifecycle smoke against a generated test agent that declares a uv managed install method.
+
+Rationale: this mirrors the existing fake Cargo smoke pattern and keeps the sandbox deterministic. The useful behavior to validate here is that Quantex chooses uv, preserves package install args, records managed state, updates through `uv tool upgrade`, and uninstalls through `uv tool uninstall`.
+
+### Keep the scenario inside the existing lifecycle smoke entrypoint
+
+Both Docker/container and Modal sandbox transports already delegate to `scripts/lifecycle-smoke.ts`. Adding a new scenario there keeps transports aligned and lets maintainers run only the uv scenario with `QTX_ISOLATION_SCENARIOS=uv-managed`.
+
+### Include uv-managed in the PR sandbox profile
+
+The fake uv scenario is local, deterministic, and does not require Modal to install real uv or Python dependencies. It should therefore be part of the trusted pull-request sandbox profile, not only the broader protected-branch default profile.
+
+## Risks / Trade-offs
+
+- [Does not prove upstream package installability] A fake uv executable does not validate that OpenHands, Kimi, or Mistral Vibe currently install from upstream. That is intentional; upstream verification belongs to catalog intake and targeted manual checks, while sandbox smoke protects Quantex lifecycle plumbing.
+- [Fixture drift] The generated fake agent or fake uv output could stop matching the real package-manager adapter assumptions. Mitigation: assert the exact fake uv log lines for install, upgrade, uninstall, and list operations so drift is visible.

--- a/openspec/changes/add-uv-sandbox-smoke/proposal.md
+++ b/openspec/changes/add-uv-sandbox-smoke/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Work-intake classification: this change modifies the durable sandbox validation workflow, so it requires OpenSpec before implementation.
+
+Quantex now supports uv as a first-class managed agent installer, but the isolated lifecycle smoke layer only has a package-manager-specific fake scenario for Cargo. That leaves uv lifecycle command routing covered by unit tests and CI, but not by the sandbox isolation layer that catches end-to-end lifecycle regressions.
+
+## What Changes
+
+- Add a deterministic `uv-managed` lifecycle smoke scenario to `scripts/lifecycle-smoke.ts`.
+- Use a fake `uv` executable inside an ephemeral sandbox bin directory so the smoke validates Quantex command routing, state handling, and lifecycle sequencing without installing real Python tools or hitting the network.
+- Include the uv smoke in the default isolation scenario list and in the trusted pull-request sandbox profile.
+- Keep real uv package installation, Python installation policy, virtualenv management, and arbitrary `uv run` workflows out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: Optional sandbox/container isolation validation covers uv-managed agent lifecycle routing.
+
+## Impact
+
+- Affected code: `scripts/lifecycle-smoke.ts`, `.github/workflows/sandbox-tests.yml`, and related tests.
+- Affected docs: `docs/runbooks/modal-sandbox-testing.md`.
+- Affected contract: `openspec/specs/code-quality-tooling/spec.md`.
+- No new runtime dependency is required.

--- a/openspec/changes/add-uv-sandbox-smoke/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/add-uv-sandbox-smoke/specs/code-quality-tooling/spec.md
@@ -1,0 +1,51 @@
+## MODIFIED Requirements
+
+### Requirement: Optional isolation validation commands
+
+The repository SHALL expose `bun run test:sandbox` and `bun run test:container` as optional maintainer-facing validation commands for running real Quantex agent lifecycle smoke checks inside isolated Bun environments. These commands MUST complement rather than replace the canonical local `bun run test` workflow.
+
+#### Scenario: Isolation smoke includes Bun-managed self-upgrade
+
+- **WHEN** the isolated lifecycle smoke script runs the default self-upgrade coverage
+- **THEN** it seeds a Bun-managed Quantex install from a sandbox-local registry at a version older than the current checkout package
+- **AND** `quantex upgrade --check --no-cache` reports that a newer self version is available from that local registry
+- **AND** `quantex upgrade --no-cache` upgrades the managed install to the current checkout package version
+- **AND** the upgraded sandbox `qtx --version` output matches that current checkout package version
+
+#### Scenario: Isolation smoke includes uv-managed lifecycle routing
+
+- **WHEN** the isolated lifecycle smoke script runs the uv-managed coverage
+- **THEN** it executes a uv-managed test agent lifecycle with an isolated fake `uv` executable
+- **AND** the smoke verifies that Quantex calls `uv tool install`, `uv tool upgrade`, `uv tool uninstall`, and `uv tool list`
+- **AND** package-specific uv install arguments are preserved in the install and upgrade commands
+- **AND** the scenario avoids real Python package installation and network access
+
+### Requirement: Modal-backed isolation workflow remains separate from merge-gating CI
+
+The repository SHALL keep Modal-backed isolation validation in a dedicated GitHub Actions workflow instead of adding it to the merge-gating `ci.yml` workflow. That dedicated workflow SHALL run on pull requests targeting `main` or `beta`, protected-branch pushes, schedule, and manual dispatch, and it SHALL always publish the stable `sandbox-tests` check context expected by repository rulesets.
+
+#### Scenario: Documentation-only pull request targets main
+
+- **WHEN** a pull request targeting `main` changes only documentation, OpenSpec, or other sandbox-irrelevant files
+- **THEN** the dedicated sandbox workflow reports a successful `sandbox-tests` context without starting Modal
+- **AND** unrelated pull requests are not blocked by a missing required check context
+
+#### Scenario: Lifecycle-sensitive repository pull request targets main
+
+- **WHEN** a pull request from a branch in the repository changes agent definitions, lifecycle commands, install or update helpers, sandbox scripts, package metadata, or the sandbox workflow itself
+- **THEN** the dedicated sandbox workflow runs a scoped Modal merge-gating profile before merge
+- **AND** that profile covers stable lifecycle scenarios such as `managed`, `uv-managed`, `adopt-preinstalled`, `ambiguous-multi-method`, and `self-binary`
+- **AND** a failing `sandbox-tests` context blocks merge through the active ruleset
+
+#### Scenario: Lifecycle-sensitive fork pull request targets main
+
+- **WHEN** a pull request from a fork changes sandbox-relevant files
+- **THEN** the dedicated sandbox workflow remains on the safe `pull_request` event instead of using `pull_request_target`
+- **AND** it reports a documented success placeholder rather than running Modal with repository secrets
+- **AND** maintainers are instructed to rerun equivalent sandbox validation from a trusted repository branch before merge
+
+#### Scenario: Lifecycle-sensitive merge reaches a protected branch
+
+- **WHEN** a merge to `main` or `beta` changes sandbox-relevant files
+- **THEN** the dedicated sandbox workflow still runs automatically from the protected-branch push for post-merge coverage
+- **AND** the protected-branch run keeps the broader default scenario set, including `self-managed`

--- a/openspec/changes/add-uv-sandbox-smoke/tasks.md
+++ b/openspec/changes/add-uv-sandbox-smoke/tasks.md
@@ -1,0 +1,24 @@
+## 1. Contract
+
+- [x] 1.1 Write proposal, design, and code-quality-tooling spec delta for uv-managed sandbox coverage.
+
+## 2. Implementation
+
+- [x] 2.1 Add a deterministic fake-uv lifecycle scenario to `scripts/lifecycle-smoke.ts`.
+- [x] 2.2 Include `uv-managed` in the default scenario set and trusted PR sandbox profile.
+- [x] 2.3 Update sandbox runbook guidance for the new scenario.
+- [x] 2.4 Add or update automated tests covering the new isolation scenario wiring.
+
+## 3. Validation
+
+- [x] 3.1 Run targeted tests for sandbox workflow/scenario changes.
+- [x] 3.2 Run `bun run lint`.
+- [x] 3.3 Run `bun run format:check`.
+- [x] 3.4 Run `bun run typecheck`.
+- [x] 3.5 Run `bun run test`.
+- [x] 3.6 Run `bun run openspec:validate`.
+- [x] 3.7 Run `bun run memory:check`.
+
+## 4. Delivery
+
+- [x] 4.1 Commit, push, open PR, and report PR/archive/release closure state.

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -29,6 +29,7 @@ const DEFAULT_SMOKE_AGENTS = ['pi', 'qoder']
 const DEFAULT_SMOKE_SCENARIOS = [
   'managed',
   'cargo-managed',
+  'uv-managed',
   'adopt-preinstalled',
   'ambiguous-multi-method',
   'self-binary',
@@ -59,6 +60,7 @@ try {
 
   if (scenarios.includes('cargo-managed')) await smokeCargoManagedLifecycle()
   if (scenarios.includes('cargo-real-agent')) await smokeCargoRealAgentLifecycle()
+  if (scenarios.includes('uv-managed')) await smokeUvManagedLifecycle()
 
   if (scenarios.includes('adopt-preinstalled')) {
     for (const agent of agents) await smokeAdoptPreinstalledAgent(agent)
@@ -131,6 +133,44 @@ async function smokeManagedAgentLifecycle(agent: string): Promise<void> {
   )
 }
 
+async function smokeUvManagedLifecycle(): Promise<void> {
+  const sandboxRoot = await mkdtemp(join(tmpdir(), 'quantex-uv-smoke-'))
+  const fakeBinDir = join(sandboxRoot, 'bin')
+  const fakeUvLog = join(sandboxRoot, 'uv.log')
+
+  try {
+    await installFakeUv(fakeBinDir, fakeUvLog)
+    console.log('\n[uv] managed lifecycle')
+    await runText('uv managed lifecycle', ['bun', 'run', 'scripts/uv-lifecycle-smoke.ts'], {
+      env: {
+        PATH: `${fakeBinDir}:${process.env.PATH ?? ''}`,
+        QTX_FAKE_UV_LOG: fakeUvLog,
+      },
+    })
+
+    const log = await readFile(fakeUvLog, 'utf8')
+    for (const expected of [
+      'uv tool install uv-smoke-agent --python 3.12',
+      'uv tool list',
+      'uv tool upgrade uv-smoke-agent --python 3.12',
+      'uv tool uninstall uv-smoke-agent',
+    ]) {
+      if (!log.includes(expected)) throw new Error(`uv smoke log did not include: ${expected}\n${log}`)
+    }
+    if (log.match(/uv tool install uv-smoke-agent/g)?.length !== 1) {
+      throw new Error(`uv smoke should run uv tool install exactly once.\n${log}`)
+    }
+    if (log.match(/uv tool upgrade uv-smoke-agent/g)?.length !== 1) {
+      throw new Error(`uv smoke should run uv tool upgrade exactly once.\n${log}`)
+    }
+    if (log.match(/uv tool uninstall uv-smoke-agent/g)?.length !== 1) {
+      throw new Error(`uv smoke should run uv tool uninstall exactly once.\n${log}`)
+    }
+  } finally {
+    await rm(sandboxRoot, { force: true, recursive: true })
+  }
+}
+
 async function smokeCargoManagedLifecycle(): Promise<void> {
   const sandboxRoot = await mkdtemp(join(tmpdir(), 'quantex-cargo-smoke-'))
   const fakeBinDir = join(sandboxRoot, 'bin')
@@ -177,6 +217,37 @@ async function smokeCargoRealAgentLifecycle(): Promise<void> {
       QTX_CARGO_SMOKE_AGENT: agent,
     },
   })
+}
+
+async function installFakeUv(fakeBinDir: string, logPath: string): Promise<void> {
+  await mkdir(fakeBinDir, { recursive: true })
+  const fakeUvPath = join(fakeBinDir, 'uv')
+  await writeFile(
+    fakeUvPath,
+    [
+      '#!/usr/bin/env sh',
+      'set -eu',
+      'if [ "${1:-}" = "--version" ]; then',
+      '  echo "uv 0.9.0"',
+      '  exit 0',
+      'fi',
+      'if [ "${1:-}" = "tool" ]; then',
+      `  printf 'uv %s\\n' "$*" >> '${logPath}'`,
+      '  case "${2:-}" in',
+      '    install|upgrade|uninstall) exit 0 ;;',
+      '    list)',
+      '      printf "uv-smoke-agent v1.2.3\\n- uv-smoke-agent\\n"',
+      '      exit 0',
+      '      ;;',
+      '  esac',
+      'fi',
+      'echo "unexpected fake uv command: $*" >&2',
+      'exit 1',
+      '',
+    ].join('\n'),
+    'utf8',
+  )
+  await chmod(fakeUvPath, 0o755)
 }
 
 async function smokeAdoptPreinstalledAgent(agent: string): Promise<void> {

--- a/scripts/path-taxonomy.ts
+++ b/scripts/path-taxonomy.ts
@@ -53,6 +53,7 @@ export const sandboxRelevantFiles = new Set([
   'scripts/lifecycle-smoke.ts',
   'scripts/test-container.ts',
   'scripts/test-sandbox.ts',
+  'scripts/uv-lifecycle-smoke.ts',
   'test/agents.test.ts',
   'test/utils/install.test.ts',
 ])

--- a/scripts/uv-lifecycle-smoke.ts
+++ b/scripts/uv-lifecycle-smoke.ts
@@ -1,0 +1,48 @@
+import type { AgentDefinition } from '../src/agents'
+import { getManagedInstalledPackageVersion, installAgent, uninstallAgent, updateAgent } from '../src/package-manager'
+import { getInstalledAgentState } from '../src/state'
+
+const PACKAGE_NAME = 'uv-smoke-agent'
+const INSTALL_ARGS = ['--python', '3.12']
+
+const agent: AgentDefinition = {
+  binaryName: PACKAGE_NAME,
+  displayName: 'Uv Smoke Agent',
+  homepage: 'https://example.com/uv-smoke-agent',
+  name: PACKAGE_NAME,
+  packages: {
+    uv: PACKAGE_NAME,
+  },
+  platforms: {
+    linux: [{ packageInstallArgs: INSTALL_ARGS, type: 'uv' }],
+    macos: [{ packageInstallArgs: INSTALL_ARGS, type: 'uv' }],
+    windows: [{ packageInstallArgs: INSTALL_ARGS, type: 'uv' }],
+  },
+}
+
+const install = await installAgent(agent)
+if (!install.success || install.installedState?.installType !== 'uv') {
+  throw new Error('uv smoke install should persist uv install state')
+}
+
+const installedState = await getInstalledAgentState(agent.name)
+if (installedState?.installType !== 'uv' || installedState.packageName !== PACKAGE_NAME) {
+  throw new Error('uv smoke install state should record the uv tool package name')
+}
+if (installedState.packageInstallArgs?.join(' ') !== INSTALL_ARGS.join(' ')) {
+  throw new Error('uv smoke install state should record package install args')
+}
+
+const managedVersion = await getManagedInstalledPackageVersion('uv', PACKAGE_NAME)
+if (managedVersion !== '1.2.3') {
+  throw new Error(`uv smoke should inspect installed tool version 1.2.3, received ${managedVersion ?? '(missing)'}`)
+}
+
+const update = await updateAgent(agent, installedState)
+if (!update.success) throw new Error('uv smoke update should succeed')
+
+const uninstall = await uninstallAgent(agent)
+if (!uninstall) throw new Error('uv smoke uninstall should succeed')
+
+const removedState = await getInstalledAgentState(agent.name)
+if (removedState) throw new Error('uv smoke uninstall should remove installed-agent state')

--- a/test/lifecycle-smoke.test.ts
+++ b/test/lifecycle-smoke.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const lifecycleSmoke = readFileSync('scripts/lifecycle-smoke.ts', 'utf8')
+const uvLifecycleSmoke = readFileSync('scripts/uv-lifecycle-smoke.ts', 'utf8')
+
+describe('lifecycle smoke scenarios', () => {
+  it('includes uv-managed coverage in the default scenario list', () => {
+    expect(lifecycleSmoke).toContain("'uv-managed'")
+    expect(lifecycleSmoke).toContain("scenarios.includes('uv-managed')")
+  })
+
+  it('asserts uv tool lifecycle commands in the fake uv scenario', () => {
+    expect(lifecycleSmoke).toContain('uv tool install uv-smoke-agent --python 3.12')
+    expect(lifecycleSmoke).toContain('uv tool upgrade uv-smoke-agent --python 3.12')
+    expect(lifecycleSmoke).toContain('uv tool uninstall uv-smoke-agent')
+    expect(lifecycleSmoke).toContain('uv tool list')
+    expect(uvLifecycleSmoke).toContain("getManagedInstalledPackageVersion('uv', PACKAGE_NAME)")
+  })
+})

--- a/test/path-taxonomy.test.ts
+++ b/test/path-taxonomy.test.ts
@@ -78,6 +78,7 @@ describe('path taxonomy', () => {
     expect(isProcessOnlyPath('.github/workflows/ci.yml')).toBe(true)
     expect(isProcessOnlyPath('src/index.ts')).toBe(false)
     expect(isSandboxRelevantPath('.github/workflows/sandbox-tests.yml')).toBe(true)
+    expect(isSandboxRelevantPath('scripts/uv-lifecycle-smoke.ts')).toBe(true)
     expect(isSandboxRelevantPath('.github/workflows/ci.yml')).toBe(false)
   })
 })

--- a/test/workflow-classification.test.ts
+++ b/test/workflow-classification.test.ts
@@ -22,7 +22,7 @@ describe('workflow classification integration', () => {
     expect(sandboxWorkflow).toContain('bun run scripts/path-taxonomy.ts')
     expect(sandboxWorkflow).toContain('sandbox_relevant')
     expect(sandboxWorkflow).toContain(
-      'QTX_ISOLATION_SCENARIOS=managed,adopt-preinstalled,ambiguous-multi-method,self-binary',
+      'QTX_ISOLATION_SCENARIOS=managed,uv-managed,adopt-preinstalled,ambiguous-multi-method,self-binary',
     )
     expect(sandboxWorkflow).not.toContain("'src/self/**'")
   })


### PR DESCRIPTION
## Summary

Add deterministic uv-managed lifecycle coverage to the isolated sandbox smoke layer using a fake `uv` executable.

Include the new `uv-managed` scenario in the default lifecycle smoke scenarios and in the trusted pull-request sandbox profile, then document how to run it directly.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/add-uv-sandbox-smoke`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- [x] Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Additional targeted validation: `QTX_ISOLATION_SCENARIOS=uv-managed bun run scripts/lifecycle-smoke.ts`.
