### PR TITLE
docs: document cloud agent workflow roles

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ GitHub workflow guidance:
 
 Operational runbooks:
 
+- [cloud-agent-automations.md](./runbooks/cloud-agent-automations.md)
 - [quantex-troubleshooting.md](./runbooks/quantex-troubleshooting.md)
 - [releasing-quantex.md](./runbooks/releasing-quantex.md)
 - [release-and-self-upgrade-debugging.md](./runbooks/release-and-self-upgrade-debugging.md)

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -177,6 +177,7 @@ Examples:
 For non-trivial behavior or durable-process changes, use Superpowers plus the central Quantex runtime skill rather than ad hoc planning files or copied per-agent workflow prompts:
 
 - `skills/quantex-agent-runtime/SKILL.md`: Quantex-specific session startup, intake, validation, artifact routing, and closure
+- [Cloud Agent Automations](./runbooks/cloud-agent-automations.md): Cursor Cloud role split, prompt baselines, model routing, and audit checklist
 - Superpowers skills: brainstorming, worktrees, planning, review, verification, and finishing branch behavior
 - OpenSpec CLI: proposal, design, spec, task, status, instructions, validation, and archive state transitions
 - [Quantex Task Start](./runbooks/quantex-task-start.md): copy-paste start prompt for fresh agent conversations when a native slash or skill launcher is unavailable
@@ -186,6 +187,8 @@ On protected branches, archive closure is an explicit agent-driven follow-up. A 
 Agents should use `openspec status --change <id> --json` and `openspec instructions <artifact> --change <id> --json` when they need to determine the next artifact or implementation step.
 
 Before final handoff, agents should also check `git status`, whether the branch has been pushed, whether a PR exists, whether the OpenSpec change is still active by design, and whether archive or release closure is pending.
+
+Cursor Cloud Automations are external role specialists. Keep their durable responsibilities and prompt baselines aligned with the runbook, but keep hard enforcement in GitHub Actions and repository validators. CI triage should classify failures before implementation changes; PR Governance should comment and request reviewers without approving; bug finding and OpenSpec archive roles should open PRs only inside their narrow role boundaries.
 
 ## Discussion promotion rules
 

