### PR TITLE
docs(project-memory): align agent-support docs with current catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Install, inspect, update, uninstall, and run AI coding assistant CLIs from one a
 
 </div>
 
-Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding assistants and terminal coding agents. Use one `qtx` surface to install, inspect, update, uninstall, run, and automate Codex CLI, Claude Code, Gemini CLI, Cursor CLI, OpenCode, Antigravity CLI, MiMoCode, Amp, Kilo CLI, and other assistant CLIs with stable machine-readable output. This README uses the shorter `qtx` form as the recommended entry point, while `quantex` remains the fully equivalent long command name.
+Quantex is a `human-friendly + agent-friendly` lifecycle CLI for AI coding assistants and terminal coding agents. Use one `qtx` surface to install, inspect, update, uninstall, run, and automate Codex CLI, Claude Code, Gemini CLI, Cursor CLI, OpenCode, Antigravity CLI, Command Code, MiMoCode, Amp, Kilo CLI, and other assistant CLIs with stable machine-readable output. This README uses the shorter `qtx` form as the recommended entry point, while `quantex` remains the fully equivalent long command name.
 
 ## Why Quantex
 
@@ -184,6 +184,7 @@ Note: `qtx upgrade` follows the registry actually used by the current Bun/npm se
 | Claude Code | `qtx claude` | Anthropic's official AI coding assistant CLI |
 | CodeBuddy Code | `qtx codebuddy` | Tencent's official AI coding assistant CLI |
 | Codex CLI | `qtx codex` | OpenAI's official AI coding assistant CLI |
+| Command Code | `qtx commandcode` | Command Code's AI coding assistant CLI |
 | Crush | `qtx crush` | Charmbracelet's terminal AI coding agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI coding assistant CLI |
 | Deep Code CLI | `qtx deepcode` | Deep Code's terminal coding agent CLI |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,7 @@
 
 </div>
 
-Quantex 是一个 `human-friendly + agent-friendly` 的 AI 编程助手 CLI lifecycle manager。它帮你把 Codex CLI、Claude Code、Gemini CLI、Cursor CLI、OpenCode、Antigravity CLI、MiMoCode、Amp、Kilo CLI 等终端 coding agent 的安装、检查、更新、卸载、启动和自动化调用统一到一组稳定命令里：人可以直接用，脚本和 coding agent 也可以通过结构化输出可靠调用。本文默认使用更短的 `qtx` 作为推荐入口，`quantex` 是完全等价的完整命令名。
+Quantex 是一个 `human-friendly + agent-friendly` 的 AI 编程助手 CLI lifecycle manager。它帮你把 Codex CLI、Claude Code、Gemini CLI、Cursor CLI、OpenCode、Antigravity CLI、Command Code、MiMoCode、Amp、Kilo CLI 等终端 coding agent 的安装、检查、更新、卸载、启动和自动化调用统一到一组稳定命令里：人可以直接用，脚本和 coding agent 也可以通过结构化输出可靠调用。本文默认使用更短的 `qtx` 作为推荐入口，`quantex` 是完全等价的完整命令名。
 
 ## 为什么用 Quantex
 
@@ -184,6 +184,7 @@ qtx upgrade --channel beta
 | Claude Code | `qtx claude` | Anthropic 官方 AI 编程助手 CLI |
 | CodeBuddy Code | `qtx codebuddy` | 腾讯官方 AI 编程助手 CLI |
 | Codex CLI | `qtx codex` | OpenAI 官方 AI 编程助手 CLI |
+| Command Code | `qtx commandcode` | Command Code AI 编程助手 CLI |
 | Crush | `qtx crush` | Charmbracelet 终端 AI 编程 Agent CLI |
 | Cursor CLI | `qtx cursor` | Cursor AI 编程助手命令行工具 |
 | Deep Code CLI | `qtx deepcode` | Deep Code 终端编程 Agent CLI |

--- a/docs/agent-support-matrix.md
+++ b/docs/agent-support-matrix.md
@@ -1,12 +1,16 @@
 # Agent Support Matrix
 
-This page defines the review format for Quantex agent-support coverage. It is a documentation and planning aid, not the runtime source of truth.
+This page defines the review format and current live-doc handoff for Quantex agent-support coverage. It is a documentation and planning aid, not the runtime source of truth.
 
-## Source Of Truth
+## Current Surfaces
 
