### PR TITLE
fix(uninstall): explain unmanaged agent uninstall targets

### DIFF
--- a/openspec/changes/fix-uninstall-unmanaged-feedback/.openspec.yaml
+++ b/openspec/changes/fix-uninstall-unmanaged-feedback/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-03

--- a/openspec/changes/fix-uninstall-unmanaged-feedback/design.md
+++ b/openspec/changes/fix-uninstall-unmanaged-feedback/design.md
@@ -1,0 +1,33 @@
+## Context
+
+`uninstallCommand()` resolves an agent, then calls `uninstallAgent()`. `uninstallAgent()` returns `false` both when no managed installed-state record exists and when a managed uninstall command fails. The command layer therefore cannot distinguish an external installer from a failed managed uninstall.
+
+`inspectCommand()` already exposes the same user-facing distinction through `inspection.lifecycle` and `capabilities.canAutoUninstall`, but using full inspection for uninstall preflight would introduce PATH and network work into a command that only needs to know whether Quantex has a managed state record.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give unmanaged or untracked uninstall targets a stable structured error distinct from managed uninstall execution failures.
+- Keep human output actionable and direct users to inspect details without guessing platform-specific cleanup state.
+- Let lifecycle commands resolve a displayed agent name such as `Qoder CLI`.
+- Preserve existing successful managed uninstall behavior.
+
+**Non-Goals:**
+
+- Automatically remove files installed by external installers.
+- Add platform-specific manual cleanup automation.
+- Change install, update, inspect, or run behavior beyond shared agent lookup.
+- Change command catalog shape or global exit-code mapping.
+
+## Decisions
+
+- `uninstallCommand()` will read `getInstalledAgentState(agent.name)` before non-dry-run uninstall execution. If the record is missing, it returns `UNINSTALL_UNMANAGED` and does not call `uninstallAgent()`.
+- Dry-run uninstall for an untracked agent will use the same unmanaged error classification, because the operation still cannot be planned as an auto-uninstall.
+- The unmanaged error details will include the canonical agent name, display name, lifecycle `unmanaged`, `canAutoUninstall: false`, and the original input.
+- `getAgentByLookupName()` will match a normalized display name after canonical names and aliases. Matching will be case-insensitive for display names only, preserving exact slug and alias behavior.
+
+## Risks / Trade-offs
+
+- [Risk] Display names are human-facing and may change. -> Acceptable for command ergonomics because canonical names and aliases remain the stable machine contract.
+- [Risk] Missing managed state can also mean stale state after manual deletion. -> Still an unmanaged/untracked uninstall target from Quantex's perspective; `inspect` remains the detailed diagnostic path.

--- a/openspec/changes/fix-uninstall-unmanaged-feedback/proposal.md
+++ b/openspec/changes/fix-uninstall-unmanaged-feedback/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`qtx uninstall qodercli` currently collapses an unmanaged external installation into the generic `UNINSTALL_FAILED` path even though `inspect` can report that Quantex cannot auto-uninstall it. Users also see `Qoder CLI` in list output but cannot use that displayed name as an uninstall target.
+
+## What Changes
+
+- Short-circuit `uninstall` before invoking package-manager removal when Quantex has no managed installed-state record for a resolved agent.
+- Return a dedicated structured error code for unmanaged or untracked uninstall targets, with a human message that explains the blocker and points users to `qtx inspect <agent>`.
+- Allow agent lookup by display name in addition to canonical name and lookup aliases, so displayed agent names remain valid lifecycle targets.
+- Keep the existing `UNINSTALL_FAILED` code for genuine managed uninstall attempts that fail after Quantex has a managed installed-state record.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-uninstall`: uninstall command behavior, structured errors, and managed-state preflight semantics.
+
+### Modified Capabilities
+
+- `agent-catalog`: stable agent identification includes display-name lookup for lifecycle command resolution.
+
+## Impact
+
+- Affected code: `src/commands/uninstall.ts`, `src/agents/index.ts`, related command and registry tests.
+- Structured output gains a distinct `UNINSTALL_UNMANAGED` error code for callers that need to branch on unmanaged uninstall targets.
+- No dependency, package, or release workflow changes.

--- a/openspec/changes/fix-uninstall-unmanaged-feedback/specs/agent-catalog/spec.md
+++ b/openspec/changes/fix-uninstall-unmanaged-feedback/specs/agent-catalog/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Supported agent catalog entries MUST stay lifecycle-focused
+
+Quantex SHALL keep supported agent catalog metadata scoped to values that directly support installation, inspection, resolution, execution, update planning, and stable machine-readable contracts.
+
+#### Scenario: Resolving a displayed agent name
+
+- GIVEN a supported agent entry has a `displayName`
+- WHEN a lifecycle command receives that display name as its agent input
+- THEN Quantex resolves the input to the same supported agent as the canonical name
+- AND canonical names and lookup aliases remain valid lookup keys

--- a/openspec/changes/fix-uninstall-unmanaged-feedback/specs/agent-uninstall/spec.md
+++ b/openspec/changes/fix-uninstall-unmanaged-feedback/specs/agent-uninstall/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Uninstall MUST distinguish unmanaged targets from execution failures
+
+Quantex SHALL report a resolved-but-unmanaged uninstall target with a stable structured error distinct from a failed managed uninstall attempt.
+
+#### Scenario: Uninstalling a resolved agent without managed state
+
+- GIVEN a supported agent resolves from the uninstall input
+- AND Quantex has no managed installed-state record for that agent
+- WHEN the user runs `qtx uninstall <agent>`
+- THEN Quantex returns `{ ok: false, error: { code: "UNINSTALL_UNMANAGED", ... } }` in structured output mode
+- AND the human output explains that Quantex cannot auto-uninstall the agent because it is unmanaged or untracked
+- AND the operation does not invoke package-manager uninstall execution
+- AND the message points the user to `qtx inspect <agent>` for details
+
+#### Scenario: Managed uninstall execution still fails generically
+
+- GIVEN a supported agent resolves from the uninstall input
+- AND Quantex has a managed installed-state record for that agent
+- WHEN managed uninstall execution fails
+- THEN Quantex keeps returning `UNINSTALL_FAILED`
+- AND the result remains distinguishable from `UNINSTALL_UNMANAGED`

--- a/openspec/changes/fix-uninstall-unmanaged-feedback/tasks.md
+++ b/openspec/changes/fix-uninstall-unmanaged-feedback/tasks.md
@@ -1,0 +1,15 @@
+## 1. Specification
+
+- [x] 1.1 Create OpenSpec proposal, design, and spec deltas for unmanaged uninstall feedback and display-name resolution.
+
+## 2. Implementation
+
+- [x] 2.1 Add failing tests for unmanaged uninstall output and display-name lookup.
+- [x] 2.2 Implement unmanaged uninstall preflight with `UNINSTALL_UNMANAGED`.
+- [x] 2.3 Implement display-name lookup for supported agents.
+- [x] 2.4 Keep managed uninstall failure behavior on `UNINSTALL_FAILED`.
+
+## 3. Validation
+
+- [x] 3.1 Run focused tests for uninstall and registry lookup.
+- [x] 3.2 Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run test`, and `bun run openspec:validate`.

