### PR TITLE
docs: refresh product readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ Install, inspect, update, uninstall, and run AI coding assistant CLIs from one a
 
 </div>
 
-Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding assistants and terminal coding agents. Use one `qtx` surface to install, inspect, update, uninstall, run, and automate Codex CLI, Claude Code, Gemini CLI, Cursor CLI, OpenCode, Amp, Kilo Code, and other assistant CLIs with stable machine-readable output. This README uses the shorter `qtx` form as the recommended entry point, while `quantex` remains the fully equivalent long command name.
+Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding assistants and terminal coding agents. Use one `qtx` surface to install, inspect, update, uninstall, run, and automate Codex CLI, Claude Code, Gemini CLI, Cursor CLI, OpenCode, Antigravity CLI, MiMoCode, Amp, Kilo CLI, and other assistant CLIs with stable machine-readable output. This README uses the shorter `qtx` form as the recommended entry point, while `quantex` remains the fully equivalent long command name.
 
 ## Why Quantex
 
 - Manage multiple AI coding assistant CLIs from one lifecycle command: install, ensure, inspect, update, uninstall, and run.
 - Designed for scripts and coding agents: stable `--json`, `--output ndjson`, `--non-interactive`, and `--dry-run` contracts for machine-readable automation.
 - Tracks real install sources: `update --all` groups updates by recorded source instead of guessing from PATH alone.
-- Supports managed agent installs through available Bun, npm, Homebrew, Cargo, Deno, pip, uv, and winget providers.
+- Supports managed agent installs through available Bun, npm, Homebrew, Cargo, Deno, mise, pip, uv, and winget providers.
 - Supports Quantex self-upgrade across Bun, npm, and standalone binary installs.
 
 ## Agent Quick Start
@@ -177,6 +177,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 
 | Agent | Run Command | Description |
 |-------|-------------|-------------|
+| Antigravity CLI | `qtx antigravity` | Google's Antigravity terminal coding agent CLI |
 | Auggie CLI | `qtx auggie` | Augment's official terminal coding agent |
 | Autohand Code CLI | `qtx autohand` | Autohand's autonomous terminal coding agent CLI |
 | Amp | `qtx amp` | Sourcegraph's frontier AI coding agent CLI |
@@ -199,6 +200,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Kilo CLI | `qtx kilo` | Kilo's official AI coding assistant CLI |
 | Kimi Code | `qtx kimi` | Moonshot AI's coding assistant CLI |
 | Kiro CLI | `qtx kiro` | Amazon's AI coding agent CLI |
+| MiMoCode | `qtx mimo` | Xiaomi's terminal-native AI coding assistant CLI |
 | Mistral Vibe | `qtx vibe` | Mistral's open-source CLI coding assistant |
 | OpenHands CLI | `qtx openhands` | OpenHands' open-source software development agent CLI |
 | OpenCode | `qtx opencode` | Open-source AI coding CLI |
@@ -246,7 +248,6 @@ User configuration lives at `~/.quantex/config.json`:
   "defaultPackageManager": "bun",
   "npmBunUpdateStrategy": "latest-major",
   "selfUpdateChannel": "stable",
-  "selfUpdateRegistry": "https://registry.npmjs.org",
   "networkRetries": 2,
   "networkTimeoutMs": 10000,
   "versionCacheTtlHours": 6
@@ -255,7 +256,7 @@ User configuration lives at `~/.quantex/config.json`:
 
 `defaultPackageManager` can be `bun`, `npm`, or `mise`. It only changes agent install-method ordering when the selected agent exposes that managed installer; it does not make Quantex install missing package managers for you.
 
-`selfUpdateRegistry` only affects the registry used when Quantex upgrades itself through Bun/npm. It does not change the default install source for your other projects. For a one-off override, use the `QTX_SELF_UPDATE_REGISTRY` environment variable.
+`selfUpdateRegistry` is unset by default. When unset, Quantex follows the active Bun/npm registry for self-upgrade. If you set `selfUpdateRegistry`, it only affects the registry used when Quantex upgrades itself through Bun/npm and does not change the default install source for your other projects. For a one-off override, use the `QTX_SELF_UPDATE_REGISTRY` environment variable.
 
 Runtime state lives at `~/.quantex/state.json`. Quantex records the actual install source for agents and itself, which powers grouped `update --all` execution, `doctor` recovery guidance, and self-upgrade source detection.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,14 +22,14 @@
 
 </div>
 