--- a/docs/runbooks/cloud-agent-automations.md
+++ b/docs/runbooks/cloud-agent-automations.md
@@ -1,0 +1,163 @@
+# Runbook: Cloud Agent Automations
+
+## Purpose
+
+This runbook records the repo-native baseline for external cloud-agent automations used by Quantex. The actual Cursor Cloud Automation schedules, connected tools, and model selections live in Cursor, but their durable role intent and prompt baselines live here.
+
+Use this runbook when configuring, auditing, or updating Cursor Cloud Automations for this repository.
+
+## Boundary
+
+Cloud agents are role specialists. They do not replace Quantex's runtime skill, OpenSpec intake, GitHub Actions, PR Governance, or release automation.
+
+Repository scripts remain executable guardrails for validation, package checks, release artifacts, and policy checks. Do not add `automation:*`, `pr:create`, or similar repo-local workflow wrappers just to sequence cloud-agent work.
+
+## Current Automations
+
+| Automation | Trigger | Recommended model | Tools | Primary output |
+|---|---|---|---|---|
+| Quantex Find critical bugs | Daily 09:00 GMT+8 | Strong reasoning model | Memories, Slack, read Slack channels, open PR | Narrow bug-fix PR or Slack summary |
+| Quantex PR Governance | PR opened and PR pushed | Strong reasoning model | Memories, comment on PR, request reviewers | PR comments and reviewer requests |
+| Quantex CI Triage | Daily 10:00 GMT+8 | General or medium reasoning model | Memories, Slack, read Slack channels | Slack failure classification |
+| Quantex OpenSpec Archive | Daily 11:00 GMT+8 | General or medium reasoning model | Memories, Slack, open PR | Archive PR or Slack blocker summary |
+
+Cursor scheduled automations currently support whole-hour schedules only. Keep the daily jobs staggered by hour so quota or provider delays are easier to reason about.
+
+## Model Routing
+
+Use a stronger, more expensive model when the role needs semantic judgment:
+
+- high-severity bug finding
+- PR governance review
+- release/archive readiness when the repository state is ambiguous
+
+Use a general or medium model when the task is bounded and mostly mechanical:
+
+- CI failure classification
+- scheduled status summaries
+- straightforward OpenSpec archive checks when the merged implementation and spec deltas are clear
+
+If quota is limited, preserve PR Governance and high-severity bug finding first. CI triage can be downgraded most safely because it should report evidence and owner rather than implement.
+
+## Shared Prompt Rules
+
+Every automation prompt should keep these rules:
+
+- Read `AGENTS.md`, `skills/quantex-agent-runtime/SKILL.md`, and `openspec/README.md` before changing files.
+- Treat Cursor Cloud Agent quota, concurrency, or missing provider authorization as operational capacity, not repository regression.
+- Do not work around PR Governance, release policy, or OpenSpec gates.
+- Do not create repo-local workflow wrapper commands.
+- Use Slack for low-confidence or no-action summaries.
+- Open PRs only when the role explicitly allows PR creation.
+
+## Prompt: Quantex Find Critical Bugs
+
+```text
+You are Quantex Critical Bug Finder.
+
+Read AGENTS.md, skills/quantex-agent-runtime/SKILL.md, and openspec/README.md before making changes.
+
+Goal:
+Inspect recent commits and merged PRs for high-severity correctness bugs in quantex-cli. Keep a broad high-severity lens: data loss, crashes, security/permission bypass, broken install/update/uninstall/upgrade behavior, release artifact breakage, CI/release workflow correctness bugs, silent corruption, infinite loops, resource leaks, and major user-facing CLI regressions.
+
+Investigation:
+- Start from current main and recent git history.
+- Prefer current source, tests, specs, GitHub PR/CI state over assumptions.
+- Trace through call paths; do not rely on diff pattern matching.
+- Check relevant OpenSpec specs when behavior contracts are involved.
+- Ignore style, minor UX, speculative concerns, and low-severity edge cases.
+
+Fix policy:
+- Open a PR only when the bug is concrete, reproducible, high severity, and the fix is narrow.
+- If behavior, durable workflow, release, config, state, schema, or product-facing docs change, create or update an OpenSpec change before implementation unless it is test-only confirmation.
+- Add or update regression tests when possible.
+- Run bun run lint, bun run format:check, bun run typecheck, and bun run test for behavior fixes.
+- Prepare the PR body from .github/pull_request_template.md and run bun run pr:body:check before opening a PR.
+
+Slack fallback:
+If no critical bug is found, or if confidence is below the PR bar, send a short Slack summary instead of opening a PR.
+
+Output:
+If a PR is opened, include bug impact, trigger scenario, root cause, fix, validation, OpenSpec state, and remaining owner.
+If no PR is opened, send a concise no-critical-bugs-found summary with what was inspected.
+```
+
+## Prompt: Quantex PR Governance
+
+```text
+You are Quantex PR Governance Agent.
+
+Review each PR against AGENTS.md, skills/quantex-agent-runtime/SKILL.md, openspec/README.md, docs/github-collaboration.md, and .github/pull_request_template.md.
+
+Focus:
+- OpenSpec intake was followed when behavior, workflow, release, docs, or project memory changed.
+- Required validation is appropriate for the changed surface.
+- PR body uses the repository template and includes validation, OpenSpec, git, remote, PR, release, and archive closure status.
+- CI failures are classified correctly instead of blindly patched.
+- Do not approve PRs. Leave concise blocking or non-blocking comments and request the right reviewers when needed.
+```
+
+## Prompt: Quantex CI Triage
+
+```text
+You are Quantex CI Triage Agent.
+
+Read AGENTS.md, skills/quantex-agent-runtime/SKILL.md, openspec/README.md, docs/github-collaboration.md, and docs/runbooks/releasing-quantex.md.
+
+Goal:
+Inspect recent failing GitHub Actions runs for Drswith/quantex-cli and classify the first real failure.
+
+Scope:
+Do not implement code changes. Do not merge, release, archive OpenSpec changes, or open PRs.
+
+Process:
+- Use gh run list and gh run view when available.
+- Separate product regression, workflow/policy failure, environment/quota/secret issue, transient external service, and expected skipped context.
+- For PR failures, identify PR number, branch, failing workflow/job/step, root cause, and exact owner.
+- If a failure is caused by Cursor Cloud Agent concurrency/quota, report it as operational capacity, not repo regression.
+
+Output:
+Send a concise Slack report with:
+Status, failing run, root cause, evidence, owner, minimal next step.
+Do not claim fixed unless rerun or validation confirms it.
+```
+
+## Prompt: Quantex OpenSpec Archive
+
+```text
+You are Quantex OpenSpec Archive Agent.
+
+Use quantex-agent-runtime. Read AGENTS.md, skills/quantex-agent-runtime/SKILL.md, openspec/README.md, docs/github-collaboration.md, and current openspec state.
+
+Goal:
+Close completed OpenSpec-backed work after implementation PRs have merged. Do not implement product behavior.
+
+Process:
+- Check git status, current branch, and bun run openspec:list.
+- For each active change, determine whether implementation PR has merged and accepted spec deltas are already synced into openspec/specs.
+- If a change is still in implementation or review, do not archive.
+- If archive closure is ready, run openspec validation and open a narrow archive PR.
+- Do not modify src/ product code.
+
+Output:
+If PR opened: change ids, spec deltas synced, validation, PR URL.
+If no PR: no archive-ready changes and why.
+If blocked: exact blocker and owner.
+```
+
+## Audit Checklist
+
+When checking Cursor automation settings, verify:
+
+- repository is `Drswith/quantex-cli`
+- branch is `main`
+- environment is Cursor Cloud
+- schedules match the table above
+- PR-triggered governance runs on PR opened and PR pushed
+- Slack delivery is enabled for summary-only roles
+- PR creation is enabled only for roles that may open PRs
+- PR approval is disabled for PR Governance
+- no provider warning says the automation requires additional connection or authentication
+- prompt text matches this runbook except for deliberate, reviewed changes
+
+Record durable prompt or role changes through OpenSpec when they affect workflow behavior.