--- a/src/agents/index.ts
+++ b/src/agents/index.ts
@@ -8,7 +8,11 @@ export function getAllAgents(): AgentDefinition[] {
 }
 
 export function getAgentByLookupName(name: string): AgentDefinition | undefined {
-  return agents.find(agent => agent.name === name || (agent.lookupAliases?.includes(name) ?? false))
+  const directMatch = agents.find(agent => agent.name === name || (agent.lookupAliases?.includes(name) ?? false))
+  if (directMatch) return directMatch
+
+  const normalizedDisplayName = normalizeDisplayName(name)
+  return agents.find(agent => normalizeDisplayName(agent.displayName) === normalizedDisplayName)
 }
 
 export function getAgentByNameOrAlias(name: string): AgentDefinition | undefined {
@@ -67,3 +71,7 @@ export type {
   Platform,
   ScriptInstallMethod,
 } from './types'
+
+function normalizeDisplayName(name: string): string {
+  return name.trim().toLowerCase()
+}

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,3 +1,4 @@
+import type { AgentDefinition } from '../agents'
 import type { CommandResult } from '../output/types'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
 import { uninstallAgent } from '../package-manager'
@@ -38,32 +39,12 @@ export async function uninstallCommand(agentName: string): Promise<CommandResult
     )
   }
 
-  if (isDryRunEnabled()) {
-    const installedState = await getInstalledAgentState(agent.name)
-    if (!installedState) {
-      return emitCommandResult(
-        createErrorResult<UninstallCommandData>({
-          action: 'uninstall',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: false,
-          },
-          error: {
-            code: 'UNINSTALL_FAILED',
-            message: `Failed to uninstall ${agent.displayName}.`,
-          },
-          target: {
-            kind: 'agent',
-            name: agent.name,
-          },
-        }),
-        renderUninstallHuman,
-      )
-    }
+  const installedState = await getInstalledAgentState(agent.name)
+  if (!installedState) {
+    return emitCommandResult(createUnmanagedUninstallResult(agentName, agent), renderUninstallHuman)
+  }
 
