### PR TITLE
feat(agent-catalog): update Kimi Code CLI distribution

### DIFF
--- a/openspec/changes/update-kimi-code-ts-cli/.openspec.yaml
+++ b/openspec/changes/update-kimi-code-ts-cli/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-03

--- a/openspec/changes/update-kimi-code-ts-cli/design.md
+++ b/openspec/changes/update-kimi-code-ts-cli/design.md
@@ -1,0 +1,45 @@
+## Context
+
+Kimi Code CLI's current upstream documentation says the CLI is written in TypeScript, distributed through npm, and runs on Node.js. The official recommended install path is still the Kimi install script, but the script URL has moved from the old `https://code.kimi.com/install.*` path to the current `https://code.kimi.com/kimi-code/install.*` path. The old Python/uv `kimi-cli` lifecycle is deprecated and is now a migration source rather than the supported fresh-install target.
+
+The npm registry currently exposes `@moonshot-ai/kimi-code` with a `kimi` binary. The official CLI docs describe `kimi upgrade` as the built-in update entrypoint and also list package-manager upgrade commands for npm installs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep Quantex's Kimi catalog entry aligned with the current official Kimi Code CLI lifecycle.
+- Prefer the official install scripts in rendered install options while allowing npm-managed lifecycle operations.
+- Remove stale uv package metadata and uv managed install methods from Kimi.
+- Keep aliases stable so users can still find Kimi through `kimi-code` and the legacy `kimi-cli` search name.
+
+**Non-Goals:**
+
+- Remove uv support from Quantex or from agents that still document uv installation.
+- Add Kimi-specific runtime behavior outside catalog metadata.
+- Model pnpm as a managed installer; Quantex does not currently expose pnpm as a managed install type.
+- Enforce Kimi's Node engine requirement inside the agent catalog.
+
+## Decisions
+
+### 1. Use `@moonshot-ai/kimi-code` as package metadata
+
+The current npm package is the lifecycle package Quantex can install, update, and uninstall through the existing npm provider. Keeping `packages.uv = kimi-cli` would route managed operations to the deprecated Python toolchain, so the Kimi entry should only identify the npm package.
+
+### 2. Keep script installers first
+
+Kimi's current docs call script installation the recommended path because it does not require a preinstalled Node.js runtime and installs a verified executable into `PATH`. Quantex should list those script methods before npm so interactive users see the upstream-recommended path first.
+
+### 3. Add npm managed methods, not Bun methods
+
+Although Quantex can install many npm packages through Bun, Kimi's current upstream docs name npm and pnpm, not Bun. This change adds npm managed install methods only, avoiding an unsupported lifecycle claim.
+
+### 4. Use `kimi upgrade` for self-update
+
+The current CLI exposes `kimi upgrade` and chooses the appropriate update path for the detected install source. That is a better self-update command than the old `uv tool upgrade kimi-cli --no-cache`, which is tied to the deprecated distribution.
+
+## Risks / Trade-offs
+
+- [Existing uv-managed Kimi state may remain in user state files] -> Quantex keeps generic uv update/uninstall support, so existing recorded uv installs can still be handled by install state, while fresh catalog guidance moves to the current source.
+- [npm package engine requirements can drift] -> The catalog records lifecycle methods, not engine enforcement; npm will surface engine/runtime issues when users choose npm-managed installation.
+- [Legacy `kimi-cli` alias now points to a different package than the old uv tool] -> Keep the alias for lookup discoverability, but package metadata and install methods intentionally point at the current Kimi Code CLI.

--- a/openspec/changes/update-kimi-code-ts-cli/proposal.md
+++ b/openspec/changes/update-kimi-code-ts-cli/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Work intake classification: this changes supported agent catalog metadata, install methods, update planning, and the agent-catalog behavior contract, so it requires an OpenSpec-backed change.
+
+Kimi Code CLI has completed a major upstream migration from the Python/uv-based `kimi-cli` distribution to a TypeScript CLI distributed through Node.js/npm and official native install scripts. Quantex still models Kimi as a uv-managed Python tool, which points new installs and update planning at the deprecated lifecycle source.
+
+## What Changes
+
+- Update the Kimi Code catalog entry to use the current official Kimi Code CLI homepage and install script URLs.
+- Replace `kimi-cli` uv package metadata with the current npm package `@moonshot-ai/kimi-code`.
+- Add npm-compatible managed install methods for supported platforms while keeping official script install methods available.
+- Replace the old uv self-update command with the current `kimi upgrade` command.
+- Update the agent-catalog spec requirement so Quantex's Kimi lifecycle contract matches the current upstream distribution.
+- Do not change Quantex runtime support for uv-managed agents generally.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-catalog`: update Kimi Code CLI's lifecycle metadata from the deprecated Python/uv distribution to the current TypeScript/npm and official script distribution.
+
+## Impact
+
+- Affected catalog file: `src/agents/catalog/kimi.json`.
+- Affected specs: `openspec/specs/agent-catalog/spec.md` and the active change delta under `openspec/changes/update-kimi-code-ts-cli/specs/agent-catalog/spec.md`.
+- Affected generated catalog outputs may change if catalog generation is required.
+- Validation should include catalog/schema checks through `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.

