### PR TITLE
chore(env): initialize CodeGraph during setup

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -14,3 +14,7 @@ cache/
 
 # Hook markers
 .dirty
+
+# Process IDs and sockets
+*.pid
+*.sock

--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -3,4 +3,17 @@ version = 1
 name = "quantex-cli"
 
 [setup]
-script = "bun install"
+script = '''
+set -euo pipefail
+
+bun install --frozen-lockfile
+codegraph init -i
+'''
+
+[cleanup]
+script = '''
+set -euo pipefail
+
+rm -rf .tmp
+rm -f quantex-*.tgz
+'''

--- a/openspec/changes/initialize-codegraph-environment/.openspec.yaml
+++ b/openspec/changes/initialize-codegraph-environment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-18

--- a/openspec/changes/initialize-codegraph-environment/design.md
+++ b/openspec/changes/initialize-codegraph-environment/design.md
@@ -1,0 +1,33 @@
+## Context
+
+The repository now includes CodeGraph metadata so agents can answer structural code questions through the configured MCP server. Codex environment setup still only installs dependencies with a mutable `bun install`, so a fresh environment can start without an initialized CodeGraph index and can accidentally update dependency resolution.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make Codex environment setup deterministic by enforcing the committed Bun lockfile.
+- Initialize CodeGraph as part of the environment bootstrap so structural exploration tools are ready before task work starts.
+- Keep cleanup limited to local transient files generated during agent work and package smoke checks.
+
+**Non-Goals:**
+
+- Change the Quantex CLI runtime surface, package contents, or user-facing commands.
+- Add new repository workflow orchestration commands.
+- Require contributors outside Codex environments to use CodeGraph.
+
+## Decisions
+
+- Use `bun install --frozen-lockfile` instead of `bun install` in `.codex/environments/environment.toml`.
+  This keeps dependency installation aligned with CI and avoids accidental lockfile churn during environment setup.
+- Run `codegraph init -i` in the setup script.
+  This reuses the existing CodeGraph CLI and local `.codegraph/` metadata instead of adding a repository-specific bootstrap command.
+- Keep cleanup scoped to `.tmp` and `quantex-*.tgz`.
+  These paths are transient agent and package artifacts, and removing them does not affect source, specs, or release artifacts.
+- Ignore CodeGraph PID and socket files under `.codegraph/`.
+  These are runtime coordination artifacts and should not appear as reviewable repository changes.
+
+## Risks / Trade-offs
+
+- `codegraph init -i` depends on the CodeGraph CLI being available in Codex setup environments. The Codex environment should fail early if that tooling is missing instead of starting without the expected structural index.
+- Removing `.tmp` during cleanup discards local PR body drafts and scratch files. Those files are intentionally transient and can be regenerated from committed sources or repository scripts.

--- a/openspec/changes/initialize-codegraph-environment/proposal.md
+++ b/openspec/changes/initialize-codegraph-environment/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Fresh Codex environments should start from the committed lockfile and have the repository CodeGraph index ready before an agent begins structural code exploration. The current setup only runs `bun install`, which allows lockfile drift and leaves CodeGraph initialization as a manual follow-up.
+
+## What Changes
+
+- Run `bun install --frozen-lockfile` in the Codex environment setup script.
+- Initialize CodeGraph during Codex environment setup with `codegraph init -i`.
+- Add Codex environment cleanup for transient `.tmp` files and local package tarballs.
+- Ignore CodeGraph runtime PID and socket files so local indexing state does not pollute git status.
+- No CLI behavior, published package surface, or runtime user command changes.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: define the Codex environment setup and cleanup contract for repository validation tooling and CodeGraph readiness.
+
+## Impact
+
+- Affected files: `.codex/environments/environment.toml`, `.codegraph/.gitignore`, and the `code-quality-tooling` OpenSpec delta for this change.
+- Validation: repository baseline validation, OpenSpec validation, project-memory validation, and direct execution of the new setup commands.

--- a/openspec/changes/initialize-codegraph-environment/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/initialize-codegraph-environment/specs/code-quality-tooling/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Codex environment setup MUST prepare deterministic validation tooling
+
+The repository's Codex environment setup SHALL install Bun dependencies with the committed lockfile enforced and SHALL initialize CodeGraph before agent task work begins. The setup contract MUST NOT modify source files, dependency manifests, or lockfiles when the committed dependency graph is already valid.
+
+#### Scenario: Codex environment setup runs
+
+- **WHEN** a Codex environment executes the repository setup script
+- **THEN** it runs Bun dependency installation with frozen lockfile semantics
+- **AND** it initializes the repository CodeGraph index
+- **AND** a valid committed dependency graph remains unchanged
+
+### Requirement: Codex environment cleanup MUST remove transient local artifacts
+
+The repository's Codex environment cleanup SHALL remove transient scratch and package-smoke artifacts that are not source-of-truth repository files. CodeGraph runtime PID and socket files MUST be ignored by git so local indexing coordination state does not appear as reviewable source changes.
+
+#### Scenario: Codex environment cleanup runs
+
+- **WHEN** a Codex environment executes the repository cleanup script
+- **THEN** it removes local `.tmp` scratch files
+- **AND** it removes local `quantex-*.tgz` package tarballs
+- **AND** source files, OpenSpec artifacts, and release source-of-truth files remain outside the cleanup scope
+
+#### Scenario: CodeGraph runtime state changes
+
+- **WHEN** CodeGraph creates local process ID or socket files under `.codegraph/`
+- **THEN** git ignores those runtime files
+- **AND** they do not appear in the tracked review diff

--- a/openspec/changes/initialize-codegraph-environment/tasks.md
+++ b/openspec/changes/initialize-codegraph-environment/tasks.md
@@ -1,0 +1,13 @@
+## 1. Environment Setup
+
+- [x] 1.1 Update Codex environment setup to run Bun install with frozen lockfile semantics.
+- [x] 1.2 Initialize CodeGraph during Codex environment setup.
+- [x] 1.3 Add Codex environment cleanup for transient scratch and package tarball artifacts.
+- [x] 1.4 Ignore CodeGraph runtime PID and socket files.
+
+## 2. Validation And Delivery
+
+- [x] 2.1 Run repository baseline validation: `bun run lint`, `bun run format:check`, and `bun run typecheck`.
+- [x] 2.2 Run workflow and project-memory validation: `bun run openspec:validate` and `bun run memory:check`.
+- [x] 2.3 Directly verify the setup commands with `bun install --frozen-lockfile` and `codegraph init -i`.
+- [x] 2.4 Commit, push, validate the PR body, and open the implementation PR.


### PR DESCRIPTION
## Summary

Configure the Codex environment setup to install dependencies with the lockfile enforced and initialize CodeGraph metadata automatically. Add cleanup for transient local artifacts and ignore CodeGraph runtime PID/socket files.

## Linked Artifacts

- Issue: not applicable
- ADR: not applicable
- OpenSpec: `initialize-codegraph-environment`
- Discussion: not applicable

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [x] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Additional validation:

- `bun run openspec:validate`
- `bun run openspec:status -- --change initialize-codegraph-environment`
- `bun install --frozen-lockfile`
- `codegraph init -i`

`bun run test` was not run because this changes Codex environment setup/cleanup only, not CLI behavior or runtime contracts.