--- a/docs/runbooks/quantex-task-start.md
+++ b/docs/runbooks/quantex-task-start.md
@@ -76,6 +76,7 @@ bun run openspec:instructions -- tasks --change <change-id>
 
 - [AGENTS.md](../../AGENTS.md)
 - [GitHub Collaboration Flow](../github-collaboration.md)
+- [Cloud Agent Automations](./cloud-agent-automations.md)
 - [Worktree-Backed Implementation](./worktree-task-execution.md)
 - [OpenSpec README](../../openspec/README.md)
 - [Quantex Agent Runtime](../../skills/quantex-agent-runtime/SKILL.md)

--- a/openspec/changes/adopt-cloud-agent-workflow-roles/.openspec.yaml
+++ b/openspec/changes/adopt-cloud-agent-workflow-roles/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/adopt-cloud-agent-workflow-roles/design.md
+++ b/openspec/changes/adopt-cloud-agent-workflow-roles/design.md
@@ -1,0 +1,75 @@
+# Design
+
+## Context
+
+The repository already has strong executable guardrails:
+
+- GitHub Actions runs CI, PR Governance, release verification, release automation, and sandbox validation.
+- Repository scripts implement narrow deterministic validators and artifact checks.
+- OpenSpec owns non-trivial behavior and durable workflow contracts.
+- The Quantex runtime skill tells a coding agent how to start, validate, deliver, and close work.
+
+The new automation layer is different: Cursor Cloud Automations are external always-on agents with schedules or event triggers and role-specific prompts. Their configuration cannot be fully stored in the repository, but the responsibilities they are expected to follow should be reviewable and durable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define the four current cloud-agent roles: critical bug finder, PR governance reviewer, CI triage reporter, and OpenSpec archive follow-up.
+- Keep role prompts in a repo runbook so browser-side automation settings can be audited against versioned text.
+- Make the runtime skill route agents to the cloud-agent runbook when they are checking or updating automation behavior.
+- Reduce avoidable red-CI repair loops by making CI triage a separate classification task before implementation changes.
+- Preserve CI and PR Governance as hard gates.
+
+**Non-Goals:**
+
+- Do not implement a multi-agent scheduler in Quantex.
+- Do not add repo-local `automation:*`, `pr:create`, or release orchestration scripts.
+- Do not remove required checks or lower validation standards.
+- Do not make external Cursor automation configuration the source of truth.
+
+## Decisions
+
+### Decision: keep cloud-agent configuration external but role contracts in the repo
+
+Cursor owns the actual automation triggers, schedules, model choice, and connected tools. The repository owns the role descriptions and prompt templates that should be copied into those automations.
+
+Why this split:
+
+- Cursor automation state changes through the Cursor UI/API, not through this repository.
+- Versioned prompt templates give reviewers a concrete baseline for drift checks.
+- The repo can evolve role responsibilities through OpenSpec when the durable workflow changes.
+
+### Decision: treat cloud agents as role specialists, not a workflow engine
+
+Each automation should have a narrow responsibility and a clear output path:
+
+- bug finder: open a narrow PR only for concrete high-severity bugs; otherwise send a short Slack summary
+- PR governance: comment on PRs and request reviewers, but never approve
+- CI triage: classify failures and report owner/next step, but not implement
+- OpenSpec archive: open archive PRs only after implementation merge and spec-delta readiness
+
+This preserves Quantex's non-goal of avoiding workflow orchestration inside the product repo.
+
+### Decision: CI remains the hard enforcement layer
+
+Cloud agents may reduce repair loops by detecting the likely failure class earlier, but they must not replace merge-gating CI, PR Governance, OpenSpec validation, or local preflight requirements.
+
+Why:
+
+- CI is deterministic and auditable.
+- Cloud agents can be quota-limited, unavailable, or mistaken.
+- The safest split is "agent classifies and proposes; CI enforces."
+
+### Decision: model choice follows task judgment requirements
+
+Use a stronger model for semantic review tasks that require source reasoning, policy interpretation, or high-confidence PR decisions. Use a general model for mechanical reporting tasks that read current state and produce a bounded summary.
+
+The runbook records current recommendations without making model names part of a product contract.
+
+## Risks / Trade-offs
+
+- [Prompt drift between Cursor UI and repo runbook] -> Keep the runbook as the review baseline and ask PR Governance/maintainers to compare changes against it when automation behavior is adjusted.
+- [Cloud quota failures make automation appear broken] -> CI triage prompt must classify Cursor Cloud quota/concurrency as operational capacity, not a repository regression.
+- [Specialized agents overlap and produce noise] -> Each role has explicit non-goals and output constraints.
+- [More docs without enforcement] -> Existing CI/OpenSpec/memory checks validate the repo artifacts; external automation still needs manual UI verification when changed.