--- a/openspec/changes/update-kimi-code-ts-cli/specs/agent-catalog/spec.md
+++ b/openspec/changes/update-kimi-code-ts-cli/specs/agent-catalog/spec.md
@@ -1,0 +1,64 @@
+## MODIFIED Requirements
+
+### Requirement: Kimi Code CLI MUST be a supported lifecycle agent
+
+Quantex SHALL include Kimi Code CLI in the supported agent catalog with lifecycle-focused metadata for installation, inspection, resolution, execution, update planning, and stable identification.
+
+#### Scenario: Looking up Kimi Code CLI
+
+- **WHEN** a user or machine consumer looks up the canonical agent name `kimi` or the aliases `kimi-code` or `kimi-cli`
+- **THEN** Quantex returns a supported agent entry for Kimi Code CLI
+- **AND** the entry identifies `kimi` as the executable binary
+- **AND** the entry identifies `@moonshot-ai/kimi-code` as its npm package metadata
+
+#### Scenario: Installing Kimi Code CLI through supported methods
+
+- **WHEN** Quantex renders or executes install options for Kimi Code CLI
+- **THEN** macOS and Linux include the official current curl install script option (`curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash`)
+- **AND** Windows includes the official current PowerShell install script option (`irm https://code.kimi.com/kimi-code/install.ps1 | iex`)
+- **AND** Windows, macOS, and Linux include the npm-compatible managed install method
+- **AND** the entry does not include uv managed install methods for fresh Kimi Code CLI installs
+
+#### Scenario: Probing Kimi Code CLI version
+
+- **WHEN** Quantex probes the installed version of Kimi Code CLI
+- **THEN** it runs `kimi --version` and parses the output
+
+#### Scenario: Planning Kimi Code CLI updates
+
+- **WHEN** Quantex plans an update for a Kimi Code CLI installation that supports self-update
+- **THEN** the catalog exposes `kimi upgrade` as the agent self-update command
+
+### Requirement: uv tool install methods MUST be supported lifecycle metadata
+
+Quantex SHALL allow supported agent catalog entries to declare uv tool managed install methods and uv package metadata when an upstream agent is distributed through `uv tool install`.
+
+#### Scenario: Registering uv package metadata
+
+- **WHEN** Quantex defines or updates a supported agent entry that is distributed through `uv tool install`
+- **THEN** the entry can identify the tool package through `packages.uv`
+- **AND** the entry can include uv managed install methods on platforms where the package is supported
+- **AND** uv package metadata is treated as lifecycle metadata, not descriptive marketing copy
+
+#### Scenario: Rendering uv install guidance
+
+- **WHEN** Quantex renders install methods for an agent with a uv managed install method
+- **THEN** the install method is labeled as a managed uv install
+- **AND** the command guidance uses `uv tool install <package>`
+- **AND** package-specific uv install arguments are preserved in the rendered command
+
+#### Scenario: Registering OpenHands uv metadata
+
+- **WHEN** Quantex defines the supported OpenHands CLI agent entry
+- **THEN** the entry identifies `openhands` as uv package metadata
+- **AND** macOS and Linux include the uv managed install method with the upstream-documented `--python 3.12` argument
+- **AND** the entry continues to include the official install script option
+- **AND** the entry does not advertise a native Windows install method because upstream CLI docs route Windows users through WSL
+
+#### Scenario: Registering Mistral Vibe uv metadata
+
+- **WHEN** Quantex defines the supported Mistral Vibe agent entry
+- **THEN** the entry identifies `mistral-vibe` as uv package metadata
+- **AND** macOS, Linux, and Windows include a uv managed install method
+- **AND** the entry continues to identify `mistral-vibe` as pip package metadata
+- **AND** macOS and Linux continue to include the official shell installer option

