### PR TITLE
refactor(lifecycle): share install ensure service

### DIFF
--- a/openspec/changes/extract-install-ensure-lifecycle-service/.openspec.yaml
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/extract-install-ensure-lifecycle-service/design.md
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The single-agent paths in `src/commands/install.ts` and `src/commands/ensure.ts` independently perform the same sequence:
+
+1. resolve the catalog agent and inspect the current installation;
+2. classify a managed, safely adoptable, or ambiguous existing installation;
+3. handle dry-run behavior;
+4. track an adopted installation or invoke `installAgent`;
+5. translate cancellation and lifecycle lock failures;
+6. construct command-specific structured output and render human output.
+
+The duplication has already accumulated subtle differences, including the install command's pre-start cancellation check and different event-emission behavior. The project has active users, so this change must preserve those differences where they are part of the current contract rather than replacing both commands with a new public model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish compatibility tests for the published single-agent install and ensure behavior.
+- Move shared inspection, adoption, dry-run, tracking, installation, and lock classification into one focused service.
+- Keep command-specific output, messages, events, batch aggregation, and rendering at the command boundary.
+- Make the shared lifecycle flow directly testable without invoking the Commander CLI.
+- Reduce the size and change surface of both command handlers without changing persisted state or public contracts.
+
+**Non-Goals:**
+
+- Changing command names, flags, aliases, schemas, warning or error codes, exit behavior, or human-facing semantics.
+- Refactoring batch install aggregation.
+- Replacing installer boolean results with richer adapter errors.
+- Changing lifecycle lock scope or concurrency.
+- Refactoring update, uninstall, exec, self-upgrade, catalog loading, configuration, or state formats.
+- Introducing a generic desired-state planner or workflow engine.
+
+## Decisions
+
+### Use a command-neutral discriminated outcome from one shared service
+
+Create `src/services/install-ensure.ts` with a single lifecycle operation that returns a discriminated outcome for the current states: agent not found, already managed, dry-run tracking, tracked existing install, ambiguous unmanaged install, dry-run install, installed, install failed, tracking cancelled, and resource locked.
+
+The outcome contains the resolved agent and installed state only when those facts exist. It does not contain `CommandResult`, action names, warning text, human copy, exit codes, or NDJSON events.
+
+This keeps the service reusable by both commands while preserving each command's existing result mapping.
+
+**Alternatives considered:**
+
+- Return `CommandResult` from a shared helper: rejected because it would move CLI action names and output contracts into the service instead of separating them.
+- Make `ensureCommand` call `installCommand`: rejected because it would emit the wrong action, messages, events, and result metadata.
+- Introduce a generic plan/apply engine now: rejected because it is too broad for the first compatibility-preserving slice.
+
+### Keep command-specific preflight and event policy at the command boundary
+
+`installCommand` keeps its current pre-start cancellation result before calling the shared service. Each command passes a mutation-start callback so the service can signal the point at which tracking or installation is about to mutate state, while the command remains responsible for emitting its current action-specific NDJSON event.
+
+Dry-run and cancellation state are passed explicitly into the service operation rather than making result construction depend on output mode.
+
+This preserves current differences without duplicating lifecycle decisions.
+
+### Preserve package-manager and state behavior unchanged
+
+The service continues to call the existing `resolveAgentInspection`, `getAdoptableExistingInstallMethod`, `trackInstalledAgent`, and `installAgent` functions. It does not alter install method ordering, fallback behavior, rollback, persisted state, or the global lifecycle lock.
+
+Resource lock errors are classified by the service and returned with the original error so each command can construct the same `RESOURCE_LOCKED` details it emits today. Other unexpected errors continue to propagate.
+
+### Treat existing command tests as compatibility tests and add focused service tests
+
+Existing install and ensure command tests remain authoritative for public results and rendering. New service tests cover the shared decision matrix directly. Refactoring proceeds test-first: add a failing service test for one outcome, add the minimum service behavior, migrate one command branch, and keep both command suites green.
+
+No snapshot of timestamps, run IDs, or other intentionally variable metadata is introduced. Compatibility assertions target stable action, target, data, warnings, errors, events, and exit behavior.
+
+## Risks / Trade-offs
+
+- **Risk: The service outcome duplicates some concepts from `CommandResult`.** → Keep it limited to lifecycle facts and do not add output messages, schema metadata, or rendering concerns.
+- **Risk: Moving logic changes a warning, event, or cancellation edge case.** → Lock current behavior with command-level characterization tests before migrating each branch.
+- **Risk: The first slice does not fix installer error opacity or global lock contention.** → Keep those explicitly out of scope; later changes can improve them after this shared boundary exists.
+- **Risk: A mutation-start callback becomes an output backchannel.** → Define it as a zero-argument lifecycle hook and prohibit passing output objects into the service.
+- **Trade-off: Commands retain result-mapping code.** → This is intentional because public compatibility belongs at the command boundary; later duplication can be reconsidered only with separate contract evidence.
+
+## Migration Plan
+
+1. Add missing command-level compatibility cases for stable install and ensure outcomes.
+2. Add focused tests for the new service outcome matrix.
+3. Implement the shared service around the existing inspection, adoption, tracking, and installation functions.
+4. Migrate the single-agent install path to map service outcomes into the existing results.
+5. Migrate ensure to map the same outcomes into its existing results.
+6. Run focused tests, the complete suite, lint, format check, typecheck, and OpenSpec validation.
+
+Rollback requires only restoring the command-local control flow and deleting the new service. There is no configuration, state, catalog, or data migration to reverse.
+
+## Open Questions
+
+None. Rich installer errors, per-agent locking, catalog decoupling, and additional lifecycle commands require separate future OpenSpec changes.

