### PR TITLE
chore: consolidate agent skill bootstrap

### DIFF
--- a/.agents/skills/quantex-agent-runtime/SKILL.md
+++ b/.agents/skills/quantex-agent-runtime/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: quantex-agent-runtime
+description: Use when starting or resuming any Quantex repository task; activate Superpowers and follow the central Quantex runtime.
+license: MIT
+---
+
+# Quantex Agent Runtime Bootstrap
+
+Activate Superpowers first when available.
+
+Then read and follow:
+
+- `skills/quantex-agent-runtime/SKILL.md`
+- `AGENTS.md`
+- `openspec/README.md`
+
+For new task start or resume, use the "Task Start Entry" in the central runtime skill. Native slash or skill commands are only launchers; OpenSpec, worktrees, branches, and PRs remain the source of truth.
+
+Do not use copied OPSX workflow bodies from agent-specific directories. OpenSpec remains the source of truth for change contracts; this bootstrap only routes the session to the central runtime.

--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,5 +1,0 @@
-{
-  "setup": ["bun install"],
-  "teardown": [],
-  "run": []
-}

--- a/openspec/changes/consolidate-agent-skill-bootstrap/.openspec.yaml
+++ b/openspec/changes/consolidate-agent-skill-bootstrap/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/consolidate-agent-skill-bootstrap/design.md
+++ b/openspec/changes/consolidate-agent-skill-bootstrap/design.md
@@ -1,0 +1,12 @@
+# Design
+
+## Approach
+
+Keep `skills/quantex-agent-runtime/SKILL.md` as the canonical contributor runtime. The new `.agents/skills/quantex-agent-runtime/SKILL.md` remains a short bootstrap that tells agents to activate Superpowers when available and then read the central runtime, `AGENTS.md`, and `openspec/README.md`.
+
+Removing `.superset/config.json` narrows repository-maintained setup guidance to the existing Quantex runtime, OpenSpec, and validation commands.
+
+## Risks
+
+- Some agent runtimes may still need agent-specific bootstrap directories. This change does not remove those directories.
+- A future cleanup may decide whether other bootstrap directories should be generated or retained, but that is outside this change.

--- a/openspec/changes/consolidate-agent-skill-bootstrap/proposal.md
+++ b/openspec/changes/consolidate-agent-skill-bootstrap/proposal.md
@@ -1,0 +1,23 @@
+# Consolidate Agent Skill Bootstrap
+
+## Summary
+
+Add a common `.agents` bootstrap for the contributor-facing Quantex agent runtime and remove the obsolete Superset local setup file.
+
+## Motivation
+
+The repository already keeps durable Quantex workflow rules in `skills/quantex-agent-runtime/SKILL.md` and allows thin agent bootstrap files. A common `.agents` bootstrap gives compatible agent runtimes a shared entry point while preserving the central runtime skill as the source of truth.
+
+The Superset local configuration is no longer part of the maintained contributor workflow and should not remain as an active setup contract.
+
+## Scope
+
+- Add `.agents/skills/quantex-agent-runtime/SKILL.md` as a thin pointer to the central runtime skill.
+- Remove `.superset/config.json`.
+- Record the project-memory contract for the common bootstrap entry point.
+
+## Non-goals
+
+- Do not rewrite the central runtime skill.
+- Do not replace every agent-specific bootstrap directory.
+- Do not add new project-local workflow commands.

--- a/openspec/changes/consolidate-agent-skill-bootstrap/specs/project-memory/spec.md
+++ b/openspec/changes/consolidate-agent-skill-bootstrap/specs/project-memory/spec.md
@@ -1,0 +1,19 @@
+# Project Memory Specification Delta
+
+## Modified Requirements
+
+### Requirement: Agent-specific workflow files SHALL stay thin
+
+The repository SHALL NOT maintain full copied OPSX workflow instructions separately for each supported coding agent. Agent-specific or common agent bootstrap directories MAY contain thin bootstrap files whose purpose is to route the agent to Superpowers, the central Quantex runtime skill, and repo-native OpenSpec artifacts.
+
+#### Scenario: Maintainer updates Quantex workflow rules
+
+- **WHEN** Quantex workflow rules change
+- **THEN** the maintainer updates the central runtime skill, OpenSpec specs, or canonical docs
+- **AND** agent-specific or common bootstrap files remain short pointers rather than full duplicate workflow copies
+
+#### Scenario: Agent uses the common bootstrap entry point
+
+- **WHEN** a compatible coding-agent runtime discovers `.agents/skills/quantex-agent-runtime/SKILL.md`
+- **THEN** the bootstrap routes the session to `skills/quantex-agent-runtime/SKILL.md`, `AGENTS.md`, and `openspec/README.md`
+- **AND** it does not duplicate the full contributor workflow body

--- a/openspec/changes/consolidate-agent-skill-bootstrap/tasks.md
+++ b/openspec/changes/consolidate-agent-skill-bootstrap/tasks.md
@@ -1,0 +1,6 @@
+# Tasks
+
+- [x] Add the common `.agents` Quantex agent runtime bootstrap.
+- [x] Remove obsolete Superset local setup configuration.
+- [x] Add an OpenSpec project-memory delta for the common bootstrap entry point.
+- [x] Run validation.


### PR DESCRIPTION
## Summary

Add a common `.agents` Quantex agent runtime bootstrap and remove the obsolete Superset local setup config.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/consolidate-agent-skill-bootstrap`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [ ] Working tree was clean after commit.
- [ ] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This PR keeps the central contributor runtime in `skills/quantex-agent-runtime` as the source of truth. The new `.agents` file is only a thin bootstrap pointer.