+  if (isDryRunEnabled()) {
     return emitCommandResult(
       createSuccessResult<UninstallCommandData>({
         action: 'uninstall',
@@ -157,6 +138,34 @@ export async function uninstallCommand(agentName: string): Promise<CommandResult
     }),
     renderUninstallHuman,
   )
+}
+
+function createUnmanagedUninstallResult(agentName: string, agent: AgentDefinition) {
+  return createErrorResult<UninstallCommandData>({
+    action: 'uninstall',
+    data: {
+      agent: {
+        displayName: agent.displayName,
+        name: agent.name,
+      },
+      changed: false,
+    },
+    error: {
+      code: 'UNINSTALL_UNMANAGED',
+      details: {
+        canAutoUninstall: false,
+        displayName: agent.displayName,
+        input: agentName,
+        lifecycle: 'unmanaged',
+        name: agent.name,
+      },
+      message: `${agent.displayName} is not managed by qtx, so qtx cannot auto-uninstall it. Run qtx inspect ${agent.name} for details.`,
+    },
+    target: {
+      kind: 'agent',
+      name: agent.name,
+    },
+  })
 }
 
 function renderUninstallHuman(result: {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -13,6 +13,7 @@ export const cliErrorCodes = [
   'STATE_READ_ERROR',
   'TIMEOUT',
   'UNINSTALL_FAILED',
+  'UNINSTALL_UNMANAGED',
   'UPDATE_FAILED',
   'UPGRADE_FAILED',
 ] as const

--- a/test/commands/uninstall.test.ts
+++ b/test/commands/uninstall.test.ts
@@ -30,6 +30,12 @@ const testAgent = {
   },
 }
 
+const managedInstalledState = {
+  agentName: 'test-agent',
+  installType: 'bun' as const,
+  packageName: 'test-pkg',
+}
+
 describe('uninstallCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
@@ -55,6 +61,7 @@ describe('uninstallCommand', () => {
 
   it('calls uninstallAgent and shows success', async () => {
     agentSpy.mockReturnValue(testAgent)
+    installedStateSpy.mockResolvedValue(managedInstalledState)
     uninstallSpy.mockResolvedValue(true)
     await uninstallCommand('test-agent')
     expect(uninstallSpy).toHaveBeenCalledWith(testAgent)
@@ -63,13 +70,40 @@ describe('uninstallCommand', () => {
 
   it('shows failure message', async () => {
     agentSpy.mockReturnValue(testAgent)
+    installedStateSpy.mockResolvedValue(managedInstalledState)
     uninstallSpy.mockResolvedValue(false)
-    await uninstallCommand('test-agent')
+    const result = await uninstallCommand('test-agent')
+    expect(result.error?.code).toBe('UNINSTALL_FAILED')
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to uninstall'))
+  })
+
+  it('returns unmanaged uninstall error when the agent has no managed installed state', async () => {
+    setCliContext({
+      interactive: false,
+      outputMode: 'human',
+      runId: 'unmanaged-id',
+    })
+    agentSpy.mockReturnValue(testAgent)
+    installedStateSpy.mockResolvedValue(undefined)
+
+    const result = await uninstallCommand('test-agent')
+
+    expect(result.error?.code).toBe('UNINSTALL_UNMANAGED')
+    expect(result.error?.details).toMatchObject({
+      canAutoUninstall: false,
+      displayName: 'Test Agent',
+      input: 'test-agent',
+      lifecycle: 'unmanaged',
+      name: 'test-agent',
+    })
+    expect(uninstallSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('cannot auto-uninstall'))
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('qtx inspect test-agent'))
   })
 
   it('returns a stable conflict when another lifecycle operation already holds the lock', async () => {
     agentSpy.mockReturnValue(testAgent)
+    installedStateSpy.mockResolvedValue(managedInstalledState)
     uninstallSpy.mockRejectedValue(new ResourceLockError('agent lifecycle', '/tmp/agent-lifecycle.lock'))
 
     const result = await uninstallCommand('test-agent')
@@ -97,6 +131,22 @@ describe('uninstallCommand', () => {
     expect(result.ok).toBe(true)
     expect(result.data?.changed).toBe(false)
     expect(result.warnings[0]?.code).toBe('DRY_RUN')
+    expect(uninstallSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns the unmanaged error in dry-run mode when the agent has no managed installed state', async () => {
+    setCliContext({
+      dryRun: true,
+      interactive: false,
+      outputMode: 'json',
+      runId: 'dry-run-unmanaged-id',
+    })
+    agentSpy.mockReturnValue(testAgent)
+    installedStateSpy.mockResolvedValue(undefined)
+
+    const result = await uninstallCommand('test-agent')
+
+    expect(result.error?.code).toBe('UNINSTALL_UNMANAGED')
     expect(uninstallSpy).not.toHaveBeenCalled()
   })
 })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -106,6 +106,11 @@ describe('agent registry', () => {
     expect(agent?.name).toBe('qoder')
   })
 
+  it('resolves Qoder by display name', () => {
+    const agent = getAgentByNameOrAlias('Qoder CLI')
+    expect(agent?.name).toBe('qoder')
+  })
+
   it('resolves Reasonix by repository-style alias', () => {
     const agent = getAgentByLookupName('deepseek-reasonix')
     expect(agent?.name).toBe('reasonix')


### PR DESCRIPTION
## Summary

Fixes issue #408 by giving unmanaged or untracked uninstall targets a dedicated error path instead of collapsing them into generic uninstall failure. Also lets lifecycle commands resolve agents by their displayed name, so `Qoder CLI` maps to the canonical `qoder` entry.

## Linked Artifacts

- Issue: Fixes #408
- ADR:
- OpenSpec: `openspec/changes/fix-uninstall-unmanaged-feedback`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

`UNINSTALL_FAILED` is preserved for managed uninstall execution failures. `UNINSTALL_UNMANAGED` is only used when the agent resolves but Quantex has no managed installed-state record to uninstall from.
