### PR TITLE
fix: keep Windows binary aliases in sync

### DIFF
--- a/docs/runbooks/release-and-self-upgrade-debugging.md
+++ b/docs/runbooks/release-and-self-upgrade-debugging.md
@@ -197,6 +197,13 @@ Focus areas:
 - post-replacement `--version` verification
 - rollback from `.bak` when verification fails
 
+Windows standalone installs use two executable files in the same install directory:
+
+- `quantex.exe` is the canonical downloaded binary
+- `qtx.exe` is a copied alias because Windows symlink permissions are not reliable for the default installer
+
+When debugging Windows binary self-upgrade, treat those files as one install. A successful delayed replacement from either entry point should leave both files on the upgraded binary. Manual recovery or uninstall cleanup should remove or replace both `quantex.exe` and `qtx.exe` together.
+
 ### 7. Debug install-source detection and state drift
 
 If the wrong provider is chosen, inspect install-source detection before touching release code.

--- a/openspec/changes/fix-windows-qtx-binary-alias/.openspec.yaml
+++ b/openspec/changes/fix-windows-qtx-binary-alias/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-23

--- a/openspec/changes/fix-windows-qtx-binary-alias/design.md
+++ b/openspec/changes/fix-windows-qtx-binary-alias/design.md
@@ -1,0 +1,49 @@
+## Context
+
+Discussion #69 split the Windows binary alias concern out of README work because it affects self-upgrade behavior. On Windows, `install.ps1` downloads the release asset to `quantex.exe` and copies it to `qtx.exe`; unlike the POSIX installer's symlink model, those are two independent files.
+
+The current binary self-upgrade path replaces only `plan.facts.executablePath`. If the user runs `qtx upgrade`, `qtx.exe` can move forward while `quantex.exe` remains old; if they run `quantex upgrade`, the opposite can happen.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep the Windows standalone `quantex.exe` and `qtx.exe` files consistent after binary self-upgrade.
+- Preserve delayed replacement semantics for the locked running executable.
+- Document manual recovery and uninstall cleanup as a two-file Windows operation.
+- Add focused regression coverage around alias path derivation and delayed replacement script generation.
+
+**Non-Goals:**
+
+- Do not switch Windows installs to symlinks or junctions.
+- Do not change npm/Bun shim behavior.
+- Do not add a dedicated Quantex self-uninstall command.
+- Do not change release asset naming.
+
+## Decisions
+
+1. Treat the executable basename as the source for deriving the peer alias.
+
+   On Windows, if the running path ends with `qtx.exe`, the peer is `quantex.exe` in the same directory. If it ends with `quantex.exe`, the peer is `qtx.exe`. Other executable names have no peer alias. This keeps the behavior local to the standalone installer's known layout.
+
+   Alternative considered: persist install metadata with both paths. That would add migration and state drift concerns for a path relationship that is already deterministic from `install.ps1`.
+
+2. Reuse the same downloaded binary for both Windows files.
+
+   The release artifact is the same executable content regardless of entrypoint name, so the delayed PowerShell script can move the downloaded temp file to the running target, verify that target, then copy the verified target to the peer alias when present.
+
+   Alternative considered: schedule two independent downloads/replacements. That would add network and checksum work without improving correctness.
+
+3. Verify the running target before syncing the peer alias.
+
+   The existing Windows path can only report that replacement was scheduled, because the current process must exit before replacement occurs. The scheduled script still performs version verification when an expected version exists. The peer alias should only be overwritten after that verification passes so rollback preserves both files as much as possible.
+
+4. Keep manual uninstall as documentation, not a new command.
+
+   Issue #76 asks for uninstall behavior consistency with the chosen model. Quantex currently has no self-uninstall command; the actionable behavior is to document that manual Windows binary uninstall removes both `quantex.exe` and `qtx.exe`.
+
+## Risks / Trade-offs
+
+- [Peer alias copy fails after target verification] -> The scheduled script exits with failure and leaves the verified running target in place; manual recovery guidance points users at both files.
+- [Only one of the two files exists before upgrade] -> The scheduled script recreates the missing peer alias from the verified target when the running file name is one of the known Windows entry points.
+- [Users run a renamed standalone binary] -> No peer alias is inferred, preserving current single-file behavior for custom names.

