### PR TITLE
fix: harden Windows managed installer cancellation

### DIFF
--- a/openspec/changes/harden-managed-installer-cancellation-e2e/design.md
+++ b/openspec/changes/harden-managed-installer-cancellation-e2e/design.md
@@ -1,0 +1,36 @@
+## Context
+
+The archived `fix-managed-installer-cancellation` change made cancellation sticky and joined, and it added Windows `taskkill /T /F` as a process-tree cleanup path. The follow-up e2e reproduction exposed an ordering issue: if the direct child is a Windows wrapper process and Quantex kills it first, the wrapper can disappear before `taskkill` walks the process tree. The real installer child can then outlive Quantex.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Prefer Windows process-tree termination before direct wrapper termination for managed child processes.
+- Exercise the real command runtime, package-manager, and state path with an isolated fake Cargo installer.
+- Keep the existing managed installer cancellation surface and structured output semantics.
+
+**Non-Goals:**
+
+- Introduce native Windows job objects.
+- Change install/update/uninstall command schemas.
+- Reopen or rewrite the archived #237 OpenSpec change.
+
+## Decisions
+
+1. Windows process-tree cleanup runs before direct child kill.
+
+   This preserves the process tree long enough for `taskkill /T /F /PID <pid>` to reach descendants created by wrappers such as `.cmd` launchers. Direct `proc.kill('SIGTERM')` remains as a fallback.
+
+2. The e2e smoke runs as a real child process.
+
+   The regression uses a sandboxed `HOME`, `USERPROFILE`, and `PATH`, then invokes `bun run scripts/managed-installer-cancellation-smoke.ts`. This exercises Quantex command runtime behavior rather than only unit-level child-process helpers.
+
+3. The fake installer records the failure mode.
+
+   Fake Cargo logs version probing and `install`, then waits long enough that Quantex must cancel it. If cleanup fails, it records completion and can exit successfully, which the e2e test rejects.
+
+## Risks / Trade-offs
+
+- [taskkill unavailable or denied] -> Direct child termination still runs as fallback and sticky cancellation prevents success state from being persisted.
+- [Timing-sensitive e2e] -> The fake installer uses bounded waits and asserts elapsed time to keep the test deterministic while still covering the user-visible failure mode.

--- a/openspec/changes/harden-managed-installer-cancellation-e2e/proposal.md
+++ b/openspec/changes/harden-managed-installer-cancellation-e2e/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+#237 was initially fixed by making managed installer cancellation sticky and joined, then archived after #288 merged. Follow-up e2e work found a Windows-specific ordering risk: when Quantex launches a managed installer through a `.cmd`-style wrapper, directly killing the wrapper before `taskkill /T /F` can orphan the real installer process. That can recreate the user-visible symptom where Quantex returns while Cargo continues writing to the console.
+
+This follow-up change keeps the archived cancellation contract intact while adding an isolated e2e reproduction and tightening the Windows process-tree termination order.
+
+## What Changes
+
+- On Windows, attempt process-tree termination with `taskkill /T /F` before direct child termination when a managed child PID is available.
+- Add an isolated e2e regression that runs the real Quantex runtime path against a fake Cargo installer under a sandboxed home/profile/PATH.
+- Assert the cancelled install returns a timeout result quickly, does not render success, does not persist installed-agent state, and terminates the fake installer before it can complete.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: Reinforce the existing managed lifecycle cancellation requirement with an e2e scenario for Windows wrapper process-tree cleanup.
+
+## Impact
+
+- Affected code: `src/utils/child-process.ts`.
+- Affected tests: `test/managed-installer-cancellation.e2e.test.ts` and `scripts/managed-installer-cancellation-smoke.ts`.
+- No new runtime dependency is introduced; Windows process-tree termination continues to use the platform-provided `taskkill.exe`.