--- a/openspec/changes/extract-install-ensure-lifecycle-service/proposal.md
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`install` and `ensure` currently duplicate the same single-agent inspection, existing-install adoption, dry-run, installation, cancellation, lock-error, and state-result decisions inside separate command handlers. Quantex already has active users, so the first refactor slice must reduce that duplication behind a shared lifecycle boundary while preserving the published CLI and machine-readable contracts.
+
+## What Changes
+
+- Add compatibility-focused tests that lock the current single-agent `install` and `ensure` results for unknown agents, managed and unmanaged existing installs, dry runs, successful installs, failed installs, cancellation, and lifecycle lock failures.
+- Introduce a shared install/ensure lifecycle service that owns command-neutral inspection, adoption, dry-run, and installation decisions.
+- Keep command handlers responsible for action names, command-specific messages, structured result mapping, event emission, batch aggregation, and human rendering.
+- Preserve existing command names, flags, aliases, JSON/NDJSON shapes, warning and error codes, exit behavior, install-source selection, persisted state format, and cancellation semantics.
+- Keep batch install behavior, installer adapter interfaces, lifecycle lock scope, `update`, `uninstall`, `exec`, self-upgrade, and catalog loading outside this first refactor slice.
+- Make no breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `install-ensure-lifecycle-service`: Defines the shared internal lifecycle boundary and the observable compatibility requirements for single-agent `install` and `ensure`.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Primary code: `src/commands/install.ts`, `src/commands/ensure.ts`, and a new focused module under `src/services/`.
+- Existing dependencies: agent inspection, install-method adoption, package-manager installation/tracking, CLI cancellation context, dry-run context, lifecycle lock errors, output result builders, and state persistence.
+- Tests: `test/commands/install.test.ts`, `test/commands/ensure.test.ts`, plus focused service tests.
+- Public APIs, package dependencies, configuration, persisted state, catalog data, release artifacts, and runtime requirements remain unchanged.

--- a/openspec/changes/extract-install-ensure-lifecycle-service/specs/install-ensure-lifecycle-service/spec.md
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/specs/install-ensure-lifecycle-service/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Install and ensure MUST preserve their published contracts during lifecycle service extraction
+
+Quantex MUST preserve the existing single-agent `install` and `ensure` command actions, targets, data fields, warnings, error codes, events, exit behavior, and persisted install state while their shared lifecycle decisions move behind an internal service boundary.
+
+#### Scenario: Unknown agent remains command-specific
+
+- **WHEN** a caller invokes `install` or `ensure` with an unknown agent name
+- **THEN** Quantex returns the existing command action and target
+- **AND** returns the existing `AGENT_NOT_FOUND` error details
+
+#### Scenario: Managed existing install remains a no-op
+
+- **WHEN** the target agent is already available and has recorded Quantex install state
+- **THEN** `install` and `ensure` return success with `changed: false` and `installed: true`
+- **AND** preserve the `ALREADY_INSTALLED` warning
+- **AND** do not run or track an installer
+
+#### Scenario: Safely adoptable existing install remains trackable
+
+- **WHEN** the target agent is already available without recorded state
+- **AND** its supported install source can be safely identified
+- **THEN** a normal `install` or `ensure` invocation records the existing install state
+- **AND** preserves the `TRACKED_EXISTING_INSTALL` warning and install-state data
+
+#### Scenario: Ambiguous existing install remains unmanaged
+
+- **WHEN** the target agent is already available without recorded state
+- **AND** Quantex cannot safely identify one supported install source
+- **THEN** `install` and `ensure` return success without changing state
+- **AND** preserve the `UNTRACKED_EXISTING_INSTALL` warning
+
+#### Scenario: Dry run remains non-mutating
+
+- **WHEN** `install` or `ensure` is invoked in dry-run mode for an adoptable or missing agent
+- **THEN** Quantex preserves the existing successful dry-run result and `DRY_RUN` warning
+- **AND** does not track state or run an installer
+
+#### Scenario: Missing agent uses the existing installation behavior
+
+- **WHEN** the target agent is not available and the invocation is not a dry run
+- **THEN** `install` and `ensure` use the existing install-method ordering and fallback behavior
+- **AND** preserve the existing success data or `INSTALL_FAILED` result
+
+### Requirement: Shared lifecycle extraction MUST preserve cancellation and lock behavior
+
+Quantex MUST preserve the existing cancellation and lifecycle lock behavior of the single-agent `install` and `ensure` commands while centralizing their shared inspection and mutation decisions.
+
+#### Scenario: Tracking cancellation preserves command action
+
+- **WHEN** tracking an adopted existing install is cancelled before state persistence completes
+- **THEN** Quantex returns the existing `CANCELLED` result
+- **AND** the result retains the invoked `install` or `ensure` action and command-specific message
+
+#### Scenario: Lifecycle lock failure preserves structured details
+
+- **WHEN** tracking or installation cannot acquire the lifecycle lock
+- **THEN** Quantex returns the existing `RESOURCE_LOCKED` error code and details
+- **AND** preserves whether the agent was already available in the command data
+
+#### Scenario: Unexpected failures continue to propagate
+
+- **WHEN** inspection, tracking, or installation throws an error that is not a lifecycle lock error
+- **THEN** the shared lifecycle boundary does not silently convert it into an install failure
+- **AND** existing command-runtime error handling remains responsible for the terminal result
+
+### Requirement: Command output MUST remain outside the shared lifecycle service
+
+The shared install/ensure lifecycle service MUST return command-neutral lifecycle outcomes, while command handlers remain responsible for structured result construction, action names, warning and error messages, NDJSON event emission, batch aggregation, and human rendering.
+
+#### Scenario: Install maps a shared outcome
+
+- **WHEN** the shared service reports an install lifecycle outcome to `install`
+- **THEN** the install command maps it to the existing `install` action, result shape, messages, and events
+
+#### Scenario: Ensure maps a shared outcome
+
+- **WHEN** the shared service reports the same lifecycle outcome to `ensure`
+- **THEN** the ensure command maps it to the existing `ensure` action, result shape, messages, and events