--- a/openspec/changes/fix-windows-qtx-binary-alias/proposal.md
+++ b/openspec/changes/fix-windows-qtx-binary-alias/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Implementation requested work-intake classification: this change modifies observable Windows standalone binary self-upgrade and uninstall behavior, so it requires OpenSpec before file edits.
+
+Windows `install.ps1` installs `quantex.exe` and copies it to `qtx.exe`, but binary self-upgrade currently replaces only the executable path that is running. That can leave the other Windows entry point stale after `qtx upgrade` or `quantex upgrade`.
+
+## What Changes
+
+- Define Windows standalone binary installs as a two-file model: `quantex.exe` is the canonical binary and `qtx.exe` is a copied alias in the same install directory.
+- Update binary self-upgrade so Windows replacements refresh both `quantex.exe` and `qtx.exe`, no matter which entry point launched the upgrade.
+- Document manual uninstall and recovery guidance for removing or replacing both Windows executable files.
+- Add regression tests for the Windows delayed replacement script and alias path derivation.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `self-upgrade`: Clarify Windows standalone binary alias consistency across self-upgrade, verification, rollback, and manual uninstall/recovery guidance.
+
+## Impact
+
+- Affected code: `src/self/binary.ts`, `src/self/providers/binary.ts`, and binary self-upgrade tests.
+- Affected docs/specs: `openspec/specs/self-upgrade/spec.md` via change delta and `docs/runbooks/release-and-self-upgrade-debugging.md`.
+- Affected user behavior: Windows standalone binary users get both `quantex.exe` and `qtx.exe` refreshed by self-upgrade and documented together for uninstall/recovery.

--- a/openspec/changes/fix-windows-qtx-binary-alias/specs/self-upgrade/spec.md
+++ b/openspec/changes/fix-windows-qtx-binary-alias/specs/self-upgrade/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Windows standalone binary self-upgrade MUST keep entry point copies consistent
+
+Windows standalone binary installs SHALL treat same-directory `quantex.exe` and `qtx.exe` files as equivalent entry point copies of the same Quantex install. When binary self-upgrade replaces either known Windows entry point, it MUST refresh the peer entry point copy from the verified replacement and manual uninstall or recovery guidance MUST account for both files.
+
+#### Scenario: Upgrading from the short Windows entry point
+
+- **GIVEN** Quantex is installed on Windows by `install.ps1`
+- **AND** the user runs `qtx upgrade`
+- **WHEN** the delayed binary replacement completes successfully
+- **THEN** both `qtx.exe` and `quantex.exe` in the install directory contain the upgraded Quantex binary
+
+#### Scenario: Upgrading from the long Windows entry point
+
+- **GIVEN** Quantex is installed on Windows by `install.ps1`
+- **AND** the user runs `quantex upgrade`
+- **WHEN** the delayed binary replacement completes successfully
+- **THEN** both `quantex.exe` and `qtx.exe` in the install directory contain the upgraded Quantex binary
+
+#### Scenario: Replacing a custom Windows binary name
+
+- **GIVEN** Quantex is running from a standalone Windows binary whose filename is not `quantex.exe` or `qtx.exe`
+- **WHEN** binary self-upgrade schedules replacement
+- **THEN** Quantex replaces only the running executable path
+- **AND** it does not infer or create a peer alias file
+
+#### Scenario: Manually uninstalling a Windows standalone binary install
+
+- **GIVEN** Quantex is installed on Windows by `install.ps1`
+- **WHEN** a user follows manual standalone-binary uninstall or recovery guidance
+- **THEN** the guidance identifies both `quantex.exe` and `qtx.exe` as files to remove or replace together

--- a/openspec/changes/fix-windows-qtx-binary-alias/tasks.md
+++ b/openspec/changes/fix-windows-qtx-binary-alias/tasks.md
@@ -1,0 +1,17 @@
+## 1. Windows Binary Alias Behavior
+
+- [x] 1.1 Add peer alias path derivation for same-directory `quantex.exe` and `qtx.exe` on Windows.
+- [x] 1.2 Update delayed Windows binary replacement so a verified replacement refreshes the peer alias copy.
+- [x] 1.3 Preserve single-file replacement behavior for custom Windows executable names and non-Windows platforms.
+
+## 2. Documentation And Tests
+
+- [x] 2.1 Document Windows standalone recovery and uninstall guidance for both `quantex.exe` and `qtx.exe`.
+- [x] 2.2 Add regression tests for Windows replacement command generation from `qtx.exe`, `quantex.exe`, and a custom executable name.
+- [x] 2.3 Add or update provider-level tests so binary self-upgrade passes the Windows alias path through the upgrade flow.
+
+## 3. Validation And Delivery
+
+- [x] 3.1 Run focused self-upgrade tests.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, `bun run openspec:validate`, and `bun run memory:check`.
+- [x] 3.3 Complete delivery closure checks, commit, push, and open a PR for issue #76.

