### PR TITLE
chore(claude): discover quantex-agent-runtime skill via symlink to central runtime

### DIFF
--- a/.claude/skills/quantex-agent-runtime
+++ b/.claude/skills/quantex-agent-runtime
@@ -1,0 +1,1 @@
+../../skills/quantex-agent-runtime

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ logs
 node_modules
 tmp
 temp
+# Claude Code local worktree state (the tracked skill entry lives at .claude/skills/)
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Add `.claude/skills/quantex-agent-runtime` as a symlink to `skills/quantex-agent-runtime/` (the central contributor runtime) so Claude Code can discover the `quantex-agent-runtime` skill. Claude Code only scans `.claude/skills/`, `~/.claude/skills/`, and plugin directories — not `.agents/`, `.codex/`, or `.github/skills/` — so without this entry the skill is invisible to Claude Code.

The symlink replaces what would otherwise be a fourth near-identical bootstrap copy. The bootstraps under `.agents/`, `.codex/`, and `.github/skills/` self-describe as routers to the central runtime; pointing Claude Code directly at the central runtime satisfies discovery without duplicating that routing layer.

Also gitignore `.claude/worktrees/` so local Claude Code worktree state is not accidentally committed alongside the tracked skill entry.

## Linked Artifacts

- Issue:
- ADR: 0005-keep-agents-as-a-thin-execution-handbook (route-to-source-of-truth principle; the same anti-duplication intent applied to the skill bootstrap layer)
- OpenSpec:
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - tooling/config change (skill discovery symlink + gitignore); no user-facing product behavior changed.

## Docs Updated

- [x] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [ ] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- Validation: `memory:check`, `lint`, `format:check`, and `typecheck` all pass locally. `test` was not run — no product/behavior code changed (only `.gitignore` and a symlink).
- No doc update is required for correctness: `docs/skill-installation-and-distribution.md` explicitly scopes the contributor runtime out, and no doc enumerates the per-agent skill directories.
- The symlink target is relative (`../../skills/quantex-agent-runtime`), so it resolves correctly in any clone location and inside git worktrees. On Windows it requires `core.symlinks=true` plus Developer Mode; otherwise it checks out as a plain text file and skill discovery fails there.
- Relationship to `AGENTS.md:33` ("各 agent 目录只保留薄 bootstrap"): the symlink honors that line's anti-duplication intent (no full runtime is copied into an agent dir) but uses a direct symlink to the central runtime instead of a thin bootstrap file. Codifying the symlink alternative in `AGENTS.md` or ADR 0005 is left as an optional follow-up for reviewer decision rather than done here.
- The other agent dirs (`.agents/`, `.codex/`, `.github/skills/`) are intentionally unchanged in this PR; they could be converted to the same single-source pattern in a separate follow-up.
