### PR TITLE
fix: make managed installer cancellation sticky

### DIFF
--- a/openspec/changes/fix-managed-installer-cancellation/.openspec.yaml
+++ b/openspec/changes/fix-managed-installer-cancellation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/fix-managed-installer-cancellation/design.md
+++ b/openspec/changes/fix-managed-installer-cancellation/design.md
@@ -1,0 +1,38 @@
+## Context
+
+Quantex runs managed lifecycle installers through `spawnWithQuantexStdio`, often with inherited stdio in human mode so tools like Cargo, npm, Bun, uv, and mise can render their own progress. The current cancellation handler sends `SIGTERM` to the direct child and the command runtime races command execution against a signal result. On Windows, Cargo can survive that direct-child termination path and continue emitting progress after PowerShell receives a prompt again.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep cancellation sticky once a user signal or command timeout has been observed.
+- Give registered child-process cleanup a chance to finish before Quantex returns a cancelled result.
+- Use process-tree termination on Windows for managed installer children when a PID is available.
+- Preserve the existing install/update/uninstall command surfaces and output schemas.
+
+**Non-Goals:**
+
+- Replace the managed installer abstraction or introduce workflow orchestration.
+- Guarantee rollback of third-party installers that already modified the host before cancellation completed.
+- Add a native Windows job-object dependency in this change.
+
+## Decisions
+
+1. Cancellation handlers may return promises.
+
+   The CLI context remains the central registry for in-flight managed operations. Making handlers awaitable lets command runtime cancellation join child cleanup without every installer implementation growing its own signal logic.
+
+2. Managed process cancellation is sticky.
+
+   If cancellation is requested while a managed process is running, `waitForSpawnedCommand` returns a non-zero exit code even when the child later exits `0`. This prevents success-after-cancel paths from persisting installed state or printing normal success messages.
+
+3. Windows process-tree termination uses `taskkill /T /F` as a bounded fallback.
+
+   `SIGTERM` against a direct child is not reliable enough for Windows console process trees. `taskkill` is available on supported Windows hosts and reaches descendants without adding a new dependency. The fallback is bounded so cancellation cannot hang indefinitely.
+
+## Risks / Trade-offs
+
+- [Third-party installer races to completion] -> Quantex reports cancellation/failure rather than normal success; later inspection can reconcile any external state the installer left behind.
+- [taskkill is unavailable or denied] -> Quantex still attempts the direct-child kill path and treats the cancelled managed command as unsuccessful.
+- [Long cleanup delays] -> Cleanup waits are bounded so the CLI does not hang indefinitely after cancellation.

--- a/openspec/changes/fix-managed-installer-cancellation/proposal.md
+++ b/openspec/changes/fix-managed-installer-cancellation/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`qtx install vtcode` can return control to Windows PowerShell after `Ctrl+C` while the underlying Cargo installer continues writing to the same console and can later be reported as a successful install. This is observable lifecycle behavior, so the fix requires an OpenSpec change before implementation.
+
+## What Changes
+
+- Make CLI signal and timeout cancellation wait for registered managed-process cleanup before returning a final result.
+- Treat cancellation as sticky for managed installer commands so a child process that exits `0` after cancellation is not reported as normal success.
+- Terminate managed child process trees on Windows with a bounded `taskkill /T /F` fallback when a child PID is available.
+- Add focused regression coverage for cancellation cleanup and success-after-cancel behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: Clarify managed lifecycle installer cancellation semantics for install, update, batch update, and uninstall paths.
+
+## Impact
+
+- Affected code: `src/cli-context.ts`, `src/command-runtime.ts`, and `src/utils/child-process.ts`.
+- Affected tests: `test/command-runtime.test.ts` and `test/utils/child-process.test.ts`.
+- No new runtime dependency is introduced; Windows process-tree termination uses the platform-provided `taskkill.exe` when needed.