-Quantex 是一个 `human-friendly + agent-friendly` 的 AI 编程助手 CLI lifecycle manager。它帮你把 Codex CLI、Claude Code、Gemini CLI、Cursor CLI、OpenCode、Amp、Kilo Code 等终端 coding agent 的安装、检查、更新、卸载、启动和自动化调用统一到一组稳定命令里：人可以直接用，脚本和 coding agent 也可以通过结构化输出可靠调用。本文默认使用更短的 `qtx` 作为推荐入口，`quantex` 是完全等价的完整命令名。
+Quantex 是一个 `human-friendly + agent-friendly` 的 AI 编程助手 CLI lifecycle manager。它帮你把 Codex CLI、Claude Code、Gemini CLI、Cursor CLI、OpenCode、Antigravity CLI、MiMoCode、Amp、Kilo CLI 等终端 coding agent 的安装、检查、更新、卸载、启动和自动化调用统一到一组稳定命令里：人可以直接用，脚本和 coding agent 也可以通过结构化输出可靠调用。本文默认使用更短的 `qtx` 作为推荐入口，`quantex` 是完全等价的完整命令名。
 
 ## 为什么用 Quantex
 
 - 一个生命周期命令管理多个 AI 编程助手 CLI：安装、确保可用、查询状态、更新、卸载、启动。
 - 适合脚本和 agent 调用：支持 `--json`、`--output ndjson`、`--non-interactive`、`--dry-run` 等适合机器读取的稳定契约。
 - 记住真实安装来源：`update --all` 会优先按已记录来源分组更新，避免混合安装环境下误用更新方式。
-- 支持通过可用的 Bun、npm、Homebrew、Cargo、Deno、pip、uv、winget provider 管理 agent 安装。
+- 支持通过可用的 Bun、npm、Homebrew、Cargo、Deno、mise、pip、uv、winget provider 管理 agent 安装。
 - 支持 Quantex 自升级：Bun、npm、独立二进制安装来源都有对应升级路径。
 
 ## Agent 快速接入
@@ -156,7 +156,7 @@ qtx upgrade --channel beta
 
 | 推荐命令 | 等价长命令 | 作用 |
 |------|------|------|
-| `qtx i <agent>` | `quantex install <agent>` | 安装 agent |
+| `qtx i <agent> [more-agents...]` | `quantex install <agent> [more-agents...]` | 安装一个或多个 agent |
 | `qtx ensure <agent>` | `quantex ensure <agent>` | 幂等确保 agent 已安装 |
 | `qtx u <agent>` | `quantex update <agent>` | 更新 agent |
 | `qtx update --all` | `quantex update --all` | 更新所有已安装 agent |
@@ -177,6 +177,7 @@ qtx upgrade --channel beta
 
 | Agent | 启动命令 | 描述 |
 |-------|----------|------|
+| Antigravity CLI | `qtx antigravity` | Google Antigravity 终端编程 Agent CLI |
 | Auggie CLI | `qtx auggie` | Augment 官方终端编程 Agent CLI |
 | Autohand Code CLI | `qtx autohand` | Autohand 官方自主终端编程 Agent CLI |
 | Amp | `qtx amp` | Sourcegraph 前沿 AI 编程 Agent CLI |
@@ -199,6 +200,7 @@ qtx upgrade --channel beta
 | Kilo CLI | `qtx kilo` | Kilo 官方 AI 编程助手 CLI |
 | Kimi Code | `qtx kimi` | Moonshot AI 编程助手 CLI |
 | Kiro CLI | `qtx kiro` | Amazon AI 编程 Agent CLI |
+| MiMoCode | `qtx mimo` | 小米终端原生 AI 编程助手 CLI |
 | Mistral Vibe | `qtx vibe` | Mistral 开源终端编程助手 |
 | OpenHands CLI | `qtx openhands` | OpenHands 开源软件开发 Agent CLI |
 | OpenCode | `qtx opencode` | 开源 AI 编程 CLI |
@@ -246,14 +248,15 @@ quantex schema --json
   "defaultPackageManager": "bun",
   "npmBunUpdateStrategy": "latest-major",
   "selfUpdateChannel": "stable",