--- a/openspec/changes/extract-install-ensure-lifecycle-service/tasks.md
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/tasks.md
@@ -1,0 +1,39 @@
+## 1. Compatibility Baseline
+
+- [x] 1.1 Extend `test/commands/install.test.ts` with stable structured-result assertions for adoptable existing installs, ambiguous existing installs, tracking cancellation, and lifecycle lock data.
+- [x] 1.2 Extend `test/commands/ensure.test.ts` with stable structured-result assertions for dry-run, install failure, tracking cancellation, and lifecycle lock data.
+- [x] 1.3 Run `bun run test -- test/commands/install.test.ts test/commands/ensure.test.ts` and confirm the characterization tests pass against the current implementation before refactoring.
+
+## 2. Shared Install/Ensure Lifecycle Service
+
+- [x] 2.1 Create `test/services/install-ensure.test.ts` with failing tests for `agent-not-found`, `already-installed`, `would-track-existing`, `tracked-existing`, `untracked-existing`, `would-install`, `installed`, `install-failed`, `tracking-cancelled`, and `resource-locked` outcomes.
+- [x] 2.2 Run `bun run test -- test/services/install-ensure.test.ts` and confirm it fails because `src/services/install-ensure.ts` does not exist.
+- [x] 2.3 Create `src/services/install-ensure.ts` with `runInstallEnsureLifecycle(agentName, options, dependencies)` and a command-neutral discriminated outcome.
+- [x] 2.4 Keep the default dependencies limited to `resolveAgentInspection`, `getAdoptableExistingInstallMethod`, `trackInstalledAgent`, `installAgent`, and `isResourceLockError`; pass `dryRun` and `onMutationStart` explicitly.
+- [x] 2.5 Run `bun run test -- test/services/install-ensure.test.ts` and confirm all service tests pass.
+
+## 3. Command Migration
+
+- [x] 3.1 Refactor the single-agent path in `src/commands/install.ts` to preserve its pre-start cancellation check and map shared service outcomes to the existing install results, warnings, errors, and started events.
+- [x] 3.2 Run `bun run test -- test/services/install-ensure.test.ts test/commands/install.test.ts` and confirm install compatibility remains green.
+- [x] 3.3 Refactor `src/commands/ensure.ts` to map the same service outcomes to the existing ensure results, warnings, errors, and started events.
+- [x] 3.4 Run `bun run test -- test/services/install-ensure.test.ts test/commands/install.test.ts test/commands/ensure.test.ts` and confirm both command suites remain green.
+- [x] 3.5 Remove duplicate inspection, adoption, tracking, installation, and lock-classification imports and branches from the command files without changing batch install aggregation or human renderers.
+
+## 4. Validation
+
+- [x] 4.1 Run `bun run lint`.
+- [x] 4.2 Run `bun run format:check`.
+- [x] 4.3 Run `bun run typecheck`.
+- [x] 4.4 Run `bun run test`.
+- [x] 4.5 Run `bun run openspec:validate`.
+- [x] 4.6 Run `bun run memory:check`.
+- [x] 4.7 Re-run `bun run openspec:status -- --change extract-install-ensure-lifecycle-service` and confirm every implementation task is complete.
+
+## 5. Delivery Closure
+
+- [x] 5.1 Review the final diff for public-contract drift and unintended changes outside the approved scope.
+- [x] 5.2 Commit the implementation and completed OpenSpec tasks on `codex/lifecycle-compatibility-refactor`.
+- [x] 5.3 Prepare a PR body file from `.github/pull_request_template.md` and validate it with `bun run pr:body:check`.
+- [x] 5.4 Push the branch and create the PR with the validated body file.
+- [x] 5.5 Report validation, OpenSpec, git, commit, push, PR, merge, release, and archive-closure state.

--- a/src/commands/ensure.ts
+++ b/src/commands/ensure.ts
@@ -1,11 +1,9 @@
 import type { CommandResult } from '../output/types'
+import type { InstallEnsureLifecycleOutcome } from '../services/install-ensure'
 import { createErrorResult, createSuccessResult, emitCommandEvent, emitCommandResult } from '../output'
-import { installAgent, trackInstalledAgent } from '../package-manager'
-import { resolveAgentInspection } from '../services/agents'
+import { runInstallEnsureLifecycle } from '../services/install-ensure'
 import { pc } from '../utils/color'
-import { getAdoptableExistingInstallMethod } from '../utils/install'
 import { createResourceLockedError } from '../utils/lifecycle-errors'