--- a/openspec/changes/fix-managed-installer-cancellation/specs/agent-update/spec.md
+++ b/openspec/changes/fix-managed-installer-cancellation/specs/agent-update/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Managed lifecycle cancellation MUST be sticky
+
+When Quantex cancels a managed lifecycle installer because of a signal or timeout, it SHALL treat that cancellation as sticky for the in-flight installer operation. Quantex MUST NOT persist installed-agent state, remove installed-agent state, or render a normal successful install, update, batch update, or uninstall result solely because the managed child process later exits successfully after cancellation was requested.
+
+#### Scenario: Cancelled managed install exits successfully later
+
+- **GIVEN** Quantex is running a managed installer for `quantex install <agent>`
+- **AND** the user sends a cancellation signal or the command timeout expires
+- **WHEN** the managed installer later exits with status `0`
+- **THEN** Quantex treats the installer attempt as cancelled or failed rather than successful
+- **AND** it does not persist the normal installed-agent state for that cancelled attempt
+- **AND** it does not render the normal installed-success message
+
+#### Scenario: Cancelled managed child process cleanup
+
+- **GIVEN** Quantex is running a managed installer child process with inherited or piped stdio
+- **WHEN** the CLI receives a cancellation signal or command timeout
+- **THEN** Quantex requests termination of the managed child process
+- **AND** on Windows it attempts process-tree termination when the child process identifier is available
+- **AND** Quantex waits for a bounded cleanup window before returning the final cancelled result

--- a/openspec/changes/fix-managed-installer-cancellation/tasks.md
+++ b/openspec/changes/fix-managed-installer-cancellation/tasks.md
@@ -1,0 +1,25 @@
+## 1. OpenSpec
+
+- [x] 1.1 Create the proposal, design, and agent-update spec delta for managed installer cancellation semantics.
+- [x] 1.2 Run `bun run openspec:status -- --change fix-managed-installer-cancellation` and follow apply instructions.
+
+## 2. Implementation
+
+- [x] 2.1 Make CLI cancellation handlers awaitable and preserve sticky cancelled state.
+- [x] 2.2 Update command runtime signal and timeout handling to wait for cancellation cleanup before returning.
+- [x] 2.3 Update managed child process handling to use sticky cancellation and Windows process-tree termination fallback.
+
+## 3. Tests
+
+- [x] 3.1 Add regression coverage for cancellation cleanup joining.
+- [x] 3.2 Add regression coverage for success-after-cancel not being treated as managed command success.
+
+## 4. Validation
+
+- [x] 4.1 Run focused tests for command runtime and child process cancellation.
+- [x] 4.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.
+
+## 5. Delivery
+
+- [ ] 5.1 Commit and push the fix branch.
+- [ ] 5.2 Prepare a PR body from `.github/pull_request_template.md`, validate it, and open the PR.

--- a/src/cli-context.ts
+++ b/src/cli-context.ts
@@ -46,8 +46,10 @@ export interface CliContextOptions {
   yes?: boolean
 }
 
+type CancellationHandler = () => Promise<void> | void
+
 let currentContext: CliContext | undefined
