### PR TITLE
ci: remove quantex package synchronization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,32 +195,3 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release-bot-token.outputs.token }}
         run: gh release upload ${{ steps.release.outputs.tag_name }} dist/bin/* --clobber
-
-      - name: Sync quantex alias package
-        if: ${{ steps.release.outputs.release_created }}
-        env:
-          QUANTEX_SYNC_TOKEN: ${{ secrets.QUANTEX_SYNC_TOKEN }}
-          RELEASE_TAG: ${{ steps.release.outputs.tag_name }}
-        run: |
-          version="${RELEASE_TAG#v}"
-
-          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-            echo "Release tag '${RELEASE_TAG}' did not resolve to a semver version without a leading v." >&2
-            exit 1
-          fi
-
-          if [ -z "${QUANTEX_SYNC_TOKEN}" ]; then
-            echo "::notice title=Alias sync skipped::QUANTEX_SYNC_TOKEN is not configured; skipping Drswith/quantex repository_dispatch."
-            exit 0
-          fi
-
-          npm_tag="latest"
-          if [[ "${version}" == *-* ]]; then
-            npm_tag="next"
-          fi
-
-          curl --fail-with-body -X POST \
-            -H "Authorization: Bearer ${QUANTEX_SYNC_TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/Drswith/quantex/dispatches \
-            -d "{\"event_type\":\"sync-quantex-cli-release\",\"client_payload\":{\"version\":\"${version}\",\"npm_tag\":\"${npm_tag}\"}}"

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -91,13 +91,15 @@ Quantex uses release-please to keep publishing compatible with protected `main` 
 4. If a successful merged `chore: release ...` commit is still untagged, the workflow publishes that commit first. Otherwise, if the merged commits warrant a version bump, release-please creates or updates a Release PR.
 5. The Release PR updates `CHANGELOG.md`, `package.json`, `.release-please-manifest.json`, and `src/generated/build-meta.ts`.
 6. `Release PR Automerge` validates the generated Release PR and enables auto-merge.
-7. After the Release PR merge produces another successful `main` CI run, the `Release` workflow creates the tag and GitHub Release, then builds artifacts, publishes npm through trusted publishing, and uploads binaries.
+7. After the Release PR merge produces another successful `main` CI run, the `Release` workflow creates the tag and GitHub Release, then builds artifacts, publishes `quantex-cli` to npm through trusted publishing, and uploads binaries.
 
 This keeps normal product changes behind PR review while making the release version visible in the source tree at the tagged commit.
 
 Release notes are tracked in [CHANGELOG.md](../CHANGELOG.md), summarized in [docs/releases.md](./releases.md), and published on GitHub Releases.
 
 The npm publish step uses GitHub Actions trusted publishing with OIDC rather than a long-lived `NPM_TOKEN`, so npm trusted publisher settings should point at `.github/workflows/release.yml`.
+
+This repository does not publish or synchronize the separate npm `quantex` alias package. Any cleanup of that package, including removing its dependency on `quantex-cli`, belongs to the separate alias package repository.
 
 For full unattended publishing, configure the release GitHub App secrets `RELEASE_APP_CLIENT_ID` and `RELEASE_APP_PRIVATE_KEY`. The workflows use `actions/create-github-app-token` to mint short-lived installation tokens for Release PR creation, Release PR auto-merge, GitHub Release creation, and artifact upload.
 

--- a/openspec/changes/remove-quantex-alias-sync/.openspec.yaml
+++ b/openspec/changes/remove-quantex-alias-sync/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/remove-quantex-alias-sync/design.md
+++ b/openspec/changes/remove-quantex-alias-sync/design.md
@@ -1,0 +1,35 @@
+## Context
+
+`quantex-cli` is the primary published package. The current Release workflow publishes that package, uploads GitHub Release binaries, and then optionally sends a `repository_dispatch` event to `Drswith/quantex` so the separate alias package can publish a matching dependency wrapper.
+
+That coupling is now undesirable. The alias package creates a visible npm dependent relationship from `quantex` to `quantex-cli`, and keeping a cross-repository dispatch in this workflow makes the primary release path depend on alias-package infrastructure.
+
+## Decision
+
+Remove alias-package synchronization from this repository's Release workflow entirely.
+
+The primary release path should end after:
+
+1. release-please creates the GitHub Release,
+2. validation/build/package checks pass,
+3. `quantex-cli` is published to npm,
+4. generated binary artifacts are uploaded to the GitHub Release.
+
+The workflow should not read `QUANTEX_SYNC_TOKEN`, derive alias npm tags, or call `https://api.github.com/repos/Drswith/quantex/dispatches`.
+
+## Boundaries
+
+- Keep package-local bin names `qtx` and `quantex` in `package.json`; they are user-facing command shims for `quantex-cli`, not npm package dependencies.
+- Do not change self-upgrade, install docs, package metadata, or command examples in this change unless they mention the external alias-package sync.
+- Do not attempt to unpublish or rewrite npm's existing `quantex` package from this repository. Removing the npm dependent relationship requires changing or deprecating the separate package.
+
+## Risks
+
+- Users who install the separate `quantex` npm package may stop receiving synchronized versions unless the alias repository is updated independently.
+- Existing npm registry metadata may continue to show `quantex` as a dependent until the alias package removes its dependency on `quantex-cli` or is otherwise retired.
+
+## Validation
+
+- `bun run openspec:validate` confirms the release-workflow delta is valid.
+- `bun run lint`, `bun run format:check`, and `bun run typecheck` cover repository baseline validation for workflow/docs/spec edits.
+- `bun run test`, `bun run build`, `bun run build:bin`, and `bun run release:artifacts` provide full release-adjacent confidence because this change touches publishing automation.

--- a/openspec/changes/remove-quantex-alias-sync/proposal.md
+++ b/openspec/changes/remove-quantex-alias-sync/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The `quantex-cli` Release workflow still dispatches successful npm releases to the separate `Drswith/quantex` alias-package repository. That cross-repository sync makes npm show `quantex` as a dependent of `quantex-cli` and keeps release automation coupled to a package alias the primary project no longer wants to maintain from this repository.
+
+## What Changes
+
+- Remove the Release workflow step that sends `repository_dispatch` events to `Drswith/quantex`.
+- Stop requiring the `QUANTEX_SYNC_TOKEN` secret for any `quantex-cli` release path.
+- Keep `quantex-cli` as the only npm package published by this repository.
+- Keep the `qtx` and `quantex` binary command names in the `quantex-cli` package unchanged; this change only removes external alias-package synchronization.
+- Document that npm package-level cleanup for the existing `quantex` package is owned outside this repository.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `release-workflow`: release publishing no longer dispatches alias-package synchronization after `quantex-cli` npm publish.
+
+## Impact
+
+- Affected workflow: `.github/workflows/release.yml`.
+- Affected docs/specs: `docs/github-collaboration.md`, `openspec/specs/release-workflow/spec.md` through this change delta.
+- Removed external dependency: `QUANTEX_SYNC_TOKEN` and repository dispatch access to `Drswith/quantex`.
+- Out of scope: changing or unpublishing the existing npm `quantex` package, which is maintained by the separate alias repository.

--- a/openspec/changes/remove-quantex-alias-sync/specs/release-workflow/spec.md
+++ b/openspec/changes/remove-quantex-alias-sync/specs/release-workflow/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Release Publishing Prioritizes Primary Artifacts
+
+The Release workflow SHALL publish the primary `quantex-cli` npm package and attach generated binary artifacts to the GitHub Release without dispatching alias-package synchronization from this repository.
+
+#### Scenario: release publishes only primary package artifacts
+
+- **WHEN** a release publish run has created the GitHub Release and published the `quantex-cli` npm package
+- **AND** generated binary artifacts are ready to upload
+- **THEN** the workflow MUST upload the binary artifacts to the GitHub Release
+- **AND** it MUST NOT dispatch `sync-quantex-cli-release` or any other alias-package synchronization event to `Drswith/quantex`
+
+#### Scenario: alias package token is absent
+
+- **WHEN** a release publish run executes without a `QUANTEX_SYNC_TOKEN` secret
+- **THEN** the workflow MUST NOT need that secret to complete `quantex-cli` npm publishing or GitHub Release artifact upload

--- a/openspec/changes/remove-quantex-alias-sync/tasks.md
+++ b/openspec/changes/remove-quantex-alias-sync/tasks.md
@@ -1,0 +1,17 @@
+## 1. Release Workflow
+
+- [x] 1.1 Remove the alias-package repository dispatch step from `.github/workflows/release.yml`.
+- [x] 1.2 Confirm no active workflow or release documentation still requires `QUANTEX_SYNC_TOKEN`.
+
+## 2. Documentation And Spec
+
+- [x] 2.1 Add the OpenSpec release-workflow delta for removing alias-package synchronization.
+- [x] 2.2 Update release collaboration documentation to describe `quantex-cli` as the only package published by this repository.
+
+## 3. Validation
+
+- [x] 3.1 Run `bun run openspec:status -- --change remove-quantex-alias-sync`.
+- [x] 3.2 Run `bun run openspec:validate`.
+- [x] 3.3 Run `bun run lint`, `bun run format:check`, and `bun run typecheck`.
+- [x] 3.4 Run `bun run test`.
+- [x] 3.5 Run `bun run build`, `bun run build:bin`, and `bun run release:artifacts`.

--- a/test/managed-installer-cancellation.e2e.test.ts
+++ b/test/managed-installer-cancellation.e2e.test.ts
@@ -27,7 +27,7 @@ describe('managed installer cancellation e2e', () => {
       const output = await runCommand(['bun', 'run', 'scripts/managed-installer-cancellation-smoke.ts'], {
         HOME: homeDir,
         PATH: `${fakeBinDir}${delimiter}${process.env.PATH ?? ''}`,
-        QTX_CANCELLATION_SMOKE_TIMEOUT_MS: '250',
+        QTX_CANCELLATION_SMOKE_TIMEOUT_MS: '1000',
         QTX_FAKE_CARGO_LOG: fakeCargoLog,
         USERPROFILE: homeDir,
       })
@@ -48,15 +48,14 @@ describe('managed installer cancellation e2e', () => {
     } finally {
       await rm(sandboxRoot, { force: true, recursive: true })
     }
-  })
+  }, 10_000)
 })
 
 async function installFakeCargo(fakeBinDir: string, logPath: string): Promise<void> {
   await mkdir(fakeBinDir, { recursive: true })
-  const fakeCargoModule = join(fakeBinDir, 'fake-cargo.mjs')
+  const fakeCargoModule = join(fakeBinDir, 'fake-cargo.cjs')
   const fakeCargoSource = [
-    "import { appendFileSync } from 'node:fs'",
-    "import process from 'node:process'",
+    "const { appendFileSync } = require('node:fs')",
     'const args = process.argv.slice(2)',
     'const logPath = process.env.QTX_FAKE_CARGO_LOG',
     'if (!logPath) throw new Error("QTX_FAKE_CARGO_LOG is required")',
@@ -75,19 +74,15 @@ async function installFakeCargo(fakeBinDir: string, logPath: string): Promise<vo
     'process.on("SIGINT", () => complete("fake cargo received SIGINT"))',
     'setTimeout(() => complete("fake cargo completed without cancellation"), 10_000)',
   ].join('\n')
-  await writeFile(fakeCargoModule, fakeCargoSource, 'utf8')
 
   if (process.platform === 'win32') {
-    await writeFile(join(fakeBinDir, 'cargo.cmd'), ['@echo off', 'bun "%~dp0fake-cargo.mjs" %*'].join('\r\n'), 'utf8')
+    await writeFile(fakeCargoModule, fakeCargoSource, 'utf8')
+    await writeFile(join(fakeBinDir, 'cargo.cmd'), ['@echo off', 'node "%~dp0fake-cargo.cjs" %*'].join('\r\n'), 'utf8')
     return
   }
 
   const fakeCargoPath = join(fakeBinDir, 'cargo')
-  await writeFile(
-    fakeCargoPath,
-    ['#!/usr/bin/env sh', 'exec bun "$(dirname "$0")/fake-cargo.mjs" "$@"', ''].join('\n'),
-    'utf8',
-  )
+  await writeFile(fakeCargoPath, ['#!/usr/bin/env node', fakeCargoSource, ''].join('\n'), 'utf8')
   await chmod(fakeCargoPath, 0o755)
 }
 


### PR DESCRIPTION
## Summary

- remove the Release workflow dispatch that synchronized successful `quantex-cli` releases to `Drswith/quantex`
- document the ownership boundary: `quantex` package update/synchronization policy is handled entirely by the `quantex` project, not by this repository
- stabilize the managed-installer cancellation e2e fixture so the full test suite can complete reliably

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/remove-quantex-alias-sync`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run openspec:validate`
- [x] `bun run build`
- [x] `bun run build:bin`
- [x] `bun run release:artifacts`
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - release workflow/docs/test-only change

## Docs Updated

- [ ] Not needed
- [x] `docs/github-collaboration.md`
- [x] `openspec/changes/remove-quantex-alias-sync`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge, then queued for agent-driven archive closure.
- [x] Release is not applicable.

## Notes

This removes only cross-repository `quantex` package synchronization from `quantex-cli`. The package-local `qtx` and `quantex` bin entries remain unchanged.