-import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
 
 interface EnsureCommandData {
@@ -22,229 +20,183 @@ interface EnsureCommandData {
 }
 
 export async function ensureCommand(agentName: string): Promise<CommandResult<EnsureCommandData>> {
-  const resolved = await resolveAgentInspection(agentName)
-  if (!resolved) {
-    return emitCommandResult(
-      createErrorResult<EnsureCommandData>({
-        action: 'ensure',
-        error: {
-          code: 'AGENT_NOT_FOUND',
-          details: {
-            input: agentName,
-          },
-          message: `Unknown agent: ${agentName}`,
+  const outcome = await runInstallEnsureLifecycle(agentName, {
+    dryRun: isDryRunEnabled(),
+    onMutationStart: emitEnsureStarted,
+  })
+
+  return emitCommandResult(createEnsureResult(agentName, outcome), renderEnsureHuman)
+}
+
+function createEnsureResult(
+  agentName: string,
+  outcome: InstallEnsureLifecycleOutcome,
+): CommandResult<EnsureCommandData> {
+  if (outcome.kind === 'agent-not-found') {
+    return createErrorResult<EnsureCommandData>({
+      action: 'ensure',
+      error: {
+        code: 'AGENT_NOT_FOUND',
+        details: {
+          input: outcome.input,
         },
-        target: {
-          kind: 'agent',
-          name: agentName,
-        },
-      }),
-      renderEnsureHuman,
-    )
+        message: `Unknown agent: ${outcome.input}`,
+      },
+      target: {
+        kind: 'agent',
+        name: agentName,
+      },
+    })
   }
 
-  const { agent, inspection } = resolved
-  if (inspection.inPath) {
-    if (inspection.installedState) {
-      return emitCommandResult(
-        createSuccessResult<EnsureCommandData>({
-          action: 'ensure',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: false,
-            installed: true,
-          },
-          target: {
-            kind: 'agent',
-            name: agent.name,
-          },
-          warnings: [
-            {
-              code: 'ALREADY_INSTALLED',
-              message: `${agent.displayName} is already installed.`,
-            },
-          ],
-        }),
-        renderEnsureHuman,
-      )
-    }
+  const { agent } = outcome
+  const target = {
+    kind: 'agent' as const,
+    name: agent.name,
+  }
+  const agentData = {
+    displayName: agent.displayName,
+    name: agent.name,
+  }
 
-    const adoptableMethod = getAdoptableExistingInstallMethod(
-      inspection.methods,
-      inspection.resolvedBinaryPath ?? inspection.binaryPath,
-    )
-    if (adoptableMethod) {
-      if (isDryRunEnabled()) {
-        return emitCommandResult(
-          createSuccessResult<EnsureCommandData>({
-            action: 'ensure',
-            data: {
-              agent: {
-                displayName: agent.displayName,
-                name: agent.name,
-              },
-              changed: false,
-              installed: true,
-            },
-            target: {
-              kind: 'agent',
-              name: agent.name,
-            },
-            warnings: [
-              {
-                code: 'DRY_RUN',
-                message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
-              },
-            ],
-          }),
-          renderEnsureHuman,
-        )
-      }
-
-      emitCommandEvent({
+  switch (outcome.kind) {
+    case 'already-installed':
+      return createSuccessResult<EnsureCommandData>({
         action: 'ensure',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
-        },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
-        type: 'started',
-      })
-
-      try {
-        const installedState = await trackInstalledAgent(agent, adoptableMethod)
-        if (!installedState) {
-          return emitCommandResult(
-            createErrorResult<EnsureCommandData>({
-              action: 'ensure',
-              error: {
-                code: 'CANCELLED',
-                message: 'Ensure was cancelled before tracking could complete.',
-              },
-              target: {
-                kind: 'agent',
-                name: agent.name,
-              },
-            }),
-            renderEnsureHuman,
-          )
-        }
-
-        return emitCommandResult(
-          createSuccessResult<EnsureCommandData>({
-            action: 'ensure',
-            data: {
-              agent: {
-                displayName: agent.displayName,
-                name: agent.name,
-              },
-              changed: true,
-              installState: {
-                installType: installedState.installType,
-                packageName: installedState.packageName,
-              },
-              installed: true,
-            },
-            target: {
-              kind: 'agent',
-              name: agent.name,
-            },
-            warnings: [
-              {
-                code: 'TRACKED_EXISTING_INSTALL',
-                message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
-              },
-            ],
-          }),
-          renderEnsureHuman,
-        )
-      } catch (error) {
-        if (isResourceLockError(error)) {
-          return emitCommandResult(
-            createErrorResult<EnsureCommandData>({
-              action: 'ensure',
-              data: {
-                agent: {
-                  displayName: agent.displayName,
-                  name: agent.name,
-                },
-                changed: false,
-                installed: true,
-              },
-              ...createResourceLockedError(error, {
-                kind: 'agent',
-                name: agent.name,
-              }),
-            }),
-            renderEnsureHuman,
-          )
-        }
-
-        throw error
-      }
-    }
-
-    return emitCommandResult(
-      createSuccessResult<EnsureCommandData>({
-        action: 'ensure',
-        data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
+          agent: agentData,
           changed: false,
           installed: true,
         },
-        target: {
-          kind: 'agent',
-          name: agent.name,
+        target,
+        warnings: [
+          {
+            code: 'ALREADY_INSTALLED',
+            message: `${agent.displayName} is already installed.`,
+          },
+        ],
+      })
+    case 'would-track-existing':
+      return createSuccessResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: true,
         },
+        target,
+        warnings: [
+          {
+            code: 'DRY_RUN',
+            message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
+          },
+        ],
+      })
+    case 'tracked-existing':
+      return createSuccessResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: true,
+          installState: {
+            installType: outcome.installedState.installType,
+            packageName: outcome.installedState.packageName,
+          },
+          installed: true,
+        },
+        target,
+        warnings: [
+          {
+            code: 'TRACKED_EXISTING_INSTALL',
+            message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
+          },
+        ],
+      })
+    case 'tracking-cancelled':
+      return createErrorResult<EnsureCommandData>({
+        action: 'ensure',
+        error: {
+          code: 'CANCELLED',
+          message: 'Ensure was cancelled before tracking could complete.',
+        },
+        target,
+      })
+    case 'untracked-existing':
+      return createSuccessResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: true,
+        },
+        target,
         warnings: [
           {
             code: 'UNTRACKED_EXISTING_INSTALL',
             message: `${agent.displayName} is already installed but not tracked by Quantex. Quantex could not safely determine the supported install source, so the existing install remains unmanaged.`,
           },
         ],
-      }),
-      renderEnsureHuman,
-    )
-  }
-
-  if (isDryRunEnabled()) {
-    return emitCommandResult(
-      createSuccessResult<EnsureCommandData>({
+      })
+    case 'would-install':
+      return createSuccessResult<EnsureCommandData>({
         action: 'ensure',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
+          agent: agentData,
           changed: false,
           installed: false,
         },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
+        target,
         warnings: [
           {
             code: 'DRY_RUN',
             message: `Dry run: would install ${agent.displayName}.`,
           },
         ],
-      }),
-      renderEnsureHuman,
-    )
+      })
+    case 'installed':
+      return createSuccessResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: true,
+          installState: outcome.installedState
+            ? {
+                installType: outcome.installedState.installType,
+                packageName: outcome.installedState.packageName,
+              }
+            : undefined,
+          installed: true,
+        },
+        target,
+      })
+    case 'install-failed':
+      return createErrorResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: false,
+        },
+        error: {
+          code: 'INSTALL_FAILED',
+          message: `Failed to install ${agent.displayName}.`,
+        },
+        target,
+      })
+    case 'resource-locked':
+      return createErrorResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: outcome.installed,
+        },
+        ...createResourceLockedError(outcome.error, target),
+      })
   }
+}
 