-let cancellationHandlers = new Set<() => void>()
+let cancellationHandlers = new Set<CancellationHandler>()
 
 export function getCliContext(): CliContext {
   currentContext ??= createDefaultCliContext()
@@ -110,13 +112,15 @@ export function markCliContextCancelled(): void {
   if (currentContext) currentContext.cancelled = true
 }
 
-export function cancelCliContextOperations(): void {
+export async function cancelCliContextOperations(): Promise<void> {
   markCliContextCancelled()
-  for (const handler of cancellationHandlers) handler()
+  const handlers = [...cancellationHandlers]
   cancellationHandlers.clear()
+
+  await Promise.allSettled(handlers.map(handler => Promise.resolve().then(handler)))
 }
 
-export function registerCliCancellationHandler(handler: () => void): () => void {
+export function registerCliCancellationHandler(handler: CancellationHandler): () => void {
   cancellationHandlers.add(handler)
   return () => {
     cancellationHandlers.delete(handler)

--- a/src/command-runtime.ts
+++ b/src/command-runtime.ts
@@ -28,44 +28,17 @@ export async function executeCommandWithRuntime<T>(options: ExecuteCommandOption
   try {
     const timeoutPromise = new Promise<CommandResult<T>>(resolve => {
       timeoutId = setTimeout(() => {
-        cancelCliContextOperations()
-        emitCommandEvent(
-          {
-            action: options.action,
-            data: {
-              reason: 'timeout',
-              timeoutMs,
-            },
-            target: options.target,
-            type: 'cancelled',
-          },
-          { force: true },
-        )
-
-        resolve(
-          emitCommandResult(
-            createErrorResult<T>({
-              action: options.action,
-              error: {
-                code: 'TIMEOUT',
-                details: {
-                  timeoutMs,
-                },
-                message: `Command timed out after ${timeoutMs}ms.`,
-              },
-              target: options.target,
-            }),
-            renderTimeoutHuman,
-            { force: true },
-          ),
-        )
+        void resolveTimeoutCancellation(options, timeoutMs).then(resolve)
       }, timeoutMs)
     })
 
     // Race only the primary command work against the deadline. Post-run steps (idempotency
     // persistence and passive self-update notice) must not consume the timeout budget.
     return await withSignalCancellation(options, async () => {
-      const result = await Promise.race([options.run(), timeoutPromise])
+      const result = await Promise.race([
+        runUntilTimeoutCancellation(options.run, () => timeoutPromise),
+        timeoutPromise,
+      ])
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId)
         timeoutId = undefined
@@ -158,42 +131,14 @@ async function withSignalCancellation<T>(
   options: ExecuteCommandOptions<T>,
   run: () => Promise<CommandResult<T>>,
 ): Promise<CommandResult<T>> {
+  let signalResultPromise: Promise<CommandResult<T>> | undefined
   let cleanup: (() => void) | undefined
 
   try {
     const signalPromise = new Promise<CommandResult<T>>(resolve => {
       const handleSignal = (signal: NodeJS.Signals): void => {
-        cancelCliContextOperations()
-        emitCommandEvent(
-          {
-            action: options.action,
-            data: {
-              reason: 'signal',
-              signal,
-            },
-            target: options.target,
-            type: 'cancelled',
-          },
-          { force: true },
-        )
-
-        resolve(
-          emitCommandResult(
-            createErrorResult<T>({
-              action: options.action,
-              error: {
-                code: 'CANCELLED',
-                details: {
-                  signal,
-                },
-                message: `Command cancelled by ${signal}.`,
-              },
-              target: options.target,
-            }),
-            renderTimeoutHuman,
-            { force: true },
-          ),
-        )
+        signalResultPromise ??= resolveSignalCancellation(options, signal)
+        void signalResultPromise.then(resolve)
       }
 
       const sigintHandler = (): void => handleSignal('SIGINT')
@@ -206,8 +151,108 @@ async function withSignalCancellation<T>(
       }
     })
 
-    return await Promise.race([run(), signalPromise])
+    return await Promise.race([runUntilSignalCancellation(run, () => signalResultPromise), signalPromise])
   } finally {
     cleanup?.()
   }
+}
+
+async function runUntilTimeoutCancellation<T>(
+  run: () => Promise<CommandResult<T>>,
+  getTimeoutResult: () => Promise<CommandResult<T>>,
+): Promise<CommandResult<T>> {
+  try {
+    const result = await run()
+    if (getCliContext().cancelled) return getTimeoutResult()
+    return result
+  } catch (error) {
+    if (getCliContext().cancelled) return getTimeoutResult()
+    throw error
+  }
+}
+
+async function runUntilSignalCancellation<T>(
+  run: () => Promise<CommandResult<T>>,
+  getSignalResult: () => Promise<CommandResult<T>> | undefined,
+): Promise<CommandResult<T>> {
+  try {
+    const result = await run()
+    const signalResult = getSignalResult()
+    if (getCliContext().cancelled && signalResult) return signalResult
+    return result
+  } catch (error) {
+    const signalResult = getSignalResult()
+    if (getCliContext().cancelled && signalResult) return signalResult
+    throw error
+  }
+}
+
+async function resolveTimeoutCancellation<T>(
+  options: ExecuteCommandOptions<T>,
+  timeoutMs: number,
+): Promise<CommandResult<T>> {
+  await cancelCliContextOperations()
+  emitCommandEvent(
+    {
+      action: options.action,
+      data: {
+        reason: 'timeout',
+        timeoutMs,
+      },
+      target: options.target,
+      type: 'cancelled',
+    },
+    { force: true },
+  )
+
+  return emitCommandResult(
+    createErrorResult<T>({
+      action: options.action,
+      error: {
+        code: 'TIMEOUT',
+        details: {
+          timeoutMs,
+        },
+        message: `Command timed out after ${timeoutMs}ms.`,
+      },
+      target: options.target,
+    }),
+    renderTimeoutHuman,
+    { force: true },
+  )
+}
+
+async function resolveSignalCancellation<T>(
+  options: ExecuteCommandOptions<T>,
+  signal: NodeJS.Signals,
+): Promise<CommandResult<T>> {
+  await cancelCliContextOperations()
+  emitCommandEvent(
+    {
+      action: options.action,
+      data: {
+        reason: 'signal',
+        signal,
+      },
+      target: options.target,
+      type: 'cancelled',
+    },
+    { force: true },
+  )
+
+  return emitCommandResult(
+    createErrorResult<T>({
+      action: options.action,
+      error: {
+        code: 'CANCELLED',
+        details: {
+          signal,
+        },
+        message: `Command cancelled by ${signal}.`,
+      },
+      target: options.target,
+    }),
+    renderTimeoutHuman,
+    { force: true },
+  )
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -305,15 +305,19 @@ async function tryInstallForRun(
 
 async function runSpawnedAgentProcess(handle: SpawnHandle, displayName: string): Promise<number> {
   const { timeoutMs } = getCliContext()
+  let cancellationCodePromise: Promise<number> | undefined
   let cleanup: (() => void) | undefined
   let timeoutId: ReturnType<typeof setTimeout> | undefined
 
   try {
     const signalPromise = new Promise<number>(resolve => {
       const handleSignal = (signal: NodeJS.Signals): void => {
-        cancelCliContextOperations()
-        printError(pc.red(`${displayName} was cancelled by ${signal}.`))
-        resolve(getExitCodeForError('CANCELLED'))
+        cancellationCodePromise ??= (async () => {
+          await cancelCliContextOperations()
+          printError(pc.red(`${displayName} was cancelled by ${signal}.`))
+          return getExitCodeForError('CANCELLED')
+        })()
+        void cancellationCodePromise.then(resolve)
       }
 
       const sigintHandler = (): void => handleSignal('SIGINT')
@@ -331,19 +335,38 @@ async function runSpawnedAgentProcess(handle: SpawnHandle, displayName: string):
         ? undefined
         : new Promise<number>(resolve => {
             timeoutId = setTimeout(() => {
-              cancelCliContextOperations()
-              printError(pc.red(`${displayName} timed out after ${timeoutMs}ms.`))
-              resolve(getExitCodeForError('TIMEOUT'))
+              cancellationCodePromise ??= (async () => {
+                await cancelCliContextOperations()
+                printError(pc.red(`${displayName} timed out after ${timeoutMs}ms.`))
+                return getExitCodeForError('TIMEOUT')
+              })()
+              void cancellationCodePromise.then(resolve)
             }, timeoutMs)
           })
 
     return await Promise.race([
-      waitForSpawnedCommand(handle),
+      waitForSpawnedAgentCommand(handle, () => cancellationCodePromise),
       signalPromise,
       ...(timeoutPromise ? [timeoutPromise] : []),
     ])
   } finally {
     if (timeoutId) clearTimeout(timeoutId)
     cleanup?.()
+  }
+}
+
+async function waitForSpawnedAgentCommand(
+  handle: SpawnHandle,
+  getCancellationCode: () => Promise<number> | undefined,
+): Promise<number> {
+  try {
+    const code = await waitForSpawnedCommand(handle)
+    const cancellationCode = getCancellationCode()
+    if (getCliContext().cancelled && cancellationCode) return cancellationCode
+    return code
+  } catch (error) {
+    const cancellationCode = getCancellationCode()
+    if (getCliContext().cancelled && cancellationCode) return cancellationCode
+    throw error
   }
 }

--- a/src/utils/child-process.ts
+++ b/src/utils/child-process.ts
@@ -13,6 +13,7 @@ interface BunSpawnLike {
   exitCode: number | null
   exited: Promise<unknown>
   kill?: (signal?: NodeJS.Signals | number) => boolean
+  pid?: number
   stderr?: unknown
   stdout?: unknown
   unref?: () => void
@@ -20,6 +21,7 @@ interface BunSpawnLike {
 
 export interface SpawnedProcessHandle {
   readonly exitCode: number | null
+  readonly pid?: number
   readonly stderr: ChildProcess['stderr']
   readonly stdout: ChildProcess['stdout']
   exited: Promise<number>
@@ -40,7 +42,7 @@ export function spawnWithQuantexStdio(command: SpawnCommand, options: SpawnOptio
       stdio: ['inherit', 'inherit', 'inherit'] as const,
     })
     return {
-      cleanup: registerCliCancellationHandler(() => proc.kill?.('SIGTERM')),
+      cleanup: registerCliCancellationHandler(() => terminateManagedProcess(proc)),
       outputDrained: Promise.resolve(),
       proc,
     }
@@ -52,16 +54,18 @@ export function spawnWithQuantexStdio(command: SpawnCommand, options: SpawnOptio
   })
 
   return {
-    cleanup: registerCliCancellationHandler(() => proc.kill?.('SIGTERM')),
+    cleanup: registerCliCancellationHandler(() => terminateManagedProcess(proc)),
     outputDrained: Promise.all([forwardToStderr(proc.stdout), forwardToStderr(proc.stderr)]).then(() => undefined),
     proc,
   }
 }
 
 export async function waitForSpawnedCommand(handle: SpawnHandle): Promise<number> {
+  const context = getCliContext()
   try {
     const exitCode = await handle.proc.exited
     await handle.outputDrained
+    if (context.cancelled) return 1
     return exitCode
   } finally {
     handle.cleanup()
@@ -85,6 +89,7 @@ export function spawnCommand(command: SpawnCommand, options: SpawnOptions = {}):
     get exitCode() {
       return child.exitCode
     },
+    pid: child.pid,
     stderr: child.stderr,
     stdout: child.stdout,
     exited: waitForChildProcess(child),
@@ -160,10 +165,53 @@ function spawnWithBun(
     get exitCode() {
       return proc.exitCode
     },
+    pid: proc.pid,
     stderr: proc.stderr as ChildProcess['stderr'],
     stdout: proc.stdout as ChildProcess['stdout'],
     exited: proc.exited.then(() => (typeof proc.exitCode === 'number' ? proc.exitCode : 1)),
     kill: signal => proc.kill?.(signal) ?? false,
     unref: () => proc.unref?.(),
+  }
+}
+
+async function terminateManagedProcess(proc: SpawnedProcessHandle): Promise<void> {
+  try {
+    proc.kill?.('SIGTERM')
+  } catch {
+    // Continue to the Windows process-tree fallback and bounded join.
+  }
+
+  if (process.platform === 'win32' && proc.pid !== undefined)
+    await runWithDeadline(killWindowsProcessTree(proc.pid), 2_000)
+
+  await runWithDeadline(
+    proc.exited.then(() => undefined).catch(() => undefined),
+    2_000,
+  )
+}
+
+async function killWindowsProcessTree(pid: number): Promise<void> {
+  await new Promise<void>(resolve => {
+    const killer = spawn('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+      windowsHide: true,
+    })
+    killer.once('error', () => resolve())
+    killer.once('close', () => resolve())
+  })
+}
+
+async function runWithDeadline(work: Promise<void>, timeoutMs: number): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    await Promise.race([
+      work,
+      new Promise<void>(resolve => {
+        timeoutId = setTimeout(resolve, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
   }
 }

--- a/test/command-runtime.test.ts
+++ b/test/command-runtime.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { setCliContext } from '../src/cli-context'
+import { registerCliCancellationHandler, setCliContext } from '../src/cli-context'
 import { executeCommandWithRuntime } from '../src/command-runtime'
 import { createSuccessResult } from '../src/output'
 import * as selfModule from '../src/self'
@@ -214,6 +214,56 @@ describe('executeCommandWithRuntime', () => {
     const cancelledEvent = JSON.parse(logSpy.mock.calls[0][0])
     expect(cancelledEvent.type).toBe('cancelled')
     expect(cancelledEvent.data.signal).toBe('SIGTERM')
+    expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('CANCELLED')
+  })
+
+  it('waits for cancellation cleanup before returning a signal cancellation result', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'ndjson',
+      runId: 'signal-cleanup-run-id',
+    })
+
+    let cleanupFinished = false
+    let releaseCleanup!: () => void
+    registerCliCancellationHandler(
+      () =>
+        new Promise<void>(resolve => {
+          releaseCleanup = () => {
+            cleanupFinished = true
+            resolve()
+          }
+        }),
+    )
+
+    const execution = executeCommandWithRuntime({
+      action: 'install',
+      run: () => new Promise<CommandResult<unknown>>(() => {}),
+      target: {
+        kind: 'agent',
+        name: 'vtcode',
+      },
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    process.emit('SIGTERM')
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    let settled = false
+    void execution.then(() => {
+      settled = true
+      return undefined
+    })
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(settled).toBe(false)
+    expect(cleanupFinished).toBe(false)
+
+    releaseCleanup()
+
+    const result = await execution
+    expect(cleanupFinished).toBe(true)
     expect(result.ok).toBe(false)
     expect(result.error?.code).toBe('CANCELLED')
   })

--- a/test/utils/child-process.test.ts
+++ b/test/utils/child-process.test.ts
@@ -72,7 +72,7 @@ describe('spawnWithQuantexStdio', () => {
     expect(stderrWriteSpy).toHaveBeenCalledWith('installer stderr')
   })
 
-  it('kills registered child processes when the cli context is cancelled', () => {
+  it('kills registered child processes when the cli context is cancelled', async () => {
     setCliContext({
       interactive: false,
       outputMode: 'json',
@@ -80,7 +80,7 @@ describe('spawnWithQuantexStdio', () => {
     })
     const kill = vi.fn()
     mockSpawn.mockReturnValue({
-      exited: new Promise(() => {}),
+      exited: Promise.resolve(),
       exitCode: null,
       kill,
       stderr: '',
@@ -88,8 +88,39 @@ describe('spawnWithQuantexStdio', () => {
     })
 
     spawnWithQuantexStdio(['npm', '--version'])
-    cancelCliContextOperations()
+    await cancelCliContextOperations()
 
+    expect(kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('does not report success when a managed child exits zero after cancellation', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'json-run-id',
+    })
+    const kill = vi.fn()
+    let resolveExit!: () => void
+    mockSpawn.mockReturnValue({
+      exited: new Promise<void>(resolve => {
+        resolveExit = resolve
+      }),
+      exitCode: null,
+      kill,
+      stderr: '',
+      stdout: '',
+    })
+
+    const handle = spawnWithQuantexStdio(['cargo', 'install', 'vtcode'])
+    const cancellation = cancelCliContextOperations()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    mockSpawn.mock.results[0]!.value.exitCode = 0
+    resolveExit()
+    await cancellation
+
+    const exitCode = await waitForSpawnedCommand(handle)
+
+    expect(exitCode).toBe(1)
     expect(kill).toHaveBeenCalledWith('SIGTERM')
   })
 })


### PR DESCRIPTION
## Summary

Fixes Windows managed installer cancellation so `Ctrl+C`/timeouts wait for registered child-process cleanup, request Windows process-tree termination for managed children, and keep cancellation sticky even if the installer later exits `0`.

This prevents cancelled installs such as `qtx install vtcode` from later rendering normal success or persisting normal installed-agent state after the user has cancelled.

Adds an isolated e2e regression that runs a real Quantex runtime path with a fake Cargo installer. The fake installer models the Windows failure mode by continuing long enough to outlive the timeout and by being capable of exiting successfully if Quantex does not terminate the process tree.

## Linked Artifacts

- Issue: Fixes #237
- ADR:
- OpenSpec: `openspec/changes/fix-managed-installer-cancellation`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [x] `bun run test -- test/managed-installer-cancellation.e2e.test.ts`
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

OpenSpec archive closure remains pending until this implementation PR merges.
