### PR TITLE
chore(release): reserve burned 1.0.0 version

### DIFF
--- a/openspec/changes/reserve-burned-1-0-0-release/.openspec.yaml
+++ b/openspec/changes/reserve-burned-1-0-0-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/reserve-burned-1-0-0-release/design.md
+++ b/openspec/changes/reserve-burned-1-0-0-release/design.md
@@ -1,0 +1,24 @@
+## Context
+
+Release PR Automerge runs in `pull_request_target` and checks out the protected base branch before importing `scripts/release-pr-policy.js`. This is the right trust boundary: a generated release-please PR cannot weaken its own validator.
+
+The accidental `1.0.0` has two separate failure modes:
+
+- Release-please can interpret a pre-1.0 breaking change as a major bump unless configured otherwise.
+- Even after the incident was recovered, npm keeps `quantex-cli@1.0.0` occupied and deprecated, so any future Release PR for the exact stable version `1.0.0` must be invalid.
+
+## Approach
+
+Add `bump-minor-pre-major` to the stable release-please package config. This prevents ordinary pre-1.0 breaking changes from generating `1.0.0`.
+
+Keep an explicit validator guard in `scripts/release-pr-policy.js` because configuration drift or release-please behavior changes should still fail before automerge. The validator should:
+
+- reject stable Release PRs that promote a zero-major base directly to `1.0.0`;
+- reject stable Release PRs whose proposed version is in a small hard-coded burned-version set, currently only `1.0.0`;
+- keep beta Release PR rules unchanged.
+
+## Non-goals
+
+- Do not reintroduce the CodeWhale catalog rename from the superseded PR.
+- Do not try to unpublish npm versions from CI.
+- Do not add runtime CLI behavior for burned release versions.

--- a/openspec/changes/reserve-burned-1-0-0-release/proposal.md
+++ b/openspec/changes/reserve-burned-1-0-0-release/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+`quantex-cli@1.0.0` was accidentally published during the pre-1.0 line, then deprecated after npm refused unpublish because registry dependents already existed. That exact version is now permanently occupied, so future stable release automation must not generate or publish `1.0.0` again.
+
+## What Changes
+
+- Configure stable release-please to keep pre-1.0 breaking changes on the zero-major minor line.
+- Extend Release PR validation so generated stable Release PRs are rejected when they propose `1.0.0`.
+- Keep the existing pre-major graduation guard explicit: a `0.x` base version must not be promoted directly to `1.0.0` without a future dedicated graduation contract.
+- Record `1.0.0` as a burned stable release version in OpenSpec.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `release-governance`: generated Release PR validation rejects burned stable versions and accidental pre-major graduation.
+- `release-workflow`: stable release planning keeps pre-major breaking changes on the zero-major line and treats `1.0.0` as unavailable for future publication.
+
+## Impact
+
+- `release-please-config.json`
+- `scripts/release-pr-policy.js`
+- `test/release-pr-policy.test.ts`
+- `test/pr-governance.test.ts`
+- `openspec/specs/release-governance/spec.md`
+- `openspec/specs/release-workflow/spec.md`

--- a/openspec/changes/reserve-burned-1-0-0-release/specs/release-governance/spec.md
+++ b/openspec/changes/reserve-burned-1-0-0-release/specs/release-governance/spec.md
@@ -1,0 +1,16 @@
+# release-governance Spec Delta
+
+## MODIFIED Requirements
+
+### Requirement: Release PRs Keep Dedicated Validation
+
+Release-please generated Release PRs SHALL remain governed by the dedicated Release PR validator instead of the product-impacting release-intent check.
+
+#### Scenario: Release-please PR opens
+
+- **WHEN** a pull request comes from a release-please branch
+- **THEN** PR Governance does not require product-impacting release intent for the version-file changes
+- **AND** Release PR Automerge validates the release branch, title, generated marker, and changed file scope
+- **AND** it rejects a generated Release PR whose proposed semantic version is less than or equal to the current version on the protected base branch
+- **AND** it rejects a generated stable Release PR that promotes a `0.x` base version directly to `1.0.0`
+- **AND** it rejects a generated stable Release PR whose proposed version is a repository-recorded burned release version