--- a/openspec/changes/update-kimi-code-ts-cli/tasks.md
+++ b/openspec/changes/update-kimi-code-ts-cli/tasks.md
@@ -1,0 +1,19 @@
+## 1. OpenSpec Contract
+
+- [x] 1.1 Create the proposal, design, and agent-catalog spec delta for the Kimi Code TypeScript CLI migration.
+- [x] 1.2 Confirm OpenSpec status reports the change as complete before implementation delivery.
+
+## 2. Catalog Implementation
+
+- [x] 2.1 Update the Kimi catalog entry to the current homepage, npm package metadata, official script URLs, npm managed install methods, and `kimi upgrade` self-update command.
+- [x] 2.2 Update the current agent-catalog spec so archive closure will preserve the accepted Kimi and uv metadata contract.
+
+## 3. Tests
+
+- [x] 3.1 Update Kimi catalog tests for npm metadata, install methods, script URLs, and self-update behavior.
+- [x] 3.2 Run the focused agent catalog test before the full validation suite.
+
+## 4. Validation and Delivery
+
+- [x] 4.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.
+- [x] 4.2 Check git state and delivery closure status, then commit, push, and open a PR if permitted.

--- a/openspec/specs/agent-catalog/spec.md
+++ b/openspec/specs/agent-catalog/spec.md
@@ -102,17 +102,25 @@ Quantex SHALL include Kimi Code CLI in the supported agent catalog with lifecycl
 - **WHEN** a user or machine consumer looks up the canonical agent name `kimi` or the aliases `kimi-code` or `kimi-cli`
 - **THEN** Quantex returns a supported agent entry for Kimi Code CLI
 - **AND** the entry identifies `kimi` as the executable binary
+- **AND** the entry identifies `@moonshot-ai/kimi-code` as its npm package metadata
 
 #### Scenario: Installing Kimi Code CLI through supported methods
 
 - **WHEN** Quantex renders or executes install options for Kimi Code CLI
-- **THEN** macOS and Linux include the official curl install script option
-- **AND** Windows includes the official PowerShell install script option
+- **THEN** macOS and Linux include the official current curl install script option (`curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash`)
+- **AND** Windows includes the official current PowerShell install script option (`irm https://code.kimi.com/kimi-code/install.ps1 | iex`)
+- **AND** Windows, macOS, and Linux include the npm-compatible managed install method
+- **AND** the entry does not include uv managed install methods for fresh Kimi Code CLI installs
+
+#### Scenario: Probing Kimi Code CLI version
+
+- **WHEN** Quantex probes the installed version of Kimi Code CLI
+- **THEN** it runs `kimi --version` and parses the output
 
 #### Scenario: Planning Kimi Code CLI updates
 
 - **WHEN** Quantex plans an update for a Kimi Code CLI installation that supports self-update
-- **THEN** the catalog exposes `uv tool upgrade kimi-cli --no-cache` as the agent self-update command
+- **THEN** the catalog exposes `kimi upgrade` as the agent self-update command
 
 ### Requirement: Crush MUST be a supported lifecycle agent
 
@@ -380,13 +388,6 @@ Quantex SHALL allow supported agent catalog entries to declare uv tool managed i
 - **AND** the entry continues to identify `mistral-vibe` as pip package metadata
 - **AND** macOS and Linux continue to include the official shell installer option
 
-#### Scenario: Registering Kimi CLI uv metadata
-
-- **WHEN** Quantex defines the supported Kimi Code CLI agent entry
-- **THEN** the entry identifies `kimi-cli` as uv package metadata
-- **AND** macOS and Linux include the uv managed install method with the upstream-documented `--python 3.13` argument
-- **AND** Windows does not include a uv managed install method while upstream docs do not list native Windows support
-
 ### Requirement: mise install methods MUST be supported lifecycle metadata
 
 Quantex SHALL allow supported agent catalog entries to declare mise-managed install methods and mise package metadata when an upstream agent can be installed through mise.
@@ -453,4 +454,3 @@ Quantex SHALL record CodeWhale's Cargo package metadata when defining the suppor
 - **THEN** the entry identifies `codewhale-cli` as Cargo package metadata
 - **AND** the Cargo install method includes the upstream-documented `--locked` argument
 - **AND** the entry identifies `codewhale` as npm package metadata
-

--- a/src/agents/catalog/kimi.json
+++ b/src/agents/catalog/kimi.json
@@ -2,13 +2,13 @@
   "name": "kimi",
   "lookupAliases": ["kimi-code", "kimi-cli"],
   "displayName": "Kimi Code",
