### PR TITLE
docs(readme): remove bundlephobia badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![Node.js >=20][node-src]][node-href]
 [![Bun][bun-src]][bun-href]
 [![Platforms][platforms-src]][release-href]
-[![bundle][bundle-src]][bundle-href]
 [![License][license-src]][license-href]
 [![GitHub stars][stars-src]][stars-href]
 
@@ -316,7 +315,5 @@ Apache-2.0
 [bun-src]: https://img.shields.io/badge/bun-1.3.11-fbf0df?style=flat-square&logo=bun&logoColor=000
 [bun-href]: https://bun.sh/
 [platforms-src]: https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-555?style=flat-square
-[bundle-src]: https://img.shields.io/bundlephobia/minzip/quantex-cli?style=flat-square
-[bundle-href]: https://bundlephobia.com/package/quantex-cli
 [license-src]: https://img.shields.io/npm/l/quantex-cli?style=flat-square
 [license-href]: ./LICENSE

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,6 @@
 [![Node.js >=20][node-src]][node-href]
 [![Bun][bun-src]][bun-href]
 [![Platforms][platforms-src]][release-href]
-[![bundle][bundle-src]][bundle-href]
 [![License][license-src]][license-href]
 [![GitHub stars][stars-src]][stars-href]
 
@@ -314,7 +313,5 @@ Apache-2.0
 [bun-src]: https://img.shields.io/badge/bun-1.3.11-fbf0df?style=flat-square&logo=bun&logoColor=000
 [bun-href]: https://bun.sh/
 [platforms-src]: https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-555?style=flat-square
-[bundle-src]: https://img.shields.io/bundlephobia/minzip/quantex-cli?style=flat-square
-[bundle-href]: https://bundlephobia.com/package/quantex-cli
 [license-src]: https://img.shields.io/npm/l/quantex-cli?style=flat-square
 [license-href]: ./LICENSE


### PR DESCRIPTION
## Summary

Remove the Bundlephobia badge from the English and Simplified Chinese README badge rows because the upstream service is unreliable for this CLI package and currently renders as an error badge.

## Linked Artifacts

- Issue: not applicable - user-requested README badge cleanup
- ADR: not applicable
- OpenSpec: not needed - docs-only badge removal with no behavior or durable process contract change
- Discussion: not applicable

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

`bun run test` was not run because this change only removes README badge markup and does not change CLI behavior.

## Release Intent

- [x] Release: not applicable - docs/process/test-only change
- [ ] Release: patch - bug fix
- [ ] Release: minor - user-facing feature
- [ ] Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

Updated `README.md` and `README.zh-CN.md`.

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

No follow-up artifact is needed because this is a narrow badge cleanup.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Reviewers should only need to verify that the broken Bundlephobia badge and its link references were removed from both README variants.