+function emitEnsureStarted(agent: { displayName: string; name: string }): void {
   emitCommandEvent({
     action: 'ensure',
     data: {
@@ -259,84 +211,6 @@ export async function ensureCommand(agentName: string): Promise<CommandResult<En
     },
     type: 'started',
   })
-
-  let result
-  try {
-    result = await installAgent(agent)
-  } catch (error) {
-    if (isResourceLockError(error)) {
-      return emitCommandResult(
-        createErrorResult<EnsureCommandData>({
-          action: 'ensure',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: false,
-            installed: false,
-          },
-          ...createResourceLockedError(error, {
-            kind: 'agent',
-            name: agent.name,
-          }),
-        }),
-        renderEnsureHuman,
-      )
-    }
-
-    throw error
-  }
-
-  if (result.success) {
-    return emitCommandResult(
-      createSuccessResult<EnsureCommandData>({
-        action: 'ensure',
-        data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
-          changed: true,
-          installState: result.installedState
-            ? {
-                installType: result.installedState.installType,
-                packageName: result.installedState.packageName,
-              }
-            : undefined,
-          installed: true,
-        },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
-      }),
-      renderEnsureHuman,
-    )
-  }
-
-  return emitCommandResult(
-    createErrorResult<EnsureCommandData>({
-      action: 'ensure',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        changed: false,
-        installed: false,
-      },
-      error: {
-        code: 'INSTALL_FAILED',
-        message: `Failed to install ${agent.displayName}.`,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-    }),
-    renderEnsureHuman,
-  )
 }
 
 function renderEnsureHuman(result: {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,12 +1,10 @@
 import type { CommandError, CommandResult, CommandWarning } from '../output/types'
+import type { InstallEnsureLifecycleOutcome } from '../services/install-ensure'
 import { getCliContext } from '../cli-context'
 import { createErrorResult, createSuccessResult, emitCommandEvent, emitCommandResult } from '../output'
-import { installAgent, trackInstalledAgent } from '../package-manager'
-import { resolveAgentInspection } from '../services/agents'
+import { runInstallEnsureLifecycle } from '../services/install-ensure'
 import { pc } from '../utils/color'
-import { getAdoptableExistingInstallMethod } from '../utils/install'
 import { createResourceLockedError } from '../utils/lifecycle-errors'
-import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
 
 interface InstallCommandData {
@@ -172,16 +170,27 @@ async function performSingleInstall(
     })
   }
 
-  const resolved = await resolveAgentInspection(agentName)
-  if (!resolved) {
+  const outcome = await runInstallEnsureLifecycle(agentName, {
+    dryRun: isDryRunEnabled(),
+    onMutationStart: agent => emitInstallStarted(agent, options.emitStartedEvent),
+  })
+
+  return createInstallResult(agentName, outcome)
+}
+
+function createInstallResult(
+  agentName: string,
+  outcome: InstallEnsureLifecycleOutcome,
+): CommandResult<InstallCommandData> {
+  if (outcome.kind === 'agent-not-found') {
     return createErrorResult<InstallCommandData>({
       action: 'install',
       error: {
         code: 'AGENT_NOT_FOUND',
         details: {
-          input: agentName,
+          input: outcome.input,
         },
-        message: `Unknown agent: ${agentName}`,
+        message: `Unknown agent: ${outcome.input}`,
       },
       target: {
         kind: 'agent',
@@ -190,23 +199,26 @@ async function performSingleInstall(
     })
   }
 
-  const { agent, inspection } = resolved
-  if (inspection.inPath) {
-    if (inspection.installedState) {
+  const { agent } = outcome
+  const target = {
+    kind: 'agent' as const,
+    name: agent.name,
+  }
+  const agentData = {
+    displayName: agent.displayName,
+    name: agent.name,
+  }
+
+  switch (outcome.kind) {
+    case 'already-installed':
       return createSuccessResult<InstallCommandData>({
         action: 'install',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
+          agent: agentData,
           changed: false,
           installed: true,
         },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
+        target,
         warnings: [
           {
             code: 'ALREADY_INSTALLED',
@@ -214,220 +226,124 @@ async function performSingleInstall(
           },
         ],
       })
-    }
-
-    const adoptableMethod = getAdoptableExistingInstallMethod(
-      inspection.methods,
-      inspection.resolvedBinaryPath ?? inspection.binaryPath,
-    )
-    if (adoptableMethod) {
-      if (isDryRunEnabled()) {
-        return createSuccessResult<InstallCommandData>({
-          action: 'install',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: false,
-            installed: true,
-          },
-          target: {
-            kind: 'agent',
-            name: agent.name,
-          },
-          warnings: [
-            {
-              code: 'DRY_RUN',
-              message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
-            },
-          ],
-        })
-      }
-
-      emitInstallStarted(agent, options.emitStartedEvent)
-
-      try {
-        const installedState = await trackInstalledAgent(agent, adoptableMethod)
-        if (!installedState) {
-          return createErrorResult<InstallCommandData>({
-            action: 'install',
-            error: {
-              code: 'CANCELLED',
-              message: 'Install was cancelled before tracking could complete.',
-            },
-            target: {
-              kind: 'agent',
-              name: agent.name,
-            },
-          })
-        }
-
-        return createSuccessResult<InstallCommandData>({
-          action: 'install',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: true,
-            installState: {
-              installType: installedState.installType,
-              packageName: installedState.packageName,
-            },
-            installed: true,
-          },
-          target: {
-            kind: 'agent',
-            name: agent.name,
-          },
-          warnings: [
-            {
-              code: 'TRACKED_EXISTING_INSTALL',
-              message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
-            },
-          ],
-        })
-      } catch (error) {
-        if (isResourceLockError(error)) {
-          return createErrorResult<InstallCommandData>({
-            action: 'install',
-            data: {
-              agent: {
-                displayName: agent.displayName,
-                name: agent.name,
-              },
-              changed: false,
-              installed: true,
-            },
-            ...createResourceLockedError(error, {
-              kind: 'agent',
-              name: agent.name,
-            }),
-          })
-        }
-
-        throw error
-      }
-    }
-
-    return createSuccessResult<InstallCommandData>({
-      action: 'install',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        changed: false,
-        installed: true,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-      warnings: [
-        {
-          code: 'UNTRACKED_EXISTING_INSTALL',
-          message: `${agent.displayName} is already installed but not tracked by Quantex. Quantex could not safely determine the supported install source, so the existing install remains unmanaged.`,
-        },
-      ],
-    })
-  }
-
-  if (isDryRunEnabled()) {
-    return createSuccessResult<InstallCommandData>({
-      action: 'install',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        changed: false,
-        installed: false,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-      warnings: [
-        {
-          code: 'DRY_RUN',
-          message: `Dry run: would install ${agent.displayName}.`,
-        },
-      ],
-    })
-  }
-
-  emitInstallStarted(agent, options.emitStartedEvent)
-
-  let result
-  try {
-    result = await installAgent(agent)
-  } catch (error) {
-    if (isResourceLockError(error)) {
-      return createErrorResult<InstallCommandData>({
+    case 'would-track-existing':
+      return createSuccessResult<InstallCommandData>({
         action: 'install',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
+          agent: agentData,
+          changed: false,
+          installed: true,
+        },
+        target,
+        warnings: [
+          {
+            code: 'DRY_RUN',
+            message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
           },
+        ],
+      })
+    case 'tracked-existing':
+      return createSuccessResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: true,
+          installState: {
+            installType: outcome.installedState.installType,
+            packageName: outcome.installedState.packageName,
+          },
+          installed: true,
+        },
+        target,
+        warnings: [
+          {
+            code: 'TRACKED_EXISTING_INSTALL',
+            message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
+          },
+        ],
+      })
+    case 'tracking-cancelled':
+      return createErrorResult<InstallCommandData>({
+        action: 'install',
+        error: {
+          code: 'CANCELLED',
+          message: 'Install was cancelled before tracking could complete.',
+        },
+        target,
+      })
+    case 'untracked-existing':
+      return createSuccessResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: true,
+        },
+        target,
+        warnings: [
+          {
+            code: 'UNTRACKED_EXISTING_INSTALL',
+            message: `${agent.displayName} is already installed but not tracked by Quantex. Quantex could not safely determine the supported install source, so the existing install remains unmanaged.`,
+          },
+        ],
+      })
+    case 'would-install':
+      return createSuccessResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
           changed: false,
           installed: false,
         },