-  "selfUpdateRegistry": "https://registry.npmjs.org",
   "networkRetries": 2,
   "networkTimeoutMs": 10000,
   "versionCacheTtlHours": 6
 }
 ```
 
-`selfUpdateRegistry` 只影响 Quantex 自身通过 Bun/npm 执行 `qtx upgrade` 的 registry 选择，不会修改你其他项目的默认安装源。一次性覆盖可使用环境变量 `QTX_SELF_UPDATE_REGISTRY`。
+`defaultPackageManager` 可以是 `bun`、`npm` 或 `mise`。它只会在目标 agent 暴露对应 managed installer 时调整 agent 安装方式排序，不会让 Quantex 自动替你安装缺失的 package manager。
+
+`selfUpdateRegistry` 默认不设置。未设置时，Quantex 自升级会跟随当前 Bun/npm 实际使用的 registry。设置 `selfUpdateRegistry` 后，它只影响 Quantex 自身通过 Bun/npm 执行 `qtx upgrade` 的 registry 选择，不会修改你其他项目的默认安装源。一次性覆盖可使用环境变量 `QTX_SELF_UPDATE_REGISTRY`。
 
 运行时状态位于 `~/.quantex/state.json`。Quantex 会记录 agent 和自身的实际安装来源，用于 `update --all` 分组更新、`doctor` 恢复建议和 self upgrade 来源判断。
 

--- a/openspec/changes/update-readme-docs/.openspec.yaml
+++ b/openspec/changes/update-readme-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/update-readme-docs/design.md
+++ b/openspec/changes/update-readme-docs/design.md
@@ -1,0 +1,22 @@
+## Overview
+
+This is a documentation sync only. The current CLI and catalog already expose the behavior being documented, so implementation is limited to README text and OpenSpec delta coverage.
+
+## Source Of Truth
+
+- Supported agent names come from `bun run dev -- list --json`, which reflects the current catalog and command surface.
+- Configuration defaults come from `src/config/default.ts`.
+- README requirements come from `openspec/specs/product-readme/spec.md`.
+
+## Decisions
+
+- Update both full product README pages, `README.md` and `README.zh-CN.md`, so language variants stay aligned.
+- Keep `README.en.md` as a pointer file because the canonical English product landing page is already `README.md`.
+- Do not add generated README tooling in this change; the update is small and localized.
+- Represent `selfUpdateRegistry` as an optional override in prose instead of placing a fixed npm URL in the default JSON example.
+
+## Non-Goals
+
+- Do not change CLI behavior, schemas, package-manager behavior, agent catalog metadata, or release artifacts.
+- Do not expand Quantex into workflow orchestration guidance.
+- Do not introduce new root-level Markdown files.

--- a/openspec/changes/update-readme-docs/proposal.md
+++ b/openspec/changes/update-readme-docs/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The product README has drifted from the current CLI surface: the supported-agent table is missing recently added catalog entries, and the configuration example no longer reflects the built-in defaults. Because README onboarding is a product-facing contract, the update needs an OpenSpec-backed documentation change.
+
+## What Changes
+
+- Refresh `README.md` and `README.zh-CN.md` so supported-agent references match the current CLI catalog.
+- Correct configuration examples and prose so `selfUpdateRegistry` is documented as optional and unset by default.
+- Keep the README guidance aligned with existing `qtx` / `quantex`, agent skill, no-install, and mise installer expectations.
+- No CLI behavior, schemas, install providers, or package dependencies change.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `product-readme`: clarify that product README examples must reflect current agent catalog entries and built-in configuration defaults.
+
+## Impact
+
+- Affected files: product README docs and the `product-readme` OpenSpec delta for this change.
+- Validation: docs/OpenSpec checks plus the repository baseline lint, format check, typecheck, and test commands required by the runtime.

--- a/openspec/changes/update-readme-docs/specs/product-readme/spec.md
+++ b/openspec/changes/update-readme-docs/specs/product-readme/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: README Examples Match Current CLI Surface
+
+The root README MUST use command examples and supported-agent references that match the current Quantex CLI surface, including current agent catalog entries and built-in configuration defaults.
+
+#### Scenario: User copies a README command
+
+- **WHEN** a user copies an install, inspect, ensure, update, upgrade, or execution example from `README.md`
+- **THEN** the command reflects an existing Quantex command or documented alias.
+
+#### Scenario: User reviews supported agents
+
+- **WHEN** a user reads the supported-agent table in `README.md` or `README.zh-CN.md`
+- **THEN** the documented agent names and shortcut commands reflect the current Quantex agent catalog.
+
+#### Scenario: User reviews default configuration
+
+- **WHEN** a user reads the configuration example in `README.md` or `README.zh-CN.md`
+- **THEN** the documented values reflect built-in defaults unless the text explicitly labels a value as an optional override.

--- a/openspec/changes/update-readme-docs/tasks.md
+++ b/openspec/changes/update-readme-docs/tasks.md
@@ -1,0 +1,5 @@
+- [x] 1.1 Verify current README-facing facts from CLI output, source defaults, and existing specs.
+- [x] 1.2 Update `README.md` with current agent catalog entries and configuration default guidance.
+- [x] 1.3 Update `README.zh-CN.md` with equivalent current agent catalog entries and configuration default guidance.
+- [x] 1.4 Update the `product-readme` OpenSpec delta for README catalog/default drift prevention.
+- [x] 1.5 Run required validation and report delivery closure state.


### PR DESCRIPTION
## Summary

Refresh the product README docs so they match the current Quantex CLI catalog and configuration defaults.

- Add Antigravity CLI and MiMoCode to the English and Simplified Chinese supported-agent tables.
- Document mise as a supported agent install provider.
- Remove the fixed `selfUpdateRegistry` value from the default config examples and clarify that it is unset by default.
- Add an OpenSpec change for README catalog/default drift prevention.

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `openspec/changes/update-readme-docs`
- Discussion: none

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

`bun run test` was not required because this change only updates product docs and OpenSpec documentation; no CLI behavior changed.

Additional checks:

- [x] `bun run openspec:validate`
- [x] `git diff --check`
- [x] Compared `bun src/cli.ts list --json` against both README supported-agent tables; both list 33 current catalog agents with no missing or extra entries.

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

Also updated:

- `README.md`
- `README.zh-CN.md`

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

OpenSpec change `update-readme-docs` remains active by design until this implementation PR merges. Archive closure should happen after merge.

## Notes

This is a docs-only sync. The current CLI catalog and `src/config/default.ts` remain the source of truth for the README content.