--- a/openspec/changes/harden-managed-installer-cancellation-e2e/specs/agent-update/spec.md
+++ b/openspec/changes/harden-managed-installer-cancellation-e2e/specs/agent-update/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Managed lifecycle cancellation MUST terminate Windows wrapper process trees before wrapper fallback kill
+
+When Quantex cancels a managed lifecycle installer on Windows and a child process identifier is available, it SHALL attempt process-tree termination before directly killing the wrapper process. Quantex MUST preserve sticky cancellation semantics if process-tree termination is unavailable, denied, or races with child exit.
+
+#### Scenario: Windows wrapper child owns a long-running installer descendant
+
+- **GIVEN** Quantex is running a managed installer through a Windows wrapper process
+- **AND** the wrapper has started a long-running installer descendant
+- **WHEN** the managed installer operation is cancelled by signal or timeout
+- **THEN** Quantex attempts process-tree termination for the wrapper process identifier before direct wrapper termination
+- **AND** the installer descendant does not continue producing installer progress after Quantex returns the cancelled result
+- **AND** Quantex does not persist normal installed-agent state for the cancelled operation

--- a/openspec/changes/harden-managed-installer-cancellation-e2e/tasks.md
+++ b/openspec/changes/harden-managed-installer-cancellation-e2e/tasks.md
@@ -1,0 +1,23 @@
+## 1. OpenSpec
+
+- [x] 1.1 Create a follow-up OpenSpec change for the e2e-discovered Windows wrapper cleanup ordering issue.
+- [x] 1.2 Link the follow-up to the archived #237 cancellation contract without editing archived task state.
+
+## 2. Implementation
+
+- [x] 2.1 Update managed child process termination so Windows process-tree cleanup runs before direct wrapper termination.
+
+## 3. Tests
+
+- [x] 3.1 Add an isolated e2e smoke script that runs a real Quantex runtime path with a fake Cargo-managed install.
+- [x] 3.2 Add a sandboxed e2e test that asserts timeout output, no success rendering, no installed-agent state persistence, and no fake installer completion.
+
+## 4. Validation
+
+- [x] 4.1 Run `bun run test -- test/managed-installer-cancellation.e2e.test.ts`.
+- [x] 4.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, `bun run openspec:validate`, and `bun run memory:check`.
+
+## 5. Delivery
+
+- [x] 5.1 Commit and push the follow-up fix branch.
+- [x] 5.2 Prepare a PR body from `.github/pull_request_template.md`, validate it, and open the PR.

--- a/scripts/managed-installer-cancellation-smoke.ts
+++ b/scripts/managed-installer-cancellation-smoke.ts
@@ -1,0 +1,80 @@
+import type { AgentDefinition } from '../src/agents'
+import { resetCliContext, setCliContext } from '../src/cli-context'
+import { executeCommandWithRuntime } from '../src/command-runtime'
+import { createErrorResult, createSuccessResult } from '../src/output'
+import { installAgent } from '../src/package-manager'
+import { getInstalledAgentState } from '../src/state'
+
+const agent: AgentDefinition = {
+  binaryName: 'cargo-cancel-smoke-agent',
+  displayName: 'Cargo Cancel Smoke Agent',
+  homepage: 'https://example.com/cargo-cancel-smoke-agent',
+  name: 'cargo-cancel-smoke-agent',
+  packages: {
+    cargo: 'cargo-cancel-smoke-agent',
+  },
+  platforms: {
+    linux: [{ type: 'cargo' }],
+    macos: [{ type: 'cargo' }],
+    windows: [{ type: 'cargo' }],
+  },
+}
+
+setCliContext({
+  interactive: false,
+  outputMode: 'json',
+  runId: 'managed-installer-cancellation-smoke',
+  timeoutMs: Number(process.env.QTX_CANCELLATION_SMOKE_TIMEOUT_MS ?? 250),
+})
+
+try {
+  const result = await executeCommandWithRuntime({
+    action: 'install',
+    run: async () => {
+      const install = await installAgent(agent)
+
+      if (install.success) {
+        return createSuccessResult({
+          action: 'install',
+          data: {
+            installed: true,
+          },
+          target: {
+            kind: 'agent',
+            name: agent.name,
+          },
+        })
+      }
+
+      return createErrorResult({
+        action: 'install',
+        data: {
+          installed: false,
+        },
+        error: {
+          code: 'INSTALL_FAILED',
+          message: 'Managed installer returned failure.',
+        },
+        target: {
+          kind: 'agent',
+          name: agent.name,
+        },
+      })
+    },
+    target: {
+      kind: 'agent',
+      name: agent.name,
+    },
+  })
+
+  if (result.ok || result.error?.code !== 'TIMEOUT') {
+    throw new Error(`Expected timeout cancellation, received ${result.error?.code ?? 'success'}.`)
+  }
+
+  const persistedState = await getInstalledAgentState(agent.name)
+  if (persistedState) {
+    throw new Error('Cancelled managed install must not persist installed-agent state.')
+  }
+} finally {
+  resetCliContext()
+}