--- a/openspec/changes/adopt-cloud-agent-workflow-roles/proposal.md
+++ b/openspec/changes/adopt-cloud-agent-workflow-roles/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Quantex now uses Cursor Cloud Automations for recurring bug finding, PR governance, CI triage, and OpenSpec archive follow-up. The browser-side automation configuration is intentionally outside the repository, but the role boundaries, prompt source, escalation rules, and CI failure handling need to live in repo-native project memory so future agents do not rebuild the same single-agent, self-policing workflow.
+
+This is a durable workflow and project-memory change. It should improve coordination without turning Quantex into a workflow orchestration platform or adding another repo-local CLI layer around native GitHub/OpenSpec actions.
+
+## What Changes
+
+- Document cloud-agent workflow roles as a repo-native runbook with role intent, triggers, tool expectations, model guidance, and prompt templates.
+- Update the Quantex runtime skill so agents distinguish role-specific cloud automation from local implementation, CI enforcement, release automation, and OpenSpec archive closure.
+- Record a project-memory contract that cloud-agent automation roles remain external scheduler configuration, while repository artifacts define their responsibilities and guardrails.
+- Clarify that CI and PR Governance remain hard enforcement layers; cloud agents classify, summarize, fix, or route failures instead of replacing required checks.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `project-memory`: Adds a durable process contract for cloud-agent role division and prompt-source alignment.
+
+## Impact
+
+- Affected files: `skills/quantex-agent-runtime/SKILL.md`, `docs/github-collaboration.md`, `docs/README.md`, `docs/runbooks/cloud-agent-automations.md`, `openspec/specs/project-memory/spec.md`, and this OpenSpec change.
+- Affected systems: Cursor Cloud Automation setup, coding-agent startup, PR/CI failure routing, OpenSpec archive follow-up, and workflow documentation.
+- Non-goals: do not add `npm` or `bun` wrapper scripts for cloud-agent orchestration; do not weaken CI/PR Governance gates; do not move Cursor's external automation settings into versioned source; do not add product CLI behavior.