-  "homepage": "https://moonshotai.github.io/kimi-cli/",
+  "homepage": "https://moonshotai.github.io/kimi-code/",
   "binaryName": "kimi",
   "packages": {
-    "uv": "kimi-cli"
+    "npm": "@moonshot-ai/kimi-code"
   },
   "selfUpdate": {
-    "command": ["uv", "tool", "upgrade", "kimi-cli", "--no-cache"]
+    "command": ["kimi", "upgrade"]
   },
   "versionProbe": {
     "command": ["kimi", "--version"]
@@ -16,28 +16,29 @@
   "platforms": {
     "windows": [
       {
-        "command": "irm https://code.kimi.com/install.ps1 | iex",
+        "command": "irm https://code.kimi.com/kimi-code/install.ps1 | iex",
         "type": "script"
+      },
+      {
+        "type": "npm"
       }
     ],
     "macos": [
       {
-        "packageInstallArgs": ["--python", "3.13"],
-        "type": "uv"
+        "command": "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+        "type": "script"
       },
       {
-        "command": "curl -LsSf https://code.kimi.com/install.sh | bash",
-        "type": "script"
+        "type": "npm"
       }
     ],
     "linux": [
       {
-        "packageInstallArgs": ["--python", "3.13"],
-        "type": "uv"
+        "command": "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash",
+        "type": "script"
       },
       {
-        "command": "curl -LsSf https://code.kimi.com/install.sh | bash",
-        "type": "script"
+        "type": "npm"
       }
     ]
   }

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -684,25 +684,33 @@ describe('kimi', () => {
     expect(kimi.lookupAliases).toEqual(['kimi-code', 'kimi-cli'])
     expect(kimi.displayName).toBe('Kimi Code')
     expect(kimi.binaryName).toBe('kimi')
-    expect(kimi.packages?.uv).toBe('kimi-cli')
-    expect(kimi.homepage).toBe('https://moonshotai.github.io/kimi-cli/')
-    expect(kimi.selfUpdate?.command).toEqual(['uv', 'tool', 'upgrade', 'kimi-cli', '--no-cache'])
+    expect(kimi.packages?.npm).toBe('@moonshot-ai/kimi-code')
+    expect(kimi.packages?.uv).toBeUndefined()
+    expect(kimi.homepage).toBe('https://moonshotai.github.io/kimi-code/')
+    expect(kimi.selfUpdate?.command).toEqual(['kimi', 'upgrade'])
     expect(kimi.versionProbe?.command).toEqual(['kimi', '--version'])
   })
 
-  it('exposes managed uv installs on macOS and Linux while preserving script installers', () => {
-    for (const methods of [kimi.platforms.macos!, kimi.platforms.linux!]) {
-      expect(
-        methods.find(
-          m => m.type === 'uv' && m.packageName === undefined && m.packageInstallArgs?.join(' ') === '--python 3.13',
-        ),
-      ).toBeDefined()
-      expect(methods.find(m => m.type === 'script' && m.command.includes('code.kimi.com/install.sh'))).toBeDefined()
+  it('exposes official script installers and npm-managed installs on all platforms', () => {
+    for (const methods of [kimi.platforms.windows!, kimi.platforms.macos!, kimi.platforms.linux!]) {
+      expect(methods.find(m => m.type === 'uv')).toBeUndefined()
+      expect(methods.find(m => m.type === 'npm')).toBeDefined()
     }
 
-    expect(kimi.platforms.windows!.find(m => m.type === 'uv')).toBeUndefined()
     expect(
-      kimi.platforms.windows!.find(m => m.type === 'script' && m.command.includes('code.kimi.com/install.ps1')),
+      kimi.platforms.windows!.find(
+        m => m.type === 'script' && m.command === 'irm https://code.kimi.com/kimi-code/install.ps1 | iex',
+      ),
+    ).toBeDefined()
+    expect(
+      kimi.platforms.macos!.find(
+        m => m.type === 'script' && m.command === 'curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash',
+      ),
+    ).toBeDefined()
+    expect(
+      kimi.platforms.linux!.find(
+        m => m.type === 'script' && m.command === 'curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash',
+      ),
     ).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary

Update the Kimi Code catalog entry for the upstream TypeScript/Node.js rewrite. Quantex now points Kimi fresh installs at the current official script URLs and npm package instead of the deprecated Python/uv `kimi-cli` distribution.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/update-kimi-code-ts-cli`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: minor - user-facing agent catalog update

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active by design until merge and queued for agent-driven archive closure.
- [x] Release is delegated to release automation.

## Notes

Official Kimi docs now describe Kimi Code CLI as TypeScript over Node.js, distributed through npm and the `code.kimi.com/kimi-code` install scripts. This PR keeps the legacy `kimi-cli` lookup alias for discovery, but no longer advertises uv as the fresh-install lifecycle source.
