### PR TITLE
fix(cli): handle state read errors and install timeouts

### DIFF
--- a/openspec/changes/fix-exec-install-timeout/.openspec.yaml
+++ b/openspec/changes/fix-exec-install-timeout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-08

--- a/openspec/changes/fix-exec-install-timeout/design.md
+++ b/openspec/changes/fix-exec-install-timeout/design.md
@@ -1,0 +1,18 @@
+## Context
+
+Management commands route through `executeCommandWithRuntime`, which races the full command body against `--timeout` and calls `cancelCliContextOperations()` on expiry. Managed installers register cancellation handlers through `spawnWithQuantexStdio`, so subprocess trees are terminated.
+
+`runCommand` bypasses that runtime wrapper. It already enforces timeout while waiting for the spawned agent binary, but `tryInstallForRun()` awaits `installAgent()` without a deadline.
+
+## Decision
+
+Reuse the same timeout semantics as `runSpawnedAgentProcess()` inside `runCommand` for install work:
+
+- When `timeoutMs` is set, race install work against a timer.
+- On expiry, call `cancelCliContextOperations()` and return exit code `10` (`TIMEOUT`).
+- When `timeoutMs` is unset, preserve current behavior.
+
+## Non-Goals
+
+- Sharing one timeout budget across install and spawn in this change.
+- Changing timeout behavior for commands that already use `executeCommandWithRuntime`.

--- a/openspec/changes/fix-exec-install-timeout/proposal.md
+++ b/openspec/changes/fix-exec-install-timeout/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`quantex exec` and shortcut `quantex <agent>` honor `--timeout` only after the agent process is spawned. When the agent is missing and install runs first, a hung managed installer can block forever even though management commands already cancel installer subprocesses on timeout.
+
+## What Changes
+
+- Apply the configured CLI timeout to the install phase in `runCommand`.
+- Cancel managed installer subprocesses through the existing CLI cancellation handlers when the install deadline expires.
+- Add regression coverage for install-phase timeout on exec/shortcut paths.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `agent-update`: exec and shortcut install flows must honor global `--timeout` during managed install work.
+
+## Impact
+
+- Affected code: `src/commands/run.ts`, `test/commands/run.test.ts`.
+- Affected specs: `openspec/specs/agent-update/spec.md` through a change delta.
+- No schema version, command catalog, or dependency changes are intended.

--- a/openspec/changes/fix-exec-install-timeout/specs/agent-update/spec.md
+++ b/openspec/changes/fix-exec-install-timeout/specs/agent-update/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Exec and shortcut install flows MUST honor global timeout during managed install
+
+When `quantex exec` or shortcut `quantex <agent>` runs with `--timeout` and must install a missing agent before launch, Quantex SHALL apply the configured timeout to the install phase and SHALL cancel managed installer subprocesses when the deadline expires.
+
+#### Scenario: Missing agent install times out before spawn
+
+- **GIVEN** the target agent is not currently installed
+- **AND** the user runs `quantex exec <agent> --install if-missing --timeout <duration>` or shortcut `quantex <agent> --timeout <duration>`
+- **WHEN** managed install work exceeds the configured timeout
+- **THEN** Quantex cancels the managed installer subprocesses
+- **AND** it returns a timeout result with exit code `10`
+- **AND** it does not continue to spawn the agent binary after the install deadline expires

