### PR TITLE
docs(readme): organize badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![GitHub stars][stars-src]][stars-href]
-[![CI][ci-src]][ci-href]
 [![Release][release-src]][release-href]
+[![Release downloads][release-downloads-src]][release-downloads-href]
+[![CI][ci-src]][ci-href]
+
+<br />
+
+[![Node.js >=20][node-src]][node-href]
+[![Bun][bun-src]][bun-href]
+[![Platforms][platforms-src]][release-href]
 [![bundle][bundle-src]][bundle-href]
 [![License][license-src]][license-href]
+[![GitHub stars][stars-src]][stars-href]
 
 Install, inspect, update, uninstall, and run AI coding assistant CLIs from one agent-friendly command line.
 
@@ -302,6 +309,13 @@ Apache-2.0
 [ci-href]: https://github.com/Drswith/quantex-cli/actions/workflows/ci.yml
 [release-src]: https://img.shields.io/github/v/release/Drswith/quantex-cli?display_name=tag&sort=semver&style=flat-square
 [release-href]: https://github.com/Drswith/quantex-cli/releases
+[release-downloads-src]: https://img.shields.io/github/downloads/Drswith/quantex-cli/total?style=flat-square&label=release%20downloads
+[release-downloads-href]: https://github.com/Drswith/quantex-cli/releases
+[node-src]: https://img.shields.io/badge/node-%3E%3D20-339933?style=flat-square&logo=node.js&logoColor=white
+[node-href]: https://nodejs.org/
+[bun-src]: https://img.shields.io/badge/bun-1.3.11-fbf0df?style=flat-square&logo=bun&logoColor=000
+[bun-href]: https://bun.sh/
+[platforms-src]: https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-555?style=flat-square
 [bundle-src]: https://img.shields.io/bundlephobia/minzip/quantex-cli?style=flat-square
 [bundle-href]: https://bundlephobia.com/package/quantex-cli
 [license-src]: https://img.shields.io/npm/l/quantex-cli?style=flat-square

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,11 +4,18 @@
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![GitHub stars][stars-src]][stars-href]
-[![CI][ci-src]][ci-href]
 [![Release][release-src]][release-href]
+[![Release downloads][release-downloads-src]][release-downloads-href]
+[![CI][ci-src]][ci-href]
+
+<br />
+
+[![Node.js >=20][node-src]][node-href]
+[![Bun][bun-src]][bun-href]
+[![Platforms][platforms-src]][release-href]
 [![bundle][bundle-src]][bundle-href]
 [![License][license-src]][license-href]
+[![GitHub stars][stars-src]][stars-href]
 
 统一管理 AI 编程助手 CLI 的安装、检查、更新、卸载与启动。
 
@@ -300,6 +307,13 @@ Apache-2.0
 [ci-href]: https://github.com/Drswith/quantex-cli/actions/workflows/ci.yml
 [release-src]: https://img.shields.io/github/v/release/Drswith/quantex-cli?display_name=tag&sort=semver&style=flat-square
 [release-href]: https://github.com/Drswith/quantex-cli/releases
+[release-downloads-src]: https://img.shields.io/github/downloads/Drswith/quantex-cli/total?style=flat-square&label=release%20downloads
+[release-downloads-href]: https://github.com/Drswith/quantex-cli/releases
+[node-src]: https://img.shields.io/badge/node-%3E%3D20-339933?style=flat-square&logo=node.js&logoColor=white
+[node-href]: https://nodejs.org/
+[bun-src]: https://img.shields.io/badge/bun-1.3.11-fbf0df?style=flat-square&logo=bun&logoColor=000
+[bun-href]: https://bun.sh/
+[platforms-src]: https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-555?style=flat-square
 [bundle-src]: https://img.shields.io/bundlephobia/minzip/quantex-cli?style=flat-square
 [bundle-href]: https://bundlephobia.com/package/quantex-cli
 [license-src]: https://img.shields.io/npm/l/quantex-cli?style=flat-square


### PR DESCRIPTION
## Summary

Add GitHub Release download, Node.js, Bun, and platform badges to the README headers.

Split the badge block into two explicit rows so release health/download signals are grouped separately from runtime/package metadata while retaining the GitHub stars badge.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/specs/product-readme/spec.md`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

`bun run test` was not run because this only changes README badge markup and does not change CLI behavior.

## Release Intent

- Release: not applicable - README badge metadata and layout only, with no CLI behavior or installation contract change

## Docs Updated

- [x] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

No separate docs or OpenSpec follow-up is needed; the README files are the only intended documentation surface for this badge cleanup.

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

OpenSpec intake classified this as a small README badge metadata/layout cleanup, so no active OpenSpec change was created.
