### PR TITLE
test(cli): stabilize late timeout success regression

### DIFF
--- a/test/command-runtime.test.ts
+++ b/test/command-runtime.test.ts
@@ -192,6 +192,7 @@ describe('executeCommandWithRuntime', () => {
   })
 
   it('returns success when the command completes successfully after the timeout deadline fires', async () => {
+    vi.useFakeTimers()
     setCliContext({
       interactive: false,
       outputMode: 'json',
@@ -199,10 +200,10 @@ describe('executeCommandWithRuntime', () => {
       timeoutMs: 20,
     })
 
-    const result = await executeCommandWithRuntime({
+    const execution = executeCommandWithRuntime({
       action: 'install',
       run: async () => {
-        await new Promise(resolve => setTimeout(resolve, 40))
+        await new Promise(resolve => setTimeout(resolve, 30))
         return createSuccessResult({
           action: 'install',
           data: {
@@ -219,6 +220,11 @@ describe('executeCommandWithRuntime', () => {
         name: 'codex',
       },
     })
+
+    await vi.advanceTimersByTimeAsync(20)
+    await vi.advanceTimersByTimeAsync(10)
+
+    const result = await execution
 
     expect(result.ok).toBe(true)
     expect(result.error).toBeNull()


### PR DESCRIPTION
## Summary

Stabilize the late-success timeout regression test that failed once in the Release workflow for PR #351. The test now uses fake timers to deterministically advance through the timeout deadline and late successful completion instead of relying on a real 20ms/40ms timer boundary.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec:
- Discussion: Release workflow run `27322365782`

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [x] `bun run test -- test/command-runtime.test.ts`
- [x] `bun run openspec:validate`
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - test-only stabilization for release workflow reliability

## Docs Updated

- [x] Not needed

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed for this test-only stabilization.
- [x] Release is delegated to release automation.

## Notes

- This does not change `src/command-runtime.ts` behavior.
- The prior Release workflow failure was `test/command-runtime.test.ts` expecting a late successful result but receiving `TIMEOUT` on a real timer boundary.