--- a/openspec/changes/reserve-burned-1-0-0-release/specs/release-workflow/spec.md
+++ b/openspec/changes/reserve-burned-1-0-0-release/specs/release-workflow/spec.md
@@ -1,0 +1,25 @@
+# release-workflow Spec Delta
+
+## ADDED Requirements
+
+### Requirement: Stable release planning MUST keep pre-major breaking changes on the zero-major line
+
+The stable Release workflow SHALL configure release-please so that breaking changes in a package whose current stable version is below `1.0.0` produce the next `0.x` minor release instead of automatically promoting the package to `1.0.0`.
+
+#### Scenario: breaking change lands while stable version is below 1.0
+
+- **WHEN** release-please plans a stable Release PR from a current version below `1.0.0`
+- **AND** the release-worthy history includes a breaking change marker
+- **THEN** the generated Release PR MUST propose the next zero-major minor version
+- **AND** it MUST NOT propose `1.0.0` unless a future explicit graduation contract allows it
+
+### Requirement: Burned stable release versions MUST NOT be reused
+
+The stable Release workflow SHALL treat `1.0.0` as a burned stable release version because that npm version was already published and deprecated after the accidental pre-1.0 promotion.
+
+#### Scenario: release automation proposes a burned stable version
+
+- **WHEN** release-please creates or updates a stable Release PR
+- **AND** the proposed version is `1.0.0`
+- **THEN** Release PR validation MUST reject the PR before automerge
+- **AND** a future 1.0 graduation MUST choose a different publishable stable version

--- a/openspec/changes/reserve-burned-1-0-0-release/tasks.md
+++ b/openspec/changes/reserve-burned-1-0-0-release/tasks.md
@@ -1,0 +1,11 @@
+## 1. Release Guardrails
+
+- [x] 1.1 Configure stable release-please to keep pre-1.0 breaking changes on the zero-major minor line.
+- [x] 1.2 Add Release PR validator logic that rejects accidental `0.x` to `1.0.0` promotion.
+- [x] 1.3 Add Release PR validator logic that rejects burned stable release version `1.0.0`.
+
+## 2. Contract and Tests
+
+- [x] 2.1 Add OpenSpec deltas for release governance and release workflow.
+- [x] 2.2 Add tests for accepted `0.x` minor release, rejected `1.0.0`, and normal post-1.0 release advancement.
+- [x] 2.3 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,6 +7,7 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "include-v-in-release-name": true,
+      "bump-minor-pre-major": true,
       "extra-files": [
         "src/generated/build-meta.ts"
       ],

--- a/scripts/release-pr-policy.js
+++ b/scripts/release-pr-policy.js
@@ -4,6 +4,7 @@ import process from 'node:process'
 const stableTitlePattern = /^chore: release (\d+\.\d+\.\d+)$/
 const betaTitlePattern = /^chore: release (\d+\.\d+\.\d+-beta(?:\.\d+)?)$/
 const generatedMarker = 'This PR was generated with [Release Please]'
+const burnedStableReleaseVersions = new Set(['1.0.0'])
 
 const allowedFiles = new Set([
   '.release-please-manifest.json',
@@ -55,9 +56,41 @@ export function validateReleasePrPolicy(input) {
         `Release PR version "${proposedVersion}" must be greater than the current ${baseBranch} version "${baseVersion}".`,
       )
     }
+
+    if (baseBranch === 'main' && isAccidentalPreMajorGraduation(proposedVersion, baseVersion)) {
+      issues.push(
+        [
+          `Release PR version "${proposedVersion}" would promote the ${baseBranch} release line from "${baseVersion}" to 1.0.0.`,
+          'Pre-1.0 breaking changes must stay on the zero-major minor line unless a dedicated 1.0 graduation contract allows it.',
+        ].join(' '),
+      )
+    }
+  }
+
+  if (versionMatch && baseBranch === 'main') {
+    const proposedVersion = versionMatch[1]
+    if (burnedStableReleaseVersions.has(proposedVersion)) {
+      issues.push(
+        `Release PR version "${proposedVersion}" is a burned stable release version and must not be published again.`,
+      )
+    }
   }
 
   return issues