--- a/openspec/changes/fix-exec-install-timeout/tasks.md
+++ b/openspec/changes/fix-exec-install-timeout/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+
+- [x] 1.1 Enforce CLI timeout during `runCommand` install phase
+- [x] 1.2 Add regression test for install-phase timeout
+
+## 2. Validation
+
+- [x] 2.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run test`

--- a/openspec/changes/fix-state-read-error-surface/.openspec.yaml
+++ b/openspec/changes/fix-state-read-error-surface/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-06

--- a/openspec/changes/fix-state-read-error-surface/design.md
+++ b/openspec/changes/fix-state-read-error-surface/design.md
@@ -1,0 +1,19 @@
+## Context
+
+`readState()` now throws `StateFileError` for corrupt JSON, invalid `installedAgents`, and other unsafe persisted-state shapes. Commands catch `ResourceLockError` locally but rethrow other errors, and `executeCommandWithRuntime()` has no top-level translation for state read failures.
+
+## Goals / Non-Goals
+
+- Goals: return structured command failures for state read errors; preserve fail-closed reads; keep the fix narrow and centralized.
+- Non-goals: auto-repair or delete corrupt `state.json`; change state normalization rules; add new recovery commands.
+
+## Decisions
+
+- Add `STATE_READ_ERROR` to the stable CLI error catalog with exit code `12`.
+- Add `createStateReadError()` beside the existing resource-lock helper.
+- Catch `StateFileError` at the outer edge of `executeCommandWithRuntime()` and in the shortcut `quantex <agent>` path before `process.exit()`.
+- Include `stateFilePath` in structured error details for remediation.
+
+## Risks / Trade-offs
+
+- Commands that intentionally let `StateFileError` bubble to callers outside the CLI runtime are unaffected; only CLI entry paths are normalized.

--- a/openspec/changes/fix-state-read-error-surface/proposal.md
+++ b/openspec/changes/fix-state-read-error-surface/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Recent fail-closed `state.json` validation correctly throws `StateFileError` on corrupt or semantically invalid persisted state, but lifecycle commands still let that exception escape the CLI runtime. The result is an unhandled stack trace instead of a structured command error, which violates the `quantex-state` contract and breaks `--json` automation on corrupt state.
+
+## What Changes
+
+- Surface corrupt or invalid persisted state as a stable CLI error (`STATE_READ_ERROR`) instead of crashing.
+- Centralize `StateFileError` handling in the command runtime and shortcut agent execution path.
+- Add regression tests for human and JSON output when `state.json` is unreadable or invalid.
+
+## Capabilities
+
+### New Capabilities
+
+- (none)
+
+### Modified Capabilities
+
+- `quantex-state`: lifecycle commands that load persisted state must fail with a state read error instead of crashing.
+
+## Impact
+
+- `src/command-runtime.ts`
+- `src/cli.ts`
+- `src/errors.ts`
+- `src/utils/lifecycle-errors.ts`
+- `test/commands/state-read-error.test.ts`

--- a/openspec/changes/fix-state-read-error-surface/specs/quantex-state/spec.md
+++ b/openspec/changes/fix-state-read-error-surface/specs/quantex-state/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Corrupt or unreadable state file MUST fail closed
+
+When `state.json` exists but cannot be read, parsed, or normalized into a safe persisted state shape, Quantex MUST NOT substitute empty default state for a subsequent write.
+
+#### Scenario: Invalid installed agent records must not crash lifecycle commands
+
+- **GIVEN** `state.json` exists with an `installedAgents` entry that uses an unknown `installType`
+- **WHEN** Quantex loads persisted state for inspection or mutation through a CLI command
+- **THEN** the operation fails with a state read error
+- **AND** Quantex does not crash while resolving installer capabilities
+- **AND** structured output mode returns `{ ok: false, error: { code: "STATE_READ_ERROR", ... } }`
+
+#### Scenario: Invalid JSON must not crash lifecycle commands
+
+- **GIVEN** `state.json` exists with previously recorded `installedAgents` or `self` data
+- **AND** the file contents are not valid JSON
+- **WHEN** Quantex runs a lifecycle command that loads persisted state
+- **THEN** the operation fails with a state read error
+- **AND** Quantex does not emit an unhandled exception stack trace to the user

--- a/openspec/changes/fix-state-read-error-surface/tasks.md
+++ b/openspec/changes/fix-state-read-error-surface/tasks.md
@@ -1,0 +1,9 @@
+## 1. Implementation
+
+- [x] 1.1 Add `STATE_READ_ERROR` and `createStateReadError()` helpers
+- [x] 1.2 Catch `StateFileError` in `executeCommandWithRuntime()` and shortcut agent execution
+- [x] 1.3 Add regression tests for corrupt `state.json` in human and JSON modes
+
+## 2. Validation
+
+- [x] 2.1 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, and `bun run test`

--- a/src/command-runtime.ts
+++ b/src/command-runtime.ts
@@ -4,7 +4,9 @@ import { cancelCliContextOperations, getCliContext } from './cli-context'
 import { loadIdempotencyRecord, saveIdempotencyRecord } from './idempotency'
 import { createErrorResult, emitCommandEvent, emitCommandResult } from './output'
 import { maybeRenderSelfUpdateNotice } from './self/update-notice'
+import { getStateFilePath, StateFileError } from './state'
 import { pc } from './utils/color'
+import { createStateReadError } from './utils/lifecycle-errors'
 
 interface ExecuteCommandOptions<T> {
   action: string
@@ -13,6 +15,16 @@ interface ExecuteCommandOptions<T> {
 }
 
 export async function executeCommandWithRuntime<T>(options: ExecuteCommandOptions<T>): Promise<CommandResult<T>> {
+  try {
+    return await executeCommandWithRuntimeInternal(options)
+  } catch (error) {
+    if (error instanceof StateFileError) return resolveStateReadError(options, error)
+
+    throw error
+  }
+}
+
+async function executeCommandWithRuntimeInternal<T>(options: ExecuteCommandOptions<T>): Promise<CommandResult<T>> {
   const replayedResult = await replayIdempotentResult<T>(options.action, options.target)
   if (replayedResult) return replayedResult
 
@@ -48,6 +60,23 @@ export async function executeCommandWithRuntime<T>(options: ExecuteCommandOption
   } finally {
     if (timeoutId) clearTimeout(timeoutId)
   }
+}
+
+async function resolveStateReadError<T>(
+  options: ExecuteCommandOptions<T>,
+  error: StateFileError,
+): Promise<CommandResult<T>> {
+  return emitCommandResult(
+    createErrorResult<T>({
+      action: options.action,
+      ...createStateReadError(error, getStateFilePath(), options.target),
+    }),
+    renderStateReadHuman,
+  )
+}
+
+function renderStateReadHuman(result: Pick<CommandResult, 'error'>): void {
+  if (result.error) console.error(pc.red(result.error.message))
 }
 
 async function finalizeSuccessfulRun<T>(

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,9 +8,11 @@ import { getExitCodeForError } from '../errors'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
 import { installAgent } from '../package-manager'
 import { resolveAgentInspection } from '../services/agents'
+import { getStateFilePath, StateFileError } from '../state'
 import { spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
 import { pc } from '../utils/color'
 import { formatInstallMethodCommand, formatInstallMethodLabel } from '../utils/install'
+import { createStateReadError } from '../utils/lifecycle-errors'
 import { isResourceLockError } from '../utils/lock'
 import {
   isAssumeYesEnabled,
@@ -57,7 +59,18 @@ export async function runCommand(
     nonInteractive?: boolean
   } = {},
 ): Promise<number> {
-  const resolved = await resolveAgentInspection(agentName)
+  let resolved
+  try {
+    resolved = await resolveAgentInspection(agentName)
+  } catch (error) {
+    if (error instanceof StateFileError) {
+      emitStateReadError(agentName, error)
+      return getExitCodeForError('STATE_READ_ERROR')
+    }
+
+    throw error
+  }
+
   if (!resolved) {
     emitExecPreflightError({
       agent: {
@@ -110,8 +123,9 @@ export async function runCommand(
       } else {
         printInfo(pc.cyan(`Installing ${agent.displayName}...`))
       }
-      const result = await tryInstallForRun(agent, dryRun)
-      if (!result.success) {
+      const installResult = await runInstallForRunWithTimeout(agent, dryRun)
+      if (installResult === 'timeout') return getExitCodeForError('TIMEOUT')
+      if (!installResult.success) {
         printError(pc.red(`Failed to install ${agent.displayName}.`))
         return 1
       }
@@ -155,8 +169,9 @@ export async function runCommand(
       } else {
         printInfo(pc.cyan(`Installing ${agent.displayName}...`))
       }
-      const result = await tryInstallForRun(agent, dryRun)
-      if (!result.success) {
+      const installResult = await runInstallForRunWithTimeout(agent, dryRun)
+      if (installResult === 'timeout') return getExitCodeForError('TIMEOUT')
+      if (!installResult.success) {
         printError(pc.red(`Failed to install ${agent.displayName}.`))
         return 1
       }
@@ -215,6 +230,27 @@ function createExecInstallGuidance(
     suggestedEnsureCommand: `quantex ensure ${agent.name}`,
     suggestedExecCommand: ['quantex', 'exec', agent.name, '--install', 'if-missing', '--', ...args].join(' '),
   }
+}
+
+function emitStateReadError(agentName: string, error: StateFileError): void {
+  const stateError = createStateReadError(error, getStateFilePath(), {
+    kind: 'agent',
+    name: agentName,
+  })
+  const context = getCliContext()
+
+  if (context.outputMode === 'human') {
+    printError(pc.red(stateError.error.message))
+    return
+  }
+
+  emitCommandResult(
+    createErrorResult<ExecPreflightData>({
+      action: 'exec',
+      ...stateError,
+    }),
+    () => {},
+  )
 }
 
 function emitExecPreflightError(input: {
@@ -280,6 +316,32 @@ function emitExecDryRun(input: {
     }),
     () => {},
   )
+}
+
+async function runInstallForRunWithTimeout(
+  agent: { displayName: string } & Parameters<typeof installAgent>[0],
+  dryRun: boolean = isDryRunEnabled(),
+): Promise<Awaited<ReturnType<typeof installAgent>> | 'timeout'> {
+  const { timeoutMs } = getCliContext()
+  if (timeoutMs === undefined) return tryInstallForRun(agent, dryRun)
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    const timeoutPromise = new Promise<'timeout'>(resolve => {
+      timeoutId = setTimeout(() => {
+        void (async () => {
+          await cancelCliContextOperations()
+          printError(pc.red(`Installing ${agent.displayName} timed out after ${timeoutMs}ms.`))
+          resolve('timeout')
+        })()
+      }, timeoutMs)
+    })
+
+    return await Promise.race([tryInstallForRun(agent, dryRun), timeoutPromise])
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
 }
 
 async function tryInstallForRun(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,7 @@ export const cliErrorCodes = [
   'MANUAL_ACTION_REQUIRED',
   'NETWORK_ERROR',
   'RESOURCE_LOCKED',
+  'STATE_READ_ERROR',
   'TIMEOUT',
   'UNINSTALL_FAILED',
   'UPDATE_FAILED',
@@ -34,6 +35,8 @@ export function getExitCodeForError(code: CliErrorCode): number {
       return 8
     case 'RESOURCE_LOCKED':
       return 9
+    case 'STATE_READ_ERROR':
+      return 12
     case 'TIMEOUT':
       return 10
     case 'CANCELLED':

--- a/src/utils/lifecycle-errors.ts
+++ b/src/utils/lifecycle-errors.ts
@@ -1,5 +1,23 @@
 import type { CommandError, CommandTarget } from '../output/types'
+import type { StateFileError } from '../state'
 import type { ResourceLockError } from './lock'
+
+export function createStateReadError(
+  error: StateFileError,
+  stateFilePath: string,
+  target?: CommandTarget,
+): { error: CommandError; target?: CommandTarget } {
+  return {
+    error: {
+      code: 'STATE_READ_ERROR',
+      details: {
+        stateFilePath,
+      },
+      message: error.message,
+    },
+    target,
+  }
+}
 
 export function createResourceLockedError(
   error: ResourceLockError,

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -244,6 +244,27 @@ describe('runCommand', () => {
     expect(mockSpawn).not.toHaveBeenCalled()
   })
 
+  it('returns timeout when install exceeds the configured limit', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'human',
+      runId: 'run-install-timeout-id',
+      timeoutMs: 1,
+    })
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+    installSpy.mockImplementation(() => new Promise(() => {}))
+
+    const code = await runCommand('test-agent', ['--help'], {
+      install: 'if-missing',
+      nonInteractive: true,
+    })
+
+    expect(code).toBe(10)
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('timed out'))
+    expect(mockSpawn).not.toHaveBeenCalled()
+  })
+
   it('returns timeout when the spawned agent exceeds the configured limit', async () => {
     let resolveExited: (() => void) | undefined
     const proc: any = {

--- a/test/commands/state-read-error.test.ts
+++ b/test/commands/state-read-error.test.ts
@@ -1,0 +1,143 @@
+import { mkdtemp, mkdir, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as agents from '../../src/agents'
+import { setCliContext } from '../../src/cli-context'
+import { executeCommandWithRuntime } from '../../src/command-runtime'
+import { listCommand } from '../../src/commands/list'
+import { runCommand } from '../../src/commands/run'
+import { getExitCodeForResult } from '../../src/errors'
+
+const agentLookupSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
+
+const testAgent = {
+  name: 'test-agent',
+  lookupAliases: [],
+  displayName: 'Test Agent',
+  homepage: 'https://example.com',
+  binaryName: 'test-bin',
+  packages: { npm: 'test-pkg' },
+  platforms: {
+    linux: [{ type: 'bun' as const }],
+    macos: [{ type: 'bun' as const }],
+    windows: [{ type: 'bun' as const }],
+  },
+}
+
+let tempHome = ''
+
+beforeEach(async () => {
+  tempHome = await mkdtemp(join(tmpdir(), 'quantex-state-read-error-'))
+  vi.stubEnv('HOME', tempHome)
+  await mkdir(join(tempHome, '.quantex'), { recursive: true })
+  agentLookupSpy.mockReset()
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('state read errors', () => {
+  it('returns structured STATE_READ_ERROR for invalid JSON in json mode', async () => {
+    await writeFile(join(tempHome, '.quantex', 'state.json'), 'not json', 'utf8')
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'state-read-error-run',
+    })
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const result = await executeCommandWithRuntime({
+        action: 'list',
+        run: () => listCommand(),
+        target: {
+          kind: 'system',
+          name: 'agents',
+        },
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.error?.code).toBe('STATE_READ_ERROR')
+      expect(result.error?.details).toMatchObject({
+        stateFilePath: join(tempHome, '.quantex', 'state.json'),
+      })
+      expect(getExitCodeForResult(result)).toBe(12)
+      expect(errorSpy).not.toHaveBeenCalled()
+      expect(logSpy).toHaveBeenCalled()
+
+      const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)
+      expect(payload.ok).toBe(false)
+      expect(payload.error.code).toBe('STATE_READ_ERROR')
+    } finally {
+      logSpy.mockRestore()
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('prints a human error instead of crashing for invalid installed agent records', async () => {
+    await writeFile(
+      join(tempHome, '.quantex', 'state.json'),
+      JSON.stringify({
+        installedAgents: {
+          codex: {
+            agentName: 'codex',
+            installType: 'invalid-install-type',
+          },
+        },
+      }),
+      'utf8',
+    )
+    setCliContext({
+      interactive: false,
+      outputMode: 'human',
+      runId: 'state-read-error-human',
+    })
+
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      const result = await executeCommandWithRuntime({
+        action: 'list',
+        run: () => listCommand(),
+        target: {
+          kind: 'system',
+          name: 'agents',
+        },
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.error?.code).toBe('STATE_READ_ERROR')
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to read Quantex state file'))
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('returns structured STATE_READ_ERROR for shortcut agent execution', async () => {
+    await writeFile(join(tempHome, '.quantex', 'state.json'), '[]', 'utf8')
+    agentLookupSpy.mockReturnValue(testAgent)
+    setCliContext({
+      interactive: false,
+      outputMode: 'json',
+      runId: 'state-read-error-run',
+    })
+
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      const exitCode = await runCommand('test-agent', ['--help'])
+      expect(exitCode).toBe(12)
+
+      const payload = JSON.parse(logSpy.mock.calls.at(-1)?.[0] as string)
+      expect(payload.ok).toBe(false)
+      expect(payload.error.code).toBe('STATE_READ_ERROR')
+      expect(payload.action).toBe('exec')
+    } finally {
+      logSpy.mockRestore()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Batch-deliver two verified Draft PR fixes in one clean maintainer-authored commit:

- Surface corrupt or semantically invalid `state.json` as `STATE_READ_ERROR` instead of leaking `StateFileError` stacks in CLI output.
- Enforce `--timeout` during `quantex exec` and shortcut install work before spawning the agent binary.

## Linked Artifacts

- Issue: Draft PR #339 and Draft PR #340 were validated against `main`
- ADR:
- OpenSpec: `openspec/changes/fix-state-read-error-surface`, `openspec/changes/fix-exec-install-timeout`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Validation notes:

- `STATE_READ_ERROR` was reproduced on `main` with invalid JSON in a temp `state.json`: `bun run dev -- list --json` exited with an unhandled `StateFileError` stack.
- Install timeout was reproduced on `main` with a mocked never-resolving installer: `runCommand()` remained pending past the configured timeout.
- The first full `bun run test` hit the known local `managed-installer-cancellation.e2e.test.ts` harness timeout; the targeted e2e then passed with default timeout, and the final full `bun run test` passed.

Draft PR handling:

- Covers the verified changes from #339 and #340 in one squash-ready branch.
- #338 is a duplicate of #339 with an identical branch tree and should be closed as covered by this batch.
- After this PR merges, archive follow-up is required for `fix-state-read-error-surface` and `fix-exec-install-timeout`.
