### PR TITLE
fix: prefer Cargo for VTCode Windows install

### DIFF
--- a/openspec/changes/fix-vtcode-windows-install-order/.openspec.yaml
+++ b/openspec/changes/fix-vtcode-windows-install-order/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/fix-vtcode-windows-install-order/design.md
+++ b/openspec/changes/fix-vtcode-windows-install-order/design.md
@@ -1,0 +1,28 @@
+## Context
+
+VTCode's catalog entry includes both Cargo and upstream script install methods. On Windows, the script currently runs first, but the latest upstream release assets still do not include the Windows zip filename that `install.ps1` constructs. That makes the first install attempt fail noisily before Quantex falls through to Cargo.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `qtx install vtcode` try the managed Cargo path first on Windows.
+- Preserve the upstream PowerShell script as a fallback and as inspect/resolve guidance.
+- Keep macOS and Linux method ordering unchanged because their native release archives exist.
+
+**Non-Goals:**
+
+- Do not add release-asset probing or dynamic catalog rewriting.
+- Do not remove the upstream Windows script permanently.
+- Do not change Cargo installer behavior or fallback execution semantics.
+
+## Decisions
+
+- Reorder only `src/agents/catalog/vtcode.json` for Windows. This keeps the fix local to the catalog metadata that already drives `install`, `ensure`, `inspect`, `resolve`, and structured output.
+- Assert the Windows method order in `test/agents.test.ts`. The issue was caused by catalog ordering, so a catalog-level regression test is enough without mocking a full Windows install session.
+- Document the order as a VTCode-specific `agent-catalog` requirement delta. This keeps the durable contract tied to the upstream packaging constraint without introducing a general installer priority rule.
+
+## Risks / Trade-offs
+
+- [Upstream later publishes Windows assets] -> Quantex can revisit the order with a new catalog/spec change once the native installer is verified on Windows.
+- [Cargo builds remain slow] -> The first attempted method becomes more reliable but may still take time; clearer fallback/cancellation behavior is handled separately by the active managed-installer cancellation change.

--- a/openspec/changes/fix-vtcode-windows-install-order/proposal.md
+++ b/openspec/changes/fix-vtcode-windows-install-order/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+This implementation request changes VTCode agent catalog metadata and observable install behavior, so it requires an OpenSpec-backed change before editing. `qtx install vtcode` currently tries the upstream Windows PowerShell installer first even though the latest upstream releases still omit the Windows zip asset that installer expects, producing confusing failure output before Cargo fallback starts.
+
+## What Changes
+
+- Prefer the Cargo-managed VTCode install method before the upstream PowerShell script on Windows.
+- Keep the upstream Windows script installer available as a fallback/install-guidance method instead of removing it from the catalog.
+- Add regression coverage so the Windows VTCode method order remains Cargo first, then script.
+- Update the `agent-catalog` spec delta for VTCode Windows installation behavior.
+
+## Capabilities
+
+### New Capabilities
+
+_None_
+
+### Modified Capabilities
+
+- `agent-catalog`: Refine VTCode Windows install method ordering so the managed Cargo path is attempted before the upstream native script while upstream Windows release assets are absent.
+
+## Impact
+
+- `src/agents/catalog/vtcode.json` - reorder Windows VTCode install methods.
+- `test/agents.test.ts` - assert the Windows VTCode install method order.
+- `openspec/changes/fix-vtcode-windows-install-order/specs/agent-catalog/spec.md` - document the catalog contract delta.

--- a/openspec/changes/fix-vtcode-windows-install-order/specs/agent-catalog/spec.md
+++ b/openspec/changes/fix-vtcode-windows-install-order/specs/agent-catalog/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: VTCode MUST be a supported lifecycle agent
+
+Quantex SHALL include VTCode in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up VTCode
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `vtcode`
+- **THEN** Quantex returns a supported agent entry for VTCode
+- **AND** the entry identifies `vtcode` as the executable binary
+- **AND** the entry identifies `vtcode` as its Cargo crate metadata
+- **AND** the entry identifies `https://github.com/vinhnx/vtcode` as the homepage
+
+#### Scenario: Installing VTCode through supported methods
+
+- **WHEN** Quantex renders or executes install options for VTCode
+- **THEN** the catalog includes the Cargo managed install method on Windows, macOS, and Linux
+- **AND** Windows orders the Cargo managed install method before the official native PowerShell installer while upstream Windows release assets are absent
+- **AND** macOS and Linux include the official native shell installer (`curl -fsSL https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.sh | bash`)
+- **AND** Windows includes the official native PowerShell installer (`irm https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.ps1 | iex`)
+- **AND** macOS and Linux include the Homebrew formula install method (`vtcode`)
+
+#### Scenario: Probing VTCode version
+
+- **WHEN** Quantex probes the installed version of VTCode
+- **THEN** it runs `vtcode --version` and parses the output
+
+#### Scenario: Planning VTCode updates
+
+- **WHEN** Quantex plans an update for a VTCode installation that supports the built-in updater
+- **THEN** the catalog exposes `vtcode update` as the agent self-update command

--- a/openspec/changes/fix-vtcode-windows-install-order/tasks.md
+++ b/openspec/changes/fix-vtcode-windows-install-order/tasks.md
@@ -1,0 +1,15 @@
+# Tasks: Fix VTCode Windows Install Order
+
+## 1. Catalog behavior
+
+- [x] 1.1 Reorder VTCode Windows install methods so Cargo is attempted before the upstream PowerShell script.
+- [x] 1.2 Add regression coverage for the VTCode Windows method order.
+
+## 2. OpenSpec and validation
+
+- [x] 2.1 Update the `agent-catalog` OpenSpec delta for the VTCode Windows install method ordering.
+- [x] 2.2 Run `bun run lint`.
+- [x] 2.3 Run `bun run format:check`.
+- [x] 2.4 Run `bun run typecheck`.
+- [x] 2.5 Run `bun run test`.
+- [x] 2.6 Run `bun run openspec:validate`.

--- a/src/agents/catalog/vtcode.json
+++ b/src/agents/catalog/vtcode.json
@@ -15,11 +15,11 @@
   "platforms": {
     "windows": [
       {
-        "command": "irm https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.ps1 | iex",
-        "type": "script"
+        "type": "cargo"
       },
       {
-        "type": "cargo"
+        "command": "irm https://raw.githubusercontent.com/vinhnx/vtcode/main/scripts/install.ps1 | iex",
+        "type": "script"
       }
     ],
     "macos": [

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -924,6 +924,7 @@ describe('vtcode', () => {
   })
 
   it('exposes official install methods per platform', () => {
+    expect(vtcode.platforms.windows!.map(m => m.type)).toEqual(['cargo', 'script'])
     expect(
       vtcode.platforms.windows!.find(
         m =>


### PR DESCRIPTION
﻿## Summary

Fix VTCode Windows install ordering so Quantex tries the Cargo-managed path before the upstream PowerShell installer, which still expects a missing Windows release asset.

## Linked Artifacts

- Issue: Closes #236
- ADR:
- OpenSpec: `openspec/changes/fix-vtcode-windows-install-order`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The upstream VTCode latest release checked during this fix is `0.108.1`; it still publishes macOS/Linux archives plus scripts/checksums, but no Windows `x86_64-pc-windows-msvc.zip` asset. The Windows script remains available as a fallback method.