--- a/src/self/binary.ts
+++ b/src/self/binary.ts
@@ -2,7 +2,7 @@ import type { SelfUpdateResult, SelfUpgradeErrorKind } from './types'
 import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
 import { chmod, mkdtemp, rename, rm, stat, writeFile } from 'node:fs/promises'
-import { basename, dirname, join } from 'node:path'
+import { basename, dirname, join, win32 } from 'node:path'
 import process from 'node:process'
 import { readProcessOutput, spawnCommand } from '../utils/child-process'
 
@@ -13,6 +13,7 @@ export async function upgradeStandaloneBinary(
   executablePath: string,
   expectedChecksum: string,
   expectedVersion?: string,
+  windowsPeerExecutablePath: string | undefined = getWindowsStandaloneBinaryPeerPath(executablePath),
 ): Promise<BinaryUpgradeResult> {
   let response: Response
 
@@ -46,7 +47,14 @@ export async function upgradeStandaloneBinary(
     await writeFile(tempPath, binary)
 
     if (process.platform === 'win32')
-      return scheduleWindowsBinaryReplacement(tempPath, executablePath, backupPath, tempDir, expectedVersion)
+      return scheduleWindowsBinaryReplacement(
+        tempPath,
+        executablePath,
+        backupPath,
+        tempDir,
+        expectedVersion,
+        windowsPeerExecutablePath,
+      )
 
     await chmod(tempPath, executableMode)
     await rm(backupPath, { force: true })
@@ -87,6 +95,16 @@ export async function upgradeStandaloneBinary(
   }
 }
 
+export function getWindowsStandaloneBinaryPeerPath(executablePath: string): string | undefined {
+  if (process.platform !== 'win32') return undefined
+
+  const executableName = win32.basename(executablePath).toLowerCase()
+  if (executableName === 'qtx.exe') return win32.join(win32.dirname(executablePath), 'quantex.exe')
+  if (executableName === 'quantex.exe') return win32.join(win32.dirname(executablePath), 'qtx.exe')
+
+  return undefined
+}
+
 async function resolveExecutableMode(executablePath: string): Promise<number> {
   try {
     return (await stat(executablePath)).mode & 0o777
@@ -101,6 +119,7 @@ function scheduleWindowsBinaryReplacement(
   backupPath: string,
   tempDir: string,
   expectedVersion?: string,
+  peerExecutablePath?: string,
 ): BinaryUpgradeResult {
   try {
     const command = createWindowsReplacementCommand(
@@ -110,6 +129,7 @@ function scheduleWindowsBinaryReplacement(
       tempDir,
       process.pid,
       expectedVersion,
+      peerExecutablePath,
     )
     const proc = spawnCommand(
       [
@@ -145,20 +165,24 @@ function createWindowsReplacementCommand(
   tempDir: string,
   pid: number,
   expectedVersion?: string,
+  peerExecutablePath?: string,
 ): string {
   const escapedTempPath = escapePowerShellString(tempPath)
   const escapedExecutablePath = escapePowerShellString(executablePath)
   const escapedBackupPath = escapePowerShellString(backupPath)
   const escapedTempDir = escapePowerShellString(tempDir)
   const escapedExpectedVersion = escapePowerShellString(expectedVersion ?? '')
+  const escapedPeerExecutablePath = escapePowerShellString(peerExecutablePath ?? '')
 
   return [
+    `$ErrorActionPreference = 'Stop'`,
     `$pidToWait = ${pid}`,
     `$tempPath = '${escapedTempPath}'`,
     `$targetPath = '${escapedExecutablePath}'`,
     `$backupPath = '${escapedBackupPath}'`,
     `$tempDir = '${escapedTempDir}'`,
     `$expectedVersion = '${escapedExpectedVersion}'`,
+    `$peerPath = '${escapedPeerExecutablePath}'`,
     `while (Get-Process -Id $pidToWait -ErrorAction SilentlyContinue) { Start-Sleep -Milliseconds 200 }`,
     `for ($attempt = 0; $attempt -lt 50; $attempt++) {`,
     `  try {`,
@@ -179,6 +203,9 @@ function createWindowsReplacementCommand(
     `    Remove-Item -LiteralPath $tempDir -Force -Recurse -ErrorAction SilentlyContinue`,
     `    exit 1`,
     `  }`,
+    `}`,
+    `if ($peerPath -ne '') {`,
+    `  Copy-Item -LiteralPath $targetPath -Destination $peerPath -Force`,
     `}`,
     `Remove-Item -LiteralPath $backupPath -Force -ErrorAction SilentlyContinue`,
     `Remove-Item -LiteralPath $tempDir -Force -Recurse -ErrorAction SilentlyContinue`,

--- a/src/self/providers/binary.ts
+++ b/src/self/providers/binary.ts
@@ -1,6 +1,6 @@
 import type { SelfInspection, SelfUpdateResult, SelfUpgradePlan } from '../types'
 import type { SelfUpgradeProvider } from './types'
-import { upgradeStandaloneBinary } from '../binary'
+import { getWindowsStandaloneBinaryPeerPath, upgradeStandaloneBinary } from '../binary'
 import { getBinaryReleaseDownloadUrl } from '../release'
 
 export const binarySelfUpgradeProvider: SelfUpgradeProvider = {
@@ -46,6 +46,7 @@ export const binarySelfUpgradeProvider: SelfUpgradeProvider = {
       plan.facts.executablePath,
       asset.checksum,
       plan.target.targetVersion ?? 'latest',
+      getWindowsStandaloneBinaryPeerPath(plan.facts.executablePath),
     )
 
     const enrichedResult =

--- a/test/self-binary.test.ts
+++ b/test/self-binary.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { upgradeStandaloneBinary } from '../src/self/binary'
+import { getWindowsStandaloneBinaryPeerPath, upgradeStandaloneBinary } from '../src/self/binary'
 
 const originalFetch = globalThis.fetch
 const originalPlatform = process.platform
@@ -57,6 +57,10 @@ describe('upgradeStandaloneBinary', () => {
       expect(command).toContain('-Command')
       expect(command[command.length - 1]).toContain('Move-Item -LiteralPath')
       expect(command[command.length - 1]).toContain('qtx.exe')
+      const peerPath = getWindowsStandaloneBinaryPeerPath(executablePath)
+      expect(peerPath).toBeTruthy()
+      expect(command[command.length - 1]).toContain(`$peerPath = '${peerPath!.replaceAll("'", "''")}'`)
+      expect(command[command.length - 1]).toContain('Copy-Item -LiteralPath $targetPath -Destination $peerPath -Force')
       expect(options).toMatchObject({
         stdio: ['ignore', 'ignore', 'ignore'],
         windowsHide: true,
@@ -64,6 +68,82 @@ describe('upgradeStandaloneBinary', () => {
     } finally {
       await rm(tempRoot, { recursive: true, force: true })
     }
+  })
+
+  it('schedules peer alias replacement when launched from quantex.exe on Windows', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'quantex-binary-win-long-'))
+    const executablePath = join(tempRoot, 'quantex.exe')
+    const mockSpawn = vi.fn().mockReturnValue({
+      exitCode: 0,
+      exited: Promise.resolve(0),
+      unref: vi.fn(),
+    })
+
+    Bun.spawn = mockSpawn as typeof Bun.spawn
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    await writeFile(executablePath, 'old-binary', 'utf8')
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(Buffer.from('new-binary'), { status: 200 })) as unknown as typeof fetch
+    const checksum = createHash('sha256').update('new-binary').digest('hex')
+
+    try {
+      expect(await upgradeStandaloneBinary('https://example.com/quantex.exe', executablePath, checksum)).toEqual({
+        success: true,
+      })
+
+      const [command] = mockSpawn.mock.calls[0] as [string[], Record<string, unknown>]
+      const peerPath = getWindowsStandaloneBinaryPeerPath(executablePath)
+      expect(peerPath).toBeTruthy()
+      expect(command[command.length - 1]).toContain(`$peerPath = '${peerPath!.replaceAll("'", "''")}'`)
+      expect(command[command.length - 1]).toContain('Copy-Item -LiteralPath $targetPath -Destination $peerPath -Force')
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not infer a peer alias for custom Windows executable names', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'quantex-binary-win-custom-'))
+    const executablePath = join(tempRoot, 'custom.exe')
+    const mockSpawn = vi.fn().mockReturnValue({
+      exitCode: 0,
+      exited: Promise.resolve(0),
+      unref: vi.fn(),
+    })
+
+    Bun.spawn = mockSpawn as typeof Bun.spawn
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    await writeFile(executablePath, 'old-binary', 'utf8')
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(Buffer.from('new-binary'), { status: 200 })) as unknown as typeof fetch
+    const checksum = createHash('sha256').update('new-binary').digest('hex')
+
+    try {
+      expect(await upgradeStandaloneBinary('https://example.com/custom.exe', executablePath, checksum)).toEqual({
+        success: true,
+      })
+
+      const [command] = mockSpawn.mock.calls[0] as [string[], Record<string, unknown>]
+      expect(command[command.length - 1]).toContain(`$peerPath = ''`)
+      expect(command[command.length - 1]).toContain("if ($peerPath -ne '')")
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('derives Windows standalone peer aliases only for known entry point names', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+
+    expect(getWindowsStandaloneBinaryPeerPath('C:\\Users\\test\\.local\\bin\\qtx.exe')).toBe(
+      'C:\\Users\\test\\.local\\bin\\quantex.exe',
+    )
+    expect(getWindowsStandaloneBinaryPeerPath('C:\\Users\\test\\.local\\bin\\quantex.exe')).toBe(
+      'C:\\Users\\test\\.local\\bin\\qtx.exe',
+    )
+    expect(getWindowsStandaloneBinaryPeerPath('C:\\Users\\test\\.local\\bin\\custom.exe')).toBeUndefined()
   })
 
   it('downloads and replaces the current executable', async () => {

--- a/test/self.test.ts
+++ b/test/self.test.ts
@@ -231,7 +231,7 @@ describe('self helpers', () => {
       installSource: 'binary',
       newVersion: '1.1.0',
     })
-    expect(binaryUpgradeSpy).toHaveBeenCalledWith(downloadUrl, '/usr/local/bin/qtx', 'abc123', '1.1.0')
+    expect(binaryUpgradeSpy).toHaveBeenCalledWith(downloadUrl, '/usr/local/bin/qtx', 'abc123', '1.1.0', undefined)
     expect(
       getSelfUpgradeRecoveryHint('binary', '/usr/local/bin/qtx', 'stable', {
         error: {
@@ -265,6 +265,52 @@ describe('self helpers', () => {
         '/usr/local/bin/qtx',
       )?.name,
     ).toBe(getBinaryReleaseAssetName('/usr/local/bin/qtx'))
+  })
+
+  it('passes the Windows standalone peer alias path into binary self-upgrade', async () => {
+    const { upgradeSelf } = await import('../src/self')
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    Object.defineProperty(process, 'arch', { value: 'x64' })
+    const downloadUrl = 'https://example.com/releases/download/v1.1.0/quantex-windows-x64.exe'
+
+    releaseManifestSpy.mockResolvedValue({
+      assets: [
+        {
+          arch: 'x64',
+          checksum: 'abc123',
+          downloadUrl,
+          name: 'quantex-windows-x64.exe',
+          platform: 'win32',
+        },
+      ],
+      channel: 'stable',
+      version: '1.1.0',
+    })
+    binaryUpgradeSpy.mockResolvedValue({ success: true })
+
+    const result = await upgradeSelf({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: 'C:\\Users\\test\\.local\\bin\\qtx.exe',
+      installSource: 'binary',
+      latestVersion: '1.1.0',
+      packageRoot: 'C:\\Users\\test\\.local\\bin',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    expect(result).toEqual({
+      success: true,
+      installSource: 'binary',
+      newVersion: '1.1.0',
+    })
+    expect(binaryUpgradeSpy).toHaveBeenCalledWith(
+      downloadUrl,
+      'C:\\Users\\test\\.local\\bin\\qtx.exe',
+      'abc123',
+      '1.1.0',
+      'C:\\Users\\test\\.local\\bin\\quantex.exe',
+    )
   })
 
   it('derives manual recovery hints through the provider registry', async () => {


### PR DESCRIPTION
## Summary

Fixes Windows standalone binary self-upgrade so `quantex.exe` and `qtx.exe` stay consistent after upgrading from either entry point.

- Derives the same-directory Windows peer alias for `qtx.exe` and `quantex.exe`
- Copies the verified delayed replacement to the peer alias during Windows binary self-upgrade
- Documents two-file Windows standalone recovery/uninstall cleanup and captures the behavior in OpenSpec

Fixes #76.

## Linked Artifacts

- Issue: #76
- ADR: not applicable
- OpenSpec: `openspec/changes/fix-windows-qtx-binary-alias/`
- Discussion: #69

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Additional validation:

- [x] `bun run test -- test/self-binary.test.ts test/self.test.ts`
- [x] `bun run openspec:validate`
- [x] `bun run build`
- [x] `bun run build:bin`
- [x] `bun run release:artifacts`

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [x] `docs/runbooks/release-and-self-upgrade-debugging.md`
- [x] `openspec/changes/fix-windows-qtx-binary-alias/`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The OpenSpec change remains active until this implementation PR merges; archive closure should be handled as the follow-up delivery step after merge.
