### PR TITLE
chore(codegraph): initialize local index metadata

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,0 +1,16 @@
+# CodeGraph data files
+# These are local to each machine and should not be committed
+
+# Database
+*.db
+*.db-wal
+*.db-shm
+
+# Cache
+cache/
+
+# Logs
+*.log
+
+# Hook markers
+.dirty


### PR DESCRIPTION
## Summary

Initialize CodeGraph metadata for this Quantex CLI worktree so agents can build and use the local structural index.

This commits only `.codegraph/.gitignore`; the generated SQLite database, WAL files, cache, logs, and hook markers remain local machine data and are intentionally ignored.

The branch has been rebased onto the latest `origin/main` baseline.

## Linked Artifacts

- Issue: not required - mechanical CodeGraph initialization metadata only
- ADR: not required - no architecture decision
- OpenSpec: not required - no CLI behavior, schema, release, or durable workflow contract change
- Discussion: not required

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed) - not run; no behavior changed
- [ ] Not run, explained below

Additional validation:

- [x] `codegraph init -i`
- [x] `codegraph sync && codegraph status`
- [x] `bun run openspec:validate` (via pre-push)

## Release Intent

- Release: not applicable - local tooling metadata only; no product behavior or distributable artifact changed

## Docs Updated

- [x] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

`codegraph init -i` completed successfully. After rebasing onto the latest baseline, `codegraph sync && codegraph status` reports 327 indexed files, 2,160 nodes, 5,062 edges, and an up-to-date local index.