--- a/openspec/changes/adopt-cloud-agent-workflow-roles/specs/project-memory/spec.md
+++ b/openspec/changes/adopt-cloud-agent-workflow-roles/specs/project-memory/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Cloud-agent automation roles SHALL be documented in repo-native project memory
+
+Quantex SHALL keep the durable responsibilities, prompt baselines, trigger expectations, and output boundaries for external cloud-agent automations in repository documentation. The external automation provider configuration MAY hold the actual schedules, connected tools, and model selections, but it MUST NOT be the only source of durable role intent.
+
+#### Scenario: Maintainer configures external cloud-agent automation
+
+- **GIVEN** a maintainer creates or updates a Cursor Cloud Automation or comparable external cloud-agent automation for Quantex
+- **WHEN** the automation changes durable workflow behavior, PR review behavior, CI triage behavior, release/archive follow-up, or prompt expectations
+- **THEN** the repository MUST document the role contract, prompt baseline, and output boundary in a runbook or OpenSpec change
+- **AND** the maintainer MUST NOT add a repo-local workflow orchestration command solely to mirror the external automation setup
+
+#### Scenario: Agent audits cloud-agent automation drift
+
+- **GIVEN** an agent or maintainer reviews existing external automation settings
+- **WHEN** they compare those settings against repository source
+- **THEN** they use the cloud-agent automation runbook and the Quantex runtime skill as the repo-native baseline
+- **AND** they report provider-side schedule, model, or connection drift separately from repository contract drift
+
+### Requirement: Cloud-agent roles MUST stay separated from CI enforcement
+
+Cloud-agent automations SHALL classify, review, summarize, propose, or open narrow follow-up pull requests according to their role. They MUST NOT replace merge-gating CI, PR Governance, OpenSpec validation, release automation, or required local preflight checks.
+
+#### Scenario: CI fails after a pull request update
+
+- **WHEN** a cloud-agent CI triage role inspects a failing GitHub Actions run
+- **THEN** it classifies the first real failure as product regression, workflow or policy failure, environment/quota/secret issue, transient external failure, or expected skipped context
+- **AND** it reports the owner and minimal next step
+- **AND** it does not implement code changes unless a separate implementation agent or user explicitly takes that work through the Quantex runtime intake gate
+
+#### Scenario: PR Governance automation reviews a pull request
+
+- **WHEN** a cloud-agent PR governance role reviews a pull request
+- **THEN** it may leave blocking or non-blocking comments and request reviewers
+- **AND** it MUST NOT approve the pull request
+- **AND** GitHub Actions PR Governance remains responsible for enforcing required body, scope, release-intent, and merge-commit policy checks
+
+#### Scenario: Cloud bug finder identifies no high-severity issue
+
+- **WHEN** a cloud-agent bug-finding role inspects recent history without finding a concrete high-severity correctness bug
+- **THEN** it sends a concise summary through the configured notification channel instead of opening a speculative pull request
+- **AND** it keeps low-confidence concerns out of the merge queue