+}
+
+export function isAccidentalPreMajorGraduation(proposedRaw, baseRaw) {
+  const proposed = parseReleaseVersion(proposedRaw)
+  const base = parseReleaseVersion(baseRaw)
+
+  return (
+    base.prerelease === null &&
+    proposed.prerelease === null &&
+    base.major === 0 &&
+    proposed.major === 1 &&
+    proposed.minor === 0 &&
+    proposed.patch === 0
+  )
 }
 
 export function compareReleaseVersions(leftRaw, rightRaw) {

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -38,6 +38,18 @@ describe('pr governance release intent', () => {
     }
   })
 
+  it('keeps stable release-please on the zero-major line for pre-1.0 breaking changes', () => {
+    const config = JSON.parse(readFileSync('release-please-config.json', 'utf8')) as {
+      packages: {
+        '.': {
+          'bump-minor-pre-major'?: boolean
+        }
+      }
+    }
+
+    expect(config.packages['.']['bump-minor-pre-major']).toBe(true)
+  })
+
   it('keeps PR template compatible with agent-driven OpenSpec archive closure', () => {
     expect(prTemplate).toContain('## Closure Check')
     expect(prTemplate).toContain('queued for agent-driven archive closure')

--- a/test/release-pr-policy.test.ts
+++ b/test/release-pr-policy.test.ts
@@ -43,6 +43,58 @@ describe('release PR policy', () => {
     expect(issues.join('\n')).toContain('must be greater than the current main version "0.13.0"')
   })
 
+  it('accepts a pre-1.0 breaking-change minor release', () => {
+    expect(
+      validateReleasePrPolicy({
+        baseBranch: 'main',
+        baseVersion: '0.21.1',
+        body: validBody,
+        changedFiles: validChangedFiles,
+        headBranch: 'release-please--branches--main--components--quantex-cli',
+        title: 'chore: release 0.22.0',
+      }),
+    ).toEqual([])
+  })
+
+  it('rejects accidental pre-1.0 promotion to 1.0.0', () => {
+    const issues = validateReleasePrPolicy({
+      baseBranch: 'main',
+      baseVersion: '0.21.1',
+      body: validBody,
+      changedFiles: validChangedFiles,
+      headBranch: 'release-please--branches--main--components--quantex-cli',
+      title: 'chore: release 1.0.0',
+    })
+
+    expect(issues.join('\n')).toContain('would promote the main release line from "0.21.1" to 1.0.0')
+  })
+
+  it('rejects burned stable release version 1.0.0 even outside zero-major promotion', () => {
+    const issues = validateReleasePrPolicy({
+      baseBranch: 'main',
+      baseVersion: '0.99.0',
+      body: validBody,
+      changedFiles: validChangedFiles,
+      headBranch: 'release-please--branches--main--components--quantex-cli',
+      title: 'chore: release 1.0.0',
+    })
+
+    expect(issues.join('\n')).toContain('version "1.0.0" is a burned stable release version')
+  })
+
+  it('allows post-1.0 stable releases to advance normally', () => {
+    expect(
+      validateReleasePrPolicy({
+        baseBranch: 'main',
+        baseVersion: '1.0.0',
+        body: validBody,
+        changedFiles: validChangedFiles,
+        headBranch: 'release-please--branches--main--components--quantex-cli',
+        title: 'chore: release 1.0.1',
+      }),
+    ).toEqual([])
+  })
+
   it('rejects unexpected file scope', () => {
     const issues = validateReleasePrPolicy({
       baseBranch: 'main',


### PR DESCRIPTION
## Summary

Extracts the useful release guard from superseded PR #301 onto the restored main baseline.

The stable release-please config now keeps pre-1.0 breaking changes on the 0.x minor line, and Release PR validation rejects both accidental 0.x -> 1.0.0 promotion and the burned stable version 1.0.0.

## Linked Artifacts

- Issue: Closes #300
- ADR: not applicable
- OpenSpec: `openspec/changes/reserve-burned-1-0-0-release`
- Discussion: supersedes #301

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - release governance guardrail only; avoids publishing an occupied/deprecated version and does not change CLI runtime behavior

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

This replaces #301 with a clean branch based on restored `main@v0.21.1`. It does not include the CodeWhale catalog rename or the accidental `chore: release 1.0.0` commit.