-        ...createResourceLockedError(error, {
-          kind: 'agent',
-          name: agent.name,
-        }),
+        target,
+        warnings: [
+          {
+            code: 'DRY_RUN',
+            message: `Dry run: would install ${agent.displayName}.`,
+          },
+        ],
       })
-    }
-
-    throw error
-  }
-
-  if (result.success) {
-    return createSuccessResult<InstallCommandData>({
-      action: 'install',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
+    case 'installed':
+      return createSuccessResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: true,
+          installState: outcome.installedState
+            ? {
+                installType: outcome.installedState.installType,
+                packageName: outcome.installedState.packageName,
+              }
+            : undefined,
+          installed: true,
         },
-        changed: true,
-        installState: result.installedState
-          ? {
-              installType: result.installedState.installType,
-              packageName: result.installedState.packageName,
-            }
-          : undefined,
-        installed: true,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-    })
+        target,
+      })
+    case 'install-failed':
+      return createErrorResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: false,
+        },
+        error: {
+          code: 'INSTALL_FAILED',
+          message: `Failed to install ${agent.displayName}.`,
+        },
+        target,
+      })
+    case 'resource-locked':
+      return createErrorResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: outcome.installed,
+        },
+        ...createResourceLockedError(outcome.error, target),
+      })
   }
-
-  return createErrorResult<InstallCommandData>({
-    action: 'install',
-    data: {
-      agent: {
-        displayName: agent.displayName,
-        name: agent.name,
-      },
-      changed: false,
-      installed: false,
-    },
-    error: {
-      code: 'INSTALL_FAILED',
-      message: `Failed to install ${agent.displayName}.`,
-    },
-    target: {
-      kind: 'agent',
-      name: agent.name,
-    },
-  })
 }
 
 function emitInstallStarted(

--- a/src/services/install-ensure.ts
+++ b/src/services/install-ensure.ts
@@ -1,0 +1,170 @@
+import type { AgentDefinition } from '../agents'
+import type { InstalledAgentState } from '../state'
+import type { ResourceLockError } from '../utils/lock'
+import { installAgent, trackInstalledAgent } from '../package-manager'
+import { getAdoptableExistingInstallMethod } from '../utils/install'
+import { isResourceLockError } from '../utils/lock'
+import { resolveAgentInspection } from './agents'
+
+export interface InstallEnsureLifecycleDependencies {
+  getAdoptableExistingInstallMethod: typeof getAdoptableExistingInstallMethod
+  installAgent: typeof installAgent
+  isResourceLockError: typeof isResourceLockError
+  resolveAgentInspection: typeof resolveAgentInspection
+  trackInstalledAgent: typeof trackInstalledAgent
+}
+
+export interface InstallEnsureLifecycleOptions {
+  dryRun: boolean
+  onMutationStart?: (agent: AgentDefinition) => void
+}
+
+type ResolvedLifecycleOutcome =
+  | {
+      agent: AgentDefinition
+      kind: 'already-installed' | 'install-failed' | 'tracking-cancelled' | 'untracked-existing'
+    }
+  | {
+      agent: AgentDefinition
+      kind: 'would-install' | 'would-track-existing'
+    }
+  | {
+      agent: AgentDefinition
+      installedState: InstalledAgentState
+      kind: 'tracked-existing'
+    }
+  | {
+      agent: AgentDefinition
+      installedState?: InstalledAgentState
+      kind: 'installed'
+    }
+  | {
+      agent: AgentDefinition
+      error: ResourceLockError
+      installed: boolean
+      kind: 'resource-locked'
+    }
+
+export type InstallEnsureLifecycleOutcome =
+  | {
+      input: string
+      kind: 'agent-not-found'
+    }
+  | ResolvedLifecycleOutcome
+
+function createDefaultDependencies(): InstallEnsureLifecycleDependencies {
+  return {
+    getAdoptableExistingInstallMethod,
+    installAgent,
+    isResourceLockError,
+    resolveAgentInspection,
+    trackInstalledAgent,
+  }
+}
+
+export async function runInstallEnsureLifecycle(
+  agentName: string,
+  options: InstallEnsureLifecycleOptions,
+  dependencies: InstallEnsureLifecycleDependencies = createDefaultDependencies(),
+): Promise<InstallEnsureLifecycleOutcome> {
+  const resolved = await dependencies.resolveAgentInspection(agentName)
+  if (!resolved) {
+    return {
+      input: agentName,
+      kind: 'agent-not-found',
+    }
+  }
+
+  const { agent, inspection } = resolved
+  if (inspection.inPath) {
+    if (inspection.installedState) {
+      return {
+        agent,
+        kind: 'already-installed',
+      }
+    }
+
+    const adoptableMethod = dependencies.getAdoptableExistingInstallMethod(
+      inspection.methods,
+      inspection.resolvedBinaryPath ?? inspection.binaryPath,
+    )
+    if (!adoptableMethod) {
+      return {
+        agent,
+        kind: 'untracked-existing',
+      }
+    }
+
+    if (options.dryRun) {
+      return {
+        agent,
+        kind: 'would-track-existing',
+      }
+    }
+
+    options.onMutationStart?.(agent)
+
+    try {
+      const installedState = await dependencies.trackInstalledAgent(agent, adoptableMethod)
+      if (!installedState) {
+        return {
+          agent,
+          kind: 'tracking-cancelled',
+        }
+      }
+
+      return {
+        agent,
+        installedState,
+        kind: 'tracked-existing',
+      }
+    } catch (error) {
+      if (dependencies.isResourceLockError(error)) {
+        return {
+          agent,
+          error,
+          installed: true,
+          kind: 'resource-locked',
+        }
+      }
+
+      throw error
+    }
+  }
+
+  if (options.dryRun) {
+    return {
+      agent,
+      kind: 'would-install',
+    }
+  }
+
+  options.onMutationStart?.(agent)
+
+  try {
+    const result = await dependencies.installAgent(agent)
+    if (!result.success) {
+      return {
+        agent,
+        kind: 'install-failed',
+      }
+    }
+
+    return {
+      agent,
+      installedState: result.installedState,
+      kind: 'installed',
+    }
+  } catch (error) {
+    if (dependencies.isResourceLockError(error)) {
+      return {
+        agent,
+        error,
+        installed: false,
+        kind: 'resource-locked',
+      }
+    }
+
+    throw error
+  }
+}

--- a/test/commands/ensure.test.ts
+++ b/test/commands/ensure.test.ts
@@ -6,6 +6,7 @@ import { ensureCommand } from '../../src/commands/ensure'
 import * as pm from '../../src/package-manager'
 import * as state from '../../src/state'
 import * as detect from '../../src/utils/detect'
+import { ResourceLockError } from '../../src/utils/lock'
 
 const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
 const installSpy = vi.spyOn(pm, 'installAgent')
@@ -176,5 +177,103 @@ describe('ensureCommand', () => {
     expect(payload.data.changed).toBe(true)
     expect(payload.data.installed).toBe(true)
     expect(payload.meta.runId).toBe('ensure-run-id')
+  })
+
+  it('returns a dry-run plan without invoking installAgent', async () => {
+    setCliContext({
+      dryRun: true,
+      interactive: false,
+      outputMode: 'json',
+      runId: 'ensure-dry-run-id',
+    })
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+
+    const result = await ensureCommand('test-agent')
+
+    expect(result).toMatchObject({
+      action: 'ensure',
+      data: {
+        changed: false,
+        installed: false,
+      },
+      ok: true,
+      warnings: [
+        {
+          code: 'DRY_RUN',
+        },
+      ],
+    })
+    expect(installSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves install failure data when the installer returns false', async () => {
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+    installSpy.mockResolvedValue({ success: false })
+
+    const result = await ensureCommand('test-agent')
+
+    expect(result).toMatchObject({
+      action: 'ensure',
+      data: {
+        changed: false,
+        installed: false,
+      },
+      error: {
+        code: 'INSTALL_FAILED',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'test-agent',
+      },
+    })
+  })
+
+  it('returns the stable cancellation result when tracking cannot complete', async () => {
+    agentSpy.mockReturnValue(scriptOnlyAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    trackSpy.mockResolvedValue(null)
+
+    const result = await ensureCommand('script-agent')
+
+    expect(result).toMatchObject({
+      action: 'ensure',
+      error: {
+        code: 'CANCELLED',
+        message: 'Ensure was cancelled before tracking could complete.',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'script-agent',
+      },
+    })
+    expect(installSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns a stable conflict when installation cannot acquire the lifecycle lock', async () => {
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+    installSpy.mockRejectedValue(new ResourceLockError('agent lifecycle', '/tmp/agent-lifecycle.lock'))
+
+    const result = await ensureCommand('test-agent')
+
+    expect(result).toMatchObject({
+      action: 'ensure',
+      data: {
+        changed: false,
+        installed: false,
+      },
+      error: {
+        code: 'RESOURCE_LOCKED',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'test-agent',
+      },
+    })
   })
 })

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -117,7 +117,7 @@ describe('installCommand', () => {
       command: expectedScriptInstallCommand,
     })
 
-    await installCommand('script-agent')
+    const result = await installCommand('script-agent')
 
     expect(trackSpy).toHaveBeenCalledWith(
       scriptOnlyAgent,
@@ -127,6 +127,30 @@ describe('installCommand', () => {
       }),
     )
     expect(installSpy).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      action: 'install',
+      data: {
+        agent: {
+          displayName: 'Script Agent',
+          name: 'script-agent',
+        },
+        changed: true,
+        installState: {
+          installType: 'script',
+        },
+        installed: true,
+      },
+      ok: true,
+      target: {
+        kind: 'agent',
+        name: 'script-agent',
+      },
+      warnings: [
+        {
+          code: 'TRACKED_EXISTING_INSTALL',
+        },
+      ],
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Quantex is now tracking the existing install'))
   })
 