--- a/openspec/changes/adopt-cloud-agent-workflow-roles/tasks.md
+++ b/openspec/changes/adopt-cloud-agent-workflow-roles/tasks.md
@@ -1,0 +1,7 @@
+# Tasks
+
+- [x] Add OpenSpec proposal, design, project-memory spec delta, and task list for cloud-agent workflow roles.
+- [x] Add a cloud-agent automation runbook with role contracts, schedules/triggers, tools, model guidance, and prompt baselines.
+- [x] Update the Quantex runtime skill and collaboration/project-memory docs to route agents to the runbook.
+- [x] Validate with `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run openspec:validate`, and `bun run memory:check`.
+- [x] Report validation, OpenSpec, git, commit, push, PR, release, and archive-closure state.

--- a/openspec/specs/project-memory/spec.md
+++ b/openspec/specs/project-memory/spec.md
@@ -220,6 +220,48 @@ Agent-driven OpenSpec archive closure SHALL be performed through repository scri
 - **THEN** the agent MUST use the generated PR body file or run the local PR body governance check before creating or editing the PR
 - **AND** PR Governance in GitHub Actions MUST evaluate the PR body with the same repository validation logic
 
+### Requirement: Cloud-agent automation roles SHALL be documented in repo-native project memory
+
+Quantex SHALL keep the durable responsibilities, prompt baselines, trigger expectations, and output boundaries for external cloud-agent automations in repository documentation. The external automation provider configuration MAY hold the actual schedules, connected tools, and model selections, but it MUST NOT be the only source of durable role intent.
+
+#### Scenario: Maintainer configures external cloud-agent automation
+
+- **GIVEN** a maintainer creates or updates a Cursor Cloud Automation or comparable external cloud-agent automation for Quantex
+- **WHEN** the automation changes durable workflow behavior, PR review behavior, CI triage behavior, release/archive follow-up, or prompt expectations
+- **THEN** the repository MUST document the role contract, prompt baseline, and output boundary in a runbook or OpenSpec change
+- **AND** the maintainer MUST NOT add a repo-local workflow orchestration command solely to mirror the external automation setup
+
+#### Scenario: Agent audits cloud-agent automation drift
+
+- **GIVEN** an agent or maintainer reviews existing external automation settings
+- **WHEN** they compare those settings against repository source
+- **THEN** they use the cloud-agent automation runbook and the Quantex runtime skill as the repo-native baseline
+- **AND** they report provider-side schedule, model, or connection drift separately from repository contract drift
+
+### Requirement: Cloud-agent roles MUST stay separated from CI enforcement
+
+Cloud-agent automations SHALL classify, review, summarize, propose, or open narrow follow-up pull requests according to their role. They MUST NOT replace merge-gating CI, PR Governance, OpenSpec validation, release automation, or required local preflight checks.
+
+#### Scenario: CI fails after a pull request update
+
+- **WHEN** a cloud-agent CI triage role inspects a failing GitHub Actions run
+- **THEN** it classifies the first real failure as product regression, workflow or policy failure, environment/quota/secret issue, transient external failure, or expected skipped context
+- **AND** it reports the owner and minimal next step
+- **AND** it does not implement code changes unless a separate implementation agent or user explicitly takes that work through the Quantex runtime intake gate
+
+#### Scenario: PR Governance automation reviews a pull request
+
+- **WHEN** a cloud-agent PR governance role reviews a pull request
+- **THEN** it may leave blocking or non-blocking comments and request reviewers
+- **AND** it MUST NOT approve the pull request
+- **AND** GitHub Actions PR Governance remains responsible for enforcing required body, scope, release-intent, and merge-commit policy checks
+
+#### Scenario: Cloud bug finder identifies no high-severity issue
+
+- **WHEN** a cloud-agent bug-finding role inspects recent history without finding a concrete high-severity correctness bug
+- **THEN** it sends a concise summary through the configured notification channel instead of opening a speculative pull request
+- **AND** it keeps low-confidence concerns out of the merge queue
+
 ### Requirement: Work Intake Gate
 
 Agents and contributors SHALL classify requested work before implementation or file edits begin.