-- `supported` entries must match validated per-agent catalog data in `src/agents/catalog/*.json`.
-- `in-progress` entries should point to an active OpenSpec change when one exists.
-- `candidate` and `excluded` entries are evaluation states only; they do not create product guarantees.
+- `supported` entries come from validated per-agent catalog data in `src/agents/catalog/*.json` and can be verified with `bun run dev -- list --json`.
+- Unsupported-candidate triage lives in GitHub issue [#134](https://github.com/Drswith/quantex-cli/issues/134). Keep per-agent implementation work in dedicated issues and OpenSpec changes; keep `#134` as the top-level backlog index until a successor issue is explicitly declared.
+- Historical records under `openspec/changes/archive/`, `docs/sessions/`, `docs/postmortems/`, and `docs/archive/` remain point-in-time artifacts and should not be rewritten as the current support matrix.
+
+## Current Supported Canonical Slugs
+
+`amp`, `antigravity`, `auggie`, `autohand`, `claude`, `codebuddy`, `codewhale`, `codex`, `commandcode`, `copilot`, `crush`, `cursor`, `deepcode`, `devin`, `droid`, `forgecode`, `gemini`, `genie`, `goose`, `hermes`, `jcode`, `junie`, `kilo`, `kimi`, `kiro`, `mimo`, `omp`, `openclaw`, `opencode`, `openhands`, `pi`, `qoder`, `qwen`, `reasonix`, `vibe`, `vtcode`
 
 ## Required Fields
 
@@ -45,14 +49,15 @@ Exception rule:
 | Product | Canonical slug | Binary command | Aliases | Status | Notes |
 |---|---|---|---|---|---|
 | Claude Code | `claude` | `claude` | - | `supported` | Default rule: branded product and executable already match. |
-| GitHub Copilot CLI | `copilot` | `copilot` | - | `supported` | Quantex identifier follows the executable command. |
+| Command Code | `commandcode` | `command-code` | `command-code`, `cmd`, `cmdc` | `supported` | Quantex keeps a product-specific slug while the upstream binary keeps its hyphenated command. |
 | Cursor CLI | `cursor` | `agent` | `agent` | `supported` | Exception rule: `agent` is too generic to use as the primary Quantex slug. |
-| Crush | `crush` | `crush` | - | `in-progress` | Track through the active OpenSpec change while implementation is unfinished. |
+| Bob | `bob` | `bob` | - | `candidate` | Has a CLI, but support should not start until backlog triage is ready for implementation. |
 | Warp | `warp` | `warp` | - | `excluded` | Terminal product rather than a Quantex-style lifecycle agent CLI. |
 
 ## Maintenance Notes
 
 - Prefer updating this page together with any catalog naming or support-status decisions.
-- Do not copy long installer details here; keep the matrix focused on identity and support state.
+- Keep candidate and excluded rationale in issue `#134` or an explicitly linked successor issue instead of duplicating a second long-lived backlog table here.
+- Do not copy long installer details here; keep the matrix focused on identity, review fields, and where to find the live backlog.
 - After adding, removing, or renaming a catalog JSON file, run `bun run agent-catalog:generate` and commit the generated manifest/schema changes.
-- If support-matrix maintenance becomes noisy, follow up with automation that derives supported rows from `src/agents/catalog/*.json`.
+- If a supported-agent snapshot changes, update this page, the README tables, `skills/quantex-cli/references/command-recipes.md`, and issue `#134` in the same branch when backlog meaning changes.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -34,6 +34,15 @@ Use the repository for:
 7. Update any affected runbooks, specs, or ADRs; if an OpenSpec change lands, merge its delta into `openspec/specs/` and archive or close the change.
 8. Treat "implementation merged" and "OpenSpec archived" as separate closure steps; a non-trivial change is not fully done until a Superpowers/Quantex-runtime archive follow-up reaches PR or merge delivery.
 
+## Top-level backlog issues
+
+Use a single top-level backlog issue when a workstream needs planning-only triage across many candidates, such as agent-catalog expansion.
+
+- keep the top-level issue as planning and triage only; supported state still lives in repo-native catalog/spec/docs artifacts
+- open a dedicated per-agent issue once implementation becomes actionable
+- pair that per-agent issue with OpenSpec when catalog behavior, product-facing docs, or durable workflow expectations change
+- keep delivered candidates checked in their original triage bucket or a documented delivered section so backlog history stays meaningful
+
 ## Delivery closure states
 
 Use explicit closure language when handing work between agents, reviewers, and automation:

--- a/docs/skill-installation-and-distribution.md
+++ b/docs/skill-installation-and-distribution.md
@@ -35,6 +35,8 @@ When the Quantex CLI behavior changes, update the relevant canonical project-mem
 
 Then update the skill files so they reflect the same contract.
 
+If a skill reference keeps a maintained supported-agent snapshot, verify it against `bun run dev -- list --json` and the current `src/agents/catalog/*.json` set in the same branch.
+
 The contributor-facing runtime lives separately under `skills/quantex-agent-runtime/`. Use it when working inside this repository with Superpowers, OpenSpec intake, validation, and delivery closure rules. Do not document it as the default skill for users who only want to operate Quantex.
 
 ## Installation model
@@ -102,6 +104,7 @@ Run this after updating:
 - JSON envelope or schema behavior
 - lifecycle command expectations in the skill
 - skill references that describe structured usage
+- skill references that enumerate supported agent names
 
 ## Update flow
 

--- a/openspec/changes/update-md-docs-and-agent-backlog/.openspec.yaml
+++ b/openspec/changes/update-md-docs-and-agent-backlog/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/update-md-docs-and-agent-backlog/design.md
+++ b/openspec/changes/update-md-docs-and-agent-backlog/design.md
@@ -1,0 +1,24 @@
+## Overview
+
+This is a documentation and backlog-tracking sync only. The CLI already supports the agents being documented, so the work is to realign active Markdown surfaces and the top-level GitHub backlog issue with existing source-of-truth artifacts.
+
+## Source Of Truth
+
+- Supported agent identities come from `src/agents/catalog/*.json`.
+- The current runnable support snapshot can be verified with `bun run dev -- list --json`.
+- Existing README expectations come from `openspec/specs/product-readme/spec.md`.
+- Durable docs/process alignment comes from `openspec/specs/project-memory/spec.md`.
+- Unsupported-candidate triage remains in GitHub issue `#134` until a successor issue is explicitly declared.
+
+## Decisions
+
+- Update active docs first and leave historical archives as point-in-time records.
+- Keep issue `#134` as the planning-only top-level agent-catalog backlog rather than splitting it into another repo-local tracker.
+- Make `docs/agent-support-matrix.md` point clearly at the supported catalog and the backlog issue instead of duplicating long candidate ledgers.
+- Keep the skill-facing support snapshot in `skills/quantex-cli/references/command-recipes.md`, but require it to stay aligned with the live catalog and discovery commands.
+
+## Non-Goals
+
+- Do not change CLI behavior, output schemas, install/update logic, or release automation.
+- Do not rewrite archived OpenSpec changes, session summaries, postmortems, or legacy archive notes into current-state docs.
+- Do not introduce generated Markdown tooling in this change.

--- a/openspec/changes/update-md-docs-and-agent-backlog/proposal.md
+++ b/openspec/changes/update-md-docs-and-agent-backlog/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Active Markdown surfaces have drifted from the current Quantex agent catalog after recent support additions. The product README pages, skill-facing support snapshot, and top-level backlog issue no longer tell the same supported-vs-candidate story, which weakens onboarding and backlog triage.
+
+## What Changes
+
+- Refresh `README.md` and `README.zh-CN.md` so supported-agent references and tables match the current catalog, including Command Code.
+- Update active support-tracking docs such as `docs/agent-support-matrix.md`, `docs/github-collaboration.md`, and `skills/quantex-cli/` references so they point at the correct supported-catalog and backlog sources of truth.
+- Rewrite GitHub issue `#134` so the candidate ledger and active backlog reflect the currently delivered agent-support work.
+- Do not change CLI behavior, schemas, install methods, package metadata, or release workflow behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `project-memory`: document how active agent-support docs and the top-level backlog issue stay aligned with `src/agents/catalog/*.json` and current catalog-triage policy.
+
+## Impact
+
+- Affected files: active README/docs/skill Markdown surfaces plus the `project-memory` OpenSpec delta for agent-support tracking.
+- Affected external surface: GitHub issue `#134`.
+- Validation: `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run openspec:validate`, `bun run memory:check`, and the Quantex CLI skill smoke check.

--- a/openspec/changes/update-md-docs-and-agent-backlog/specs/project-memory/spec.md
+++ b/openspec/changes/update-md-docs-and-agent-backlog/specs/project-memory/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Active agent-support docs MUST stay aligned with catalog and backlog tracking
+
+Quantex SHALL keep active agent-support Markdown surfaces and their top-level GitHub backlog tracker aligned with the current supported catalog and support-matrix policy. Historical archives MAY preserve point-in-time state and MUST NOT be silently rewritten as current-state support docs.
+
+#### Scenario: Maintainer updates supported-agent docs
+
+- **GIVEN** a supported agent is added, renamed, or removed in `src/agents/catalog/*.json`
+- **WHEN** active docs or skill references enumerate supported agent names or shortcuts
+- **THEN** `README.md`, `README.zh-CN.md`, `docs/agent-support-matrix.md`, and `skills/quantex-cli/references/command-recipes.md` reflect the current catalog entries or explicitly point readers to live CLI discovery commands for exact support
+- **AND** the maintained snapshot does not omit known supported agents
+
+#### Scenario: Maintainer reviews the top-level backlog issue
+
+- **GIVEN** GitHub issue `#134` is the active top-level tracking issue for agent-catalog expansion
+- **WHEN** a candidate moves into supported, active implementation, or exclusion
+- **THEN** the issue keeps planning-only triage separate from repo-native source-of-truth docs and catalog files
+- **AND** delivered candidates remain visible in their original triage bucket or a documented delivered section so backlog history stays meaningful
+- **AND** `docs/agent-support-matrix.md` points unsupported backlog triage at issue `#134` or an explicitly named successor issue
+
+#### Scenario: Agent syncs current docs without rewriting history
+
+- **GIVEN** archived OpenSpec changes, session summaries, postmortems, or files under `docs/archive/`
+- **WHEN** an agent is asked to update the current Markdown docs
+- **THEN** the agent updates active docs and live tracking artifacts first
+- **AND** historical records remain point-in-time snapshots unless the task explicitly asks to correct historical data

--- a/openspec/changes/update-md-docs-and-agent-backlog/tasks.md
+++ b/openspec/changes/update-md-docs-and-agent-backlog/tasks.md
@@ -1,0 +1,6 @@
+- [x] 1.1 Verify current supported-agent facts from `src/agents/catalog/*.json`, `bun run dev -- list --json`, and the active docs/issue surfaces.
+- [x] 1.2 Update `README.md` and `README.zh-CN.md` so supported-agent references match the current catalog.
+- [x] 1.3 Update active support-tracking docs under `docs/` and `skills/quantex-cli/` so supported snapshots and backlog pointers match current policy.
+- [x] 1.4 Update GitHub issue `#134` so delivered candidates and active backlog state match the current catalog rollout.
+- [x] 1.5 Update the `project-memory` OpenSpec delta for active-doc and backlog-tracker alignment.
+- [x] 1.6 Run required validation and report delivery closure state.

--- a/skills/quantex-cli/SKILL.md
+++ b/skills/quantex-cli/SKILL.md
@@ -28,6 +28,7 @@ Reach for this skill when you need to:
 If the environment or command surface is unclear, start with:
 
 ```bash
+quantex list --json
 quantex capabilities --json
 quantex commands --json
 quantex schema --json

--- a/skills/quantex-cli/references/command-recipes.md
+++ b/skills/quantex-cli/references/command-recipes.md
@@ -6,26 +6,33 @@ Use this file when you need concrete Quantex command choices, example invocation
 
 This skill snapshot knows about these Quantex agent names:
 
+- `amp`
+- `antigravity`
 - `auggie`
 - `autohand`
-- `amp`
 - `claude`
 - `codebuddy`
 - `codewhale`
 - `codex`
+- `commandcode`
 - `copilot`
 - `crush`
 - `cursor`
+- `deepcode`
 - `devin`
 - `droid`
 - `forgecode`
 - `gemini`
+- `genie`
 - `goose`
+- `hermes`
 - `jcode`
 - `junie`
 - `kilo`
 - `kimi`
 - `kiro`
+- `mimo`
+- `openclaw`
 - `openhands`
 - `opencode`
 - `omp`
@@ -39,6 +46,7 @@ This skill snapshot knows about these Quantex agent names:
 The running binary remains the source of truth. If you are unsure whether the current binary supports a specific agent, command, flag, or output shape, run:
 
 ```bash
+quantex list --json
 quantex capabilities --json
 quantex commands --json
 ```
@@ -49,6 +57,7 @@ quantex commands --json
 
 ```bash
 quantex list
+quantex list --json
 quantex info codex
 quantex inspect codex --json
 quantex resolve codex --json
@@ -60,6 +69,7 @@ quantex schema --json
 Use:
 
 - `list` for human overview
+- `list --json` for an exact supported-agent inventory
 - `info` for human-friendly details
 - `inspect` for structured state
 - `resolve` for executable path and launch resolution


### PR DESCRIPTION
## Summary

- Refresh `README.md` / `README.zh-CN.md` and skill snapshots so supported-agent references include Command Code and match the current catalog.
- Update active support-tracking docs (`docs/agent-support-matrix.md`, `docs/github-collaboration.md`, `docs/skill-installation-and-distribution.md`, `skills/quantex-cli/`) so live backlog handoff points at issue `#134` and repo-native catalog/spec sources of truth.
- Add OpenSpec change `update-md-docs-and-agent-backlog` with a `project-memory` delta for agent-support doc alignment policy.

## Linked Artifacts

- Issue: https://github.com/Drswith/quantex-cli/issues/134
- ADR:
- OpenSpec: `openspec/changes/update-md-docs-and-agent-backlog`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [x] Not run, explained below

Docs/process-only change; no CLI behavior, schema, or integration logic changed.

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

- Issue `#134` was updated in a prior task step to reflect delivered candidates and current backlog state.
- Archive closure for `update-md-docs-and-agent-backlog` should follow merge via agent-driven OpenSpec archive workflow.