@@ -134,11 +158,46 @@ describe('installCommand', () => {
     agentSpy.mockReturnValue(testAgent)
     binaryInPathSpy.mockResolvedValue(true)
 
-    await installCommand('test-agent')
+    const result = await installCommand('test-agent')
 
     expect(trackSpy).not.toHaveBeenCalled()
     expect(installSpy).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      action: 'install',
+      data: {
+        changed: false,
+        installed: true,
+      },
+      ok: true,
+      warnings: [
+        {
+          code: 'UNTRACKED_EXISTING_INSTALL',
+        },
+      ],
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('not tracked by Quantex'))
+  })
+
+  it('returns the stable cancellation result when tracking cannot complete', async () => {
+    agentSpy.mockReturnValue(scriptOnlyAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    trackSpy.mockResolvedValue(null)
+
+    const result = await installCommand('script-agent')
+
+    expect(result).toMatchObject({
+      action: 'install',
+      error: {
+        code: 'CANCELLED',
+        message: 'Install was cancelled before tracking could complete.',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'script-agent',
+      },
+    })
+    expect(installSpy).not.toHaveBeenCalled()
   })
 
   it('calls installAgent and shows success', async () => {
@@ -166,6 +225,18 @@ describe('installCommand', () => {
     const result = await installCommand('test-agent')
 
     expect(result.error?.code).toBe('RESOURCE_LOCKED')
+    expect(result).toMatchObject({
+      action: 'install',
+      data: {
+        changed: false,
+        installed: false,
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'test-agent',
+      },
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('agent lifecycle lock'))
   })
 

--- a/test/services/install-ensure.test.ts
+++ b/test/services/install-ensure.test.ts
@@ -1,0 +1,277 @@
+import type { AgentDefinition, InstallMethod } from '../../src/agents'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runInstallEnsureLifecycle, type InstallEnsureLifecycleDependencies } from '../../src/services/install-ensure'
+import { ResourceLockError } from '../../src/utils/lock'
+
+const testAgent: AgentDefinition = {
+  binaryName: 'test-bin',
+  displayName: 'Test Agent',
+  homepage: 'https://example.com',
+  name: 'test-agent',
+  packages: {
+    npm: 'test-pkg',
+  },
+  platforms: {
+    linux: [{ type: 'bun' }],
+    macos: [{ type: 'bun' }],
+    windows: [{ type: 'bun' }],
+  },
+}
+
+const scriptMethod: InstallMethod = {
+  command: 'curl https://example.com/install | bash',
+  type: 'script',
+}
+
+function createInspection(
+  overrides: Partial<{
+    inPath: boolean
+    installedState: {
+      agentName: string
+      installType: 'bun'
+      packageName: string
+    }
+    methods: InstallMethod[]
+  }> = {},
+) {
+  return {
+    agent: testAgent,
+    inspection: {
+      agent: testAgent,
+      inPath: overrides.inPath ?? false,
+      installedState: overrides.installedState,
+      lifecycle: overrides.installedState ? ('managed' as const) : ('unmanaged' as const),
+      methods: overrides.methods ?? testAgent.platforms.macos!,
+      sourceLabel: 'Unknown',
+      updateLabel: 'Manual',
+    },
+  }
+}
+
+function createDependencies(): InstallEnsureLifecycleDependencies {
+  return {
+    getAdoptableExistingInstallMethod: vi.fn(),
+    installAgent: vi.fn(),
+    isResourceLockError: (error): error is ResourceLockError => error instanceof ResourceLockError,
+    resolveAgentInspection: vi.fn(),
+    trackInstalledAgent: vi.fn(),
+  }
+}
+
+describe('runInstallEnsureLifecycle', () => {
+  let dependencies: InstallEnsureLifecycleDependencies
+
+  beforeEach(() => {
+    dependencies = createDependencies()
+  })
+
+  it('returns agent-not-found without attempting a mutation', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(undefined)
+
+    const result = await runInstallEnsureLifecycle('missing-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      input: 'missing-agent',
+      kind: 'agent-not-found',
+    })
+    expect(dependencies.installAgent).not.toHaveBeenCalled()
+    expect(dependencies.trackInstalledAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns already-installed for a managed existing install', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+        installedState: {
+          agentName: 'test-agent',
+          installType: 'bun',
+          packageName: 'test-pkg',
+        },
+      }),
+    )
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'already-installed',
+    })
+    expect(dependencies.installAgent).not.toHaveBeenCalled()
+    expect(dependencies.trackInstalledAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns would-track-existing for an adoptable dry run', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+        methods: [scriptMethod],
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(scriptMethod)
+    const onMutationStart = vi.fn()
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: true, onMutationStart }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'would-track-existing',
+    })
+    expect(onMutationStart).not.toHaveBeenCalled()
+    expect(dependencies.trackInstalledAgent).not.toHaveBeenCalled()
+  })
+
+  it('tracks an adoptable existing install after announcing the mutation', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+        methods: [scriptMethod],
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(scriptMethod)
+    vi.mocked(dependencies.trackInstalledAgent).mockResolvedValue({
+      agentName: 'test-agent',
+      command: scriptMethod.command,
+      installType: 'script',
+    })
+    const onMutationStart = vi.fn()
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false, onMutationStart }, dependencies)
+
+    expect(onMutationStart).toHaveBeenCalledWith(testAgent)
+    expect(dependencies.trackInstalledAgent).toHaveBeenCalledWith(testAgent, scriptMethod)
+    expect(result).toMatchObject({
+      agent: testAgent,
+      installedState: {
+        agentName: 'test-agent',
+        installType: 'script',
+      },
+      kind: 'tracked-existing',
+    })
+  })
+
+  it('returns tracking-cancelled when adopted state is not persisted', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+        methods: [scriptMethod],
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(scriptMethod)
+    vi.mocked(dependencies.trackInstalledAgent).mockResolvedValue(null)
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'tracking-cancelled',
+    })
+  })
+
+  it('returns untracked-existing when no install source is safely adoptable', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(undefined)
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'untracked-existing',
+    })
+    expect(dependencies.installAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns would-install for a missing agent dry run', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(createInspection())
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: true }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'would-install',
+    })
+    expect(dependencies.installAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns installed with persisted install state after installation succeeds', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(createInspection())
+    vi.mocked(dependencies.installAgent).mockResolvedValue({
+      installedState: {
+        agentName: 'test-agent',
+        installType: 'bun',
+        packageName: 'test-pkg',
+      },
+      success: true,
+    })
+    const onMutationStart = vi.fn()
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false, onMutationStart }, dependencies)
+
+    expect(onMutationStart).toHaveBeenCalledWith(testAgent)
+    expect(result).toMatchObject({
+      agent: testAgent,
+      installedState: {
+        installType: 'bun',
+        packageName: 'test-pkg',
+      },
+      kind: 'installed',
+    })
+  })
+
+  it('returns install-failed when installation reports failure', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(createInspection())
+    vi.mocked(dependencies.installAgent).mockResolvedValue({ success: false })
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'install-failed',
+    })
+  })
+
+  it.each([
+    {
+      expectedInstalled: true,
+      inPath: true,
+      operation: 'track',
+    },
+    {
+      expectedInstalled: false,
+      inPath: false,
+      operation: 'install',
+    },
+  ])('returns resource-locked when $operation cannot acquire the lock', async ({ expectedInstalled, inPath }) => {
+    const error = new ResourceLockError('agent lifecycle', '/tmp/agent-lifecycle.lock')
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath,
+        methods: [scriptMethod],
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(scriptMethod)
+
+    if (inPath) vi.mocked(dependencies.trackInstalledAgent).mockRejectedValue(error)
+    else vi.mocked(dependencies.installAgent).mockRejectedValue(error)
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      error,
+      installed: expectedInstalled,
+      kind: 'resource-locked',
+    })
+  })
+
+  it('propagates unexpected installation errors', async () => {
+    const error = new Error('unexpected')
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(createInspection())
+    vi.mocked(dependencies.installAgent).mockRejectedValue(error)
+
+    await expect(runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)).rejects.toBe(error)
+  })
+})


### PR DESCRIPTION
## Summary

- extract the shared single-agent inspection, adoption, dry-run, install, cancellation, and lock decisions used by `install` and `ensure`
- keep command-specific actions, messages, events, batch aggregation, and human rendering at the CLI boundary
- add compatibility assertions plus focused service tests without changing public commands, structured output, state, installer ordering, or fallback behavior

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `extract-install-ensure-lifecycle-service`
- Discussion: none

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - internal compatibility-preserving refactor with no observable behavior change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The full suite initially hit the repository's known one-off 10-second timing timeout in `test/managed-installer-cancellation.e2e.test.ts`. The isolated test then completed in 1.52 seconds with its original timeout, and the subsequent full run passed all 62 test files and 708 tests.