@@ -325,4 +367,3 @@ The central Quantex agent runtime skill SHALL be treated as a repository develop
 - **WHEN** a user wants a skill for operating Quantex from an external agent runtime
 - **THEN** the documented default target is `quantex-cli`
 - **AND** the user is not instructed to install `quantex-agent-runtime` unless they are contributing to this repository
-

--- a/skills/quantex-agent-runtime/SKILL.md
+++ b/skills/quantex-agent-runtime/SKILL.md
@@ -13,6 +13,7 @@ Use this skill at the start of every Quantex repository session, and again befor
 - Superpowers is the cross-agent workflow runtime.
 - OpenSpec is the source of truth for non-trivial behavior and durable process contracts.
 - GitHub Actions are the remote enforcement layer.
+- Cursor Cloud Automations provide external role specialists for recurring bug finding, PR governance review, CI triage, and OpenSpec archive follow-up.
 - Repository scripts are executable validation, build, release, and package checks.
 - `AGENTS.md` is the thin fallback when Superpowers is unavailable.
 
@@ -140,6 +141,21 @@ Do not rely on repository automation to create archive PRs.
 Repository scripts are executable guardrails: validation, path classification, build metadata, package checks, release artifact generation, and release smoke verification. Prefer Superpowers runtime instructions, OpenSpec artifacts, GitHub Actions, and native CLIs for workflow actions.
 
 Do not add project-specific workflow orchestration commands, such as `pr:create`, when a native CLI action plus a shared validator is sufficient.
+
+## Cloud Agent Roles
+
+Use `docs/runbooks/cloud-agent-automations.md` as the repo-native baseline when configuring or auditing external cloud-agent automations.
+
+Current role split:
+
+- Critical bug finder: scheduled semantic bug hunting; opens a narrow PR only for concrete high-severity bugs, otherwise reports to Slack.
+- PR governance: PR-opened and PR-pushed review; comments and requests reviewers but never approves.
+- CI triage: scheduled failure classification; reports root cause, evidence, owner, and minimal next step without implementing code.
+- OpenSpec archive: scheduled archive-readiness follow-up; opens narrow archive PRs only after implementation merge and spec-delta readiness.
+
+Cloud agents reduce manual repair loops by classifying and routing work earlier. They do not replace merge-gating CI, PR Governance, OpenSpec validation, release automation, local validation, or delivery closure reporting.
+
+If a Cursor Cloud run fails because of concurrency, quota, missing Slack/GitHub connection, or provider capacity, classify it as operational capacity rather than a repository regression.
 
 ## Artifact Routing
 


### PR DESCRIPTION
## Summary

Document Quantex's Cursor Cloud Automation role split as repo-native project memory so external automation settings have a versioned baseline.

This keeps cloud agents as role specialists for bug finding, PR review, CI triage, and OpenSpec archive follow-up without adding repo-local workflow wrapper commands or weakening CI/PR Governance.

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: `openspec/changes/adopt-cloud-agent-workflow-roles`
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

`bun run test` was not required because this change only updates durable workflow documentation, OpenSpec project-memory contracts, and runbooks. It does not change executable CLI behavior.

Additional validation:

- [x] `bun run openspec:validate`
- [x] pre-push hook reran `bun run format:check`, `bun run typecheck`, `bun run openspec:validate`, and `bun run memory:check`

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [ ] Not needed
- [x] `docs/runbooks/cloud-agent-automations.md`
- [x] `openspec/changes/adopt-cloud-agent-workflow-roles`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

OpenSpec change `adopt-cloud-agent-workflow-roles` remains active by design until this implementation PR merges; archive closure should follow after merge.

## Notes

This PR intentionally does not add `automation:*`, `pr:create`, or similar orchestration scripts. Repository scripts remain narrow executable guardrails.