--- a/src/utils/child-process.ts
+++ b/src/utils/child-process.ts
@@ -175,14 +175,14 @@ function spawnWithBun(
 }
 
 async function terminateManagedProcess(proc: SpawnedProcessHandle): Promise<void> {
+  if (process.platform === 'win32' && proc.pid !== undefined)
+    await runWithDeadline(killWindowsProcessTree(proc.pid), 2_000)
+
   try {
     proc.kill?.('SIGTERM')
   } catch {
-    // Continue to the Windows process-tree fallback and bounded join.
+    // Continue to the bounded join.
   }
-
-  if (process.platform === 'win32' && proc.pid !== undefined)
-    await runWithDeadline(killWindowsProcessTree(proc.pid), 2_000)
 
   await runWithDeadline(
     proc.exited.then(() => undefined).catch(() => undefined),

--- a/test/managed-installer-cancellation.e2e.test.ts
+++ b/test/managed-installer-cancellation.e2e.test.ts
@@ -1,0 +1,140 @@
+import { spawn } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import process from 'node:process'
+import { text as readText } from 'node:stream/consumers'
+import { describe, expect, it } from 'vitest'
+
+interface CommandOutput {
+  durationMs: number
+  exitCode: number
+  stderr: string
+  stdout: string
+}
+
+describe('managed installer cancellation e2e', () => {
+  it('times out a Cargo-managed install in an isolated sandbox without persisting success', async () => {
+    const sandboxRoot = await mkdtemp(join(tmpdir(), 'quantex-cancel-e2e-'))
+    const fakeBinDir = join(sandboxRoot, 'bin')
+    const homeDir = join(sandboxRoot, 'home')
+    const fakeCargoLog = join(sandboxRoot, 'fake-cargo.log')
+
+    try {
+      await mkdir(homeDir, { recursive: true })
+      await installFakeCargo(fakeBinDir, fakeCargoLog)
+
+      const output = await runCommand(['bun', 'run', 'scripts/managed-installer-cancellation-smoke.ts'], {
+        HOME: homeDir,
+        PATH: `${fakeBinDir}${delimiter}${process.env.PATH ?? ''}`,
+        QTX_CANCELLATION_SMOKE_TIMEOUT_MS: '250',
+        QTX_FAKE_CARGO_LOG: fakeCargoLog,
+        USERPROFILE: homeDir,
+      })
+
+      expect(output.exitCode, output.stderr).toBe(0)
+      expect(output.durationMs).toBeLessThan(4_000)
+      expect(output.stdout).toContain('"code": "TIMEOUT"')
+      expect(output.stdout).not.toContain('installed successfully')
+
+      const state = await readJsonFile(join(homeDir, '.quantex', 'state.json'))
+      expect(state?.installedAgents?.['cargo-cancel-smoke-agent']).toBeUndefined()
+
+      const log = await readFile(fakeCargoLog, 'utf8')
+      expect(log).toContain('cargo --version')
+      expect(log).toContain('cargo install cargo-cancel-smoke-agent')
+      expect(log).not.toContain('fake cargo completed without cancellation')
+      if (process.platform !== 'win32') expect(log).toContain('fake cargo received SIGTERM')
+    } finally {
+      await rm(sandboxRoot, { force: true, recursive: true })
+    }
+  })
+})
+
+async function installFakeCargo(fakeBinDir: string, logPath: string): Promise<void> {
+  await mkdir(fakeBinDir, { recursive: true })
+  const fakeCargoModule = join(fakeBinDir, 'fake-cargo.mjs')
+  const fakeCargoSource = [
+    "import { appendFileSync } from 'node:fs'",
+    "import process from 'node:process'",
+    'const args = process.argv.slice(2)',
+    'const logPath = process.env.QTX_FAKE_CARGO_LOG',
+    'if (!logPath) throw new Error("QTX_FAKE_CARGO_LOG is required")',
+    'const log = message => appendFileSync(logPath, `${message}\\n`)',
+    'log(`cargo ${args.join(" ")}`)',
+    'if (args[0] === "--version") {',
+    '  console.log("cargo 1.88.0")',
+    '  process.exit(0)',
+    '}',
+    'if (args[0] !== "install") process.exit(0)',
+    'const complete = message => {',
+    '  log(message)',
+    '  setTimeout(() => process.exit(0), 25)',
+    '}',
+    'process.on("SIGTERM", () => complete("fake cargo received SIGTERM"))',
+    'process.on("SIGINT", () => complete("fake cargo received SIGINT"))',
+    'setTimeout(() => complete("fake cargo completed without cancellation"), 10_000)',
+  ].join('\n')
+  await writeFile(fakeCargoModule, fakeCargoSource, 'utf8')
+
+  if (process.platform === 'win32') {
+    await writeFile(join(fakeBinDir, 'cargo.cmd'), ['@echo off', 'bun "%~dp0fake-cargo.mjs" %*'].join('\r\n'), 'utf8')
+    return
+  }
+
+  const fakeCargoPath = join(fakeBinDir, 'cargo')
+  await writeFile(
+    fakeCargoPath,
+    ['#!/usr/bin/env sh', 'exec bun "$(dirname "$0")/fake-cargo.mjs" "$@"', ''].join('\n'),
+    'utf8',
+  )
+  await chmod(fakeCargoPath, 0o755)
+}
+
+async function runCommand(command: string[], env: Record<string, string>): Promise<CommandOutput> {
+  const startedAt = Date.now()
+  const [file, ...args] = command
+  const proc = spawn(file!, args, {
+    env: {
+      ...process.env,
+      ...env,
+      NO_COLOR: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const timeout = setTimeout(() => {
+    proc.kill('SIGTERM')
+  }, 10_000)
+
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      readText(proc.stdout),
+      readText(proc.stderr),
+      waitForChild(proc),
+    ])
+
+    return {
+      durationMs: Date.now() - startedAt,
+      exitCode,
+      stderr,
+      stdout,
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function waitForChild(proc: ReturnType<typeof spawn>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    proc.once('error', reject)
+    proc.once('close', code => resolve(typeof code === 'number' ? code : 1))
+  })
+}
+
+async function readJsonFile(path: string): Promise<any | undefined> {
+  try {
+    return JSON.parse(await readFile(path, 'utf8'))
+  } catch {
+    return undefined
+  }
+}


### PR DESCRIPTION
## Summary

Follow-up to #288 for the Windows managed installer cancellation bug reported in #237.

This adds an isolated e2e regression that runs the real Quantex runtime path against a fake Cargo installer in a sandboxed home/profile/PATH. The test reproduces the important failure mode: a managed installer can outlive the Quantex cancellation path and later report success if Quantex does not terminate the underlying process tree.

The implementation also hardens Windows cleanup by invoking `taskkill /T /F` before directly killing the wrapper process. This matters for `.cmd`-style wrappers where killing the direct child first can orphan the real installer process before process-tree cleanup runs.

## Linked Artifacts

- Issue: Follow-up for #237
- ADR:
- OpenSpec: `openspec/changes/harden-managed-installer-cancellation-e2e`
- Discussion: Follow-up to #288

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [x] `bun run test -- test/managed-installer-cancellation.e2e.test.ts`
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until this follow-up implementation PR merges, then queued for agent-driven archive closure.
- [x] Release is delegated to release automation.

## Notes

#288 merged the first cancellation fix, closed #237, and its original OpenSpec change has since been archived on `main`. This PR uses a new follow-up OpenSpec change for the e2e-discovered Windows `.cmd` wrapper orphaning fix and the sandbox reproduction test.
