### PR TITLE
refactor(lifecycle): separate execution boundaries

### DIFF
--- a/openspec/changes/extract-install-ensure-lifecycle-service/.openspec.yaml
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/extract-install-ensure-lifecycle-service/design.md
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/design.md
@@ -1,0 +1,90 @@
+## Context
+
+The single-agent paths in `src/commands/install.ts` and `src/commands/ensure.ts` independently perform the same sequence:
+
+1. resolve the catalog agent and inspect the current installation;
+2. classify a managed, safely adoptable, or ambiguous existing installation;
+3. handle dry-run behavior;
+4. track an adopted installation or invoke `installAgent`;
+5. translate cancellation and lifecycle lock failures;
+6. construct command-specific structured output and render human output.
+
+The duplication has already accumulated subtle differences, including the install command's pre-start cancellation check and different event-emission behavior. The project has active users, so this change must preserve those differences where they are part of the current contract rather than replacing both commands with a new public model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Establish compatibility tests for the published single-agent install and ensure behavior.
+- Move shared inspection, adoption, dry-run, tracking, installation, and lock classification into one focused service.
+- Keep command-specific output, messages, events, batch aggregation, and rendering at the command boundary.
+- Make the shared lifecycle flow directly testable without invoking the Commander CLI.
+- Reduce the size and change surface of both command handlers without changing persisted state or public contracts.
+
+**Non-Goals:**
+
+- Changing command names, flags, aliases, schemas, warning or error codes, exit behavior, or human-facing semantics.
+- Refactoring batch install aggregation.
+- Replacing installer boolean results with richer adapter errors.
+- Changing lifecycle lock scope or concurrency.
+- Refactoring update, uninstall, exec, self-upgrade, catalog loading, configuration, or state formats.
+- Introducing a generic desired-state planner or workflow engine.
+
+## Decisions
+
+### Use a command-neutral discriminated outcome from one shared service
+
+Create `src/services/install-ensure.ts` with a single lifecycle operation that returns a discriminated outcome for the current states: agent not found, already managed, dry-run tracking, tracked existing install, ambiguous unmanaged install, dry-run install, installed, install failed, tracking cancelled, and resource locked.
+
+The outcome contains the resolved agent and installed state only when those facts exist. It does not contain `CommandResult`, action names, warning text, human copy, exit codes, or NDJSON events.
+
+This keeps the service reusable by both commands while preserving each command's existing result mapping.
+
+**Alternatives considered:**
+
+- Return `CommandResult` from a shared helper: rejected because it would move CLI action names and output contracts into the service instead of separating them.
+- Make `ensureCommand` call `installCommand`: rejected because it would emit the wrong action, messages, events, and result metadata.
+- Introduce a generic plan/apply engine now: rejected because it is too broad for the first compatibility-preserving slice.
+
+### Keep command-specific preflight and event policy at the command boundary
+
+`installCommand` keeps its current pre-start cancellation result before calling the shared service. Each command passes a mutation-start callback so the service can signal the point at which tracking or installation is about to mutate state, while the command remains responsible for emitting its current action-specific NDJSON event.
+
+Dry-run and cancellation state are passed explicitly into the service operation rather than making result construction depend on output mode.
+
+This preserves current differences without duplicating lifecycle decisions.
+
+### Preserve package-manager and state behavior unchanged
+
+The service continues to call the existing `resolveAgentInspection`, `getAdoptableExistingInstallMethod`, `trackInstalledAgent`, and `installAgent` functions. It does not alter install method ordering, fallback behavior, rollback, persisted state, or the global lifecycle lock.
+
+Resource lock errors are classified by the service and returned with the original error so each command can construct the same `RESOURCE_LOCKED` details it emits today. Other unexpected errors continue to propagate.
+
+### Treat existing command tests as compatibility tests and add focused service tests
+
+Existing install and ensure command tests remain authoritative for public results and rendering. New service tests cover the shared decision matrix directly. Refactoring proceeds test-first: add a failing service test for one outcome, add the minimum service behavior, migrate one command branch, and keep both command suites green.
+
+No snapshot of timestamps, run IDs, or other intentionally variable metadata is introduced. Compatibility assertions target stable action, target, data, warnings, errors, events, and exit behavior.
+
+## Risks / Trade-offs
+
+- **Risk: The service outcome duplicates some concepts from `CommandResult`.** → Keep it limited to lifecycle facts and do not add output messages, schema metadata, or rendering concerns.
+- **Risk: Moving logic changes a warning, event, or cancellation edge case.** → Lock current behavior with command-level characterization tests before migrating each branch.
+- **Risk: The first slice does not fix installer error opacity or global lock contention.** → Keep those explicitly out of scope; later changes can improve them after this shared boundary exists.
+- **Risk: A mutation-start callback becomes an output backchannel.** → Define it as a zero-argument lifecycle hook and prohibit passing output objects into the service.
+- **Trade-off: Commands retain result-mapping code.** → This is intentional because public compatibility belongs at the command boundary; later duplication can be reconsidered only with separate contract evidence.
+
+## Migration Plan
+
+1. Add missing command-level compatibility cases for stable install and ensure outcomes.
+2. Add focused tests for the new service outcome matrix.
+3. Implement the shared service around the existing inspection, adoption, tracking, and installation functions.
+4. Migrate the single-agent install path to map service outcomes into the existing results.
+5. Migrate ensure to map the same outcomes into its existing results.
+6. Run focused tests, the complete suite, lint, format check, typecheck, and OpenSpec validation.
+
+Rollback requires only restoring the command-local control flow and deleting the new service. There is no configuration, state, catalog, or data migration to reverse.
+
+## Open Questions
+
+None. Rich installer errors, per-agent locking, catalog decoupling, and additional lifecycle commands require separate future OpenSpec changes.

--- a/openspec/changes/extract-install-ensure-lifecycle-service/proposal.md
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`install` and `ensure` currently duplicate the same single-agent inspection, existing-install adoption, dry-run, installation, cancellation, lock-error, and state-result decisions inside separate command handlers. Quantex already has active users, so the first refactor slice must reduce that duplication behind a shared lifecycle boundary while preserving the published CLI and machine-readable contracts.
+
+## What Changes
+
+- Add compatibility-focused tests that lock the current single-agent `install` and `ensure` results for unknown agents, managed and unmanaged existing installs, dry runs, successful installs, failed installs, cancellation, and lifecycle lock failures.
+- Introduce a shared install/ensure lifecycle service that owns command-neutral inspection, adoption, dry-run, and installation decisions.
+- Keep command handlers responsible for action names, command-specific messages, structured result mapping, event emission, batch aggregation, and human rendering.
+- Preserve existing command names, flags, aliases, JSON/NDJSON shapes, warning and error codes, exit behavior, install-source selection, persisted state format, and cancellation semantics.
+- Keep batch install behavior, installer adapter interfaces, lifecycle lock scope, `update`, `uninstall`, `exec`, self-upgrade, and catalog loading outside this first refactor slice.
+- Make no breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `install-ensure-lifecycle-service`: Defines the shared internal lifecycle boundary and the observable compatibility requirements for single-agent `install` and `ensure`.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Primary code: `src/commands/install.ts`, `src/commands/ensure.ts`, and a new focused module under `src/services/`.
+- Existing dependencies: agent inspection, install-method adoption, package-manager installation/tracking, CLI cancellation context, dry-run context, lifecycle lock errors, output result builders, and state persistence.
+- Tests: `test/commands/install.test.ts`, `test/commands/ensure.test.ts`, plus focused service tests.
+- Public APIs, package dependencies, configuration, persisted state, catalog data, release artifacts, and runtime requirements remain unchanged.

--- a/openspec/changes/extract-install-ensure-lifecycle-service/specs/install-ensure-lifecycle-service/spec.md
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/specs/install-ensure-lifecycle-service/spec.md
@@ -1,0 +1,80 @@
+## ADDED Requirements
+
+### Requirement: Install and ensure MUST preserve their published contracts during lifecycle service extraction
+
+Quantex MUST preserve the existing single-agent `install` and `ensure` command actions, targets, data fields, warnings, error codes, events, exit behavior, and persisted install state while their shared lifecycle decisions move behind an internal service boundary.
+
+#### Scenario: Unknown agent remains command-specific
+
+- **WHEN** a caller invokes `install` or `ensure` with an unknown agent name
+- **THEN** Quantex returns the existing command action and target
+- **AND** returns the existing `AGENT_NOT_FOUND` error details
+
+#### Scenario: Managed existing install remains a no-op
+
+- **WHEN** the target agent is already available and has recorded Quantex install state
+- **THEN** `install` and `ensure` return success with `changed: false` and `installed: true`
+- **AND** preserve the `ALREADY_INSTALLED` warning
+- **AND** do not run or track an installer
+
+#### Scenario: Safely adoptable existing install remains trackable
+
+- **WHEN** the target agent is already available without recorded state
+- **AND** its supported install source can be safely identified
+- **THEN** a normal `install` or `ensure` invocation records the existing install state
+- **AND** preserves the `TRACKED_EXISTING_INSTALL` warning and install-state data
+
+#### Scenario: Ambiguous existing install remains unmanaged
+
+- **WHEN** the target agent is already available without recorded state
+- **AND** Quantex cannot safely identify one supported install source
+- **THEN** `install` and `ensure` return success without changing state
+- **AND** preserve the `UNTRACKED_EXISTING_INSTALL` warning
+
+#### Scenario: Dry run remains non-mutating
+
+- **WHEN** `install` or `ensure` is invoked in dry-run mode for an adoptable or missing agent
+- **THEN** Quantex preserves the existing successful dry-run result and `DRY_RUN` warning
+- **AND** does not track state or run an installer
+
+#### Scenario: Missing agent uses the existing installation behavior
+
+- **WHEN** the target agent is not available and the invocation is not a dry run
+- **THEN** `install` and `ensure` use the existing install-method ordering and fallback behavior
+- **AND** preserve the existing success data or `INSTALL_FAILED` result
+
+### Requirement: Shared lifecycle extraction MUST preserve cancellation and lock behavior
+
+Quantex MUST preserve the existing cancellation and lifecycle lock behavior of the single-agent `install` and `ensure` commands while centralizing their shared inspection and mutation decisions.
+
+#### Scenario: Tracking cancellation preserves command action
+
+- **WHEN** tracking an adopted existing install is cancelled before state persistence completes
+- **THEN** Quantex returns the existing `CANCELLED` result
+- **AND** the result retains the invoked `install` or `ensure` action and command-specific message
+
+#### Scenario: Lifecycle lock failure preserves structured details
+
+- **WHEN** tracking or installation cannot acquire the lifecycle lock
+- **THEN** Quantex returns the existing `RESOURCE_LOCKED` error code and details
+- **AND** preserves whether the agent was already available in the command data
+
+#### Scenario: Unexpected failures continue to propagate
+
+- **WHEN** inspection, tracking, or installation throws an error that is not a lifecycle lock error
+- **THEN** the shared lifecycle boundary does not silently convert it into an install failure
+- **AND** existing command-runtime error handling remains responsible for the terminal result
+
+### Requirement: Command output MUST remain outside the shared lifecycle service
+
+The shared install/ensure lifecycle service MUST return command-neutral lifecycle outcomes, while command handlers remain responsible for structured result construction, action names, warning and error messages, NDJSON event emission, batch aggregation, and human rendering.
+
+#### Scenario: Install maps a shared outcome
+
+- **WHEN** the shared service reports an install lifecycle outcome to `install`
+- **THEN** the install command maps it to the existing `install` action, result shape, messages, and events
+
+#### Scenario: Ensure maps a shared outcome
+
+- **WHEN** the shared service reports the same lifecycle outcome to `ensure`
+- **THEN** the ensure command maps it to the existing `ensure` action, result shape, messages, and events

--- a/openspec/changes/extract-install-ensure-lifecycle-service/tasks.md
+++ b/openspec/changes/extract-install-ensure-lifecycle-service/tasks.md
@@ -1,0 +1,39 @@
+## 1. Compatibility Baseline
+
+- [x] 1.1 Extend `test/commands/install.test.ts` with stable structured-result assertions for adoptable existing installs, ambiguous existing installs, tracking cancellation, and lifecycle lock data.
+- [x] 1.2 Extend `test/commands/ensure.test.ts` with stable structured-result assertions for dry-run, install failure, tracking cancellation, and lifecycle lock data.
+- [x] 1.3 Run `bun run test -- test/commands/install.test.ts test/commands/ensure.test.ts` and confirm the characterization tests pass against the current implementation before refactoring.
+
+## 2. Shared Install/Ensure Lifecycle Service
+
+- [x] 2.1 Create `test/services/install-ensure.test.ts` with failing tests for `agent-not-found`, `already-installed`, `would-track-existing`, `tracked-existing`, `untracked-existing`, `would-install`, `installed`, `install-failed`, `tracking-cancelled`, and `resource-locked` outcomes.
+- [x] 2.2 Run `bun run test -- test/services/install-ensure.test.ts` and confirm it fails because `src/services/install-ensure.ts` does not exist.
+- [x] 2.3 Create `src/services/install-ensure.ts` with `runInstallEnsureLifecycle(agentName, options, dependencies)` and a command-neutral discriminated outcome.
+- [x] 2.4 Keep the default dependencies limited to `resolveAgentInspection`, `getAdoptableExistingInstallMethod`, `trackInstalledAgent`, `installAgent`, and `isResourceLockError`; pass `dryRun` and `onMutationStart` explicitly.
+- [x] 2.5 Run `bun run test -- test/services/install-ensure.test.ts` and confirm all service tests pass.
+
+## 3. Command Migration
+
+- [x] 3.1 Refactor the single-agent path in `src/commands/install.ts` to preserve its pre-start cancellation check and map shared service outcomes to the existing install results, warnings, errors, and started events.
+- [x] 3.2 Run `bun run test -- test/services/install-ensure.test.ts test/commands/install.test.ts` and confirm install compatibility remains green.
+- [x] 3.3 Refactor `src/commands/ensure.ts` to map the same service outcomes to the existing ensure results, warnings, errors, and started events.
+- [x] 3.4 Run `bun run test -- test/services/install-ensure.test.ts test/commands/install.test.ts test/commands/ensure.test.ts` and confirm both command suites remain green.
+- [x] 3.5 Remove duplicate inspection, adoption, tracking, installation, and lock-classification imports and branches from the command files without changing batch install aggregation or human renderers.
+
+## 4. Validation
+
+- [x] 4.1 Run `bun run lint`.
+- [x] 4.2 Run `bun run format:check`.
+- [x] 4.3 Run `bun run typecheck`.
+- [x] 4.4 Run `bun run test`.
+- [x] 4.5 Run `bun run openspec:validate`.
+- [x] 4.6 Run `bun run memory:check`.
+- [x] 4.7 Re-run `bun run openspec:status -- --change extract-install-ensure-lifecycle-service` and confirm every implementation task is complete.
+
+## 5. Delivery Closure
+
+- [x] 5.1 Review the final diff for public-contract drift and unintended changes outside the approved scope.
+- [x] 5.2 Commit the implementation and completed OpenSpec tasks on `codex/lifecycle-compatibility-refactor`.
+- [x] 5.3 Prepare a PR body file from `.github/pull_request_template.md` and validate it with `bun run pr:body:check`.
+- [x] 5.4 Push the branch and create the PR with the validated body file.
+- [x] 5.5 Report validation, OpenSpec, git, commit, push, PR, merge, release, and archive-closure state.

--- a/openspec/changes/extract-uninstall-lifecycle-service/.openspec.yaml
+++ b/openspec/changes/extract-uninstall-lifecycle-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/extract-uninstall-lifecycle-service/design.md
+++ b/openspec/changes/extract-uninstall-lifecycle-service/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The uninstall command performs one command-neutral lifecycle sequence before mapping results: resolve the agent, require recorded managed state, honor dry-run, invoke the existing package-manager uninstall operation, and classify lifecycle lock errors. This is the same boundary already adopted for install and ensure.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move uninstall lifecycle decisions into a focused, directly testable service.
+- Preserve all published uninstall behavior and persisted-state semantics.
+- Leave command-specific messages and rendering in the command.
+
+**Non-Goals:**
+
+- Changing which installs Quantex may uninstall.
+- Changing package-manager adapter results, lock scope, state format, or command output.
+- Combining uninstall with install/ensure outcomes or a generic desired-state engine.
+
+## Decisions
+
+### Return a command-neutral discriminated outcome
+
+Create `runUninstallLifecycle(agentName, options, dependencies)` with outcomes for unknown agent, unmanaged install, dry-run plan, success, failure, and resource lock. The service returns resolved agent facts and the original lock error where needed, but never creates a `CommandResult` or message.
+
+### Preserve current package-manager ownership
+
+The service delegates to existing `resolveAgent`, `getInstalledAgentState`, and `uninstallAgent` functions. State removal, absence probes, and rollback semantics remain owned by `uninstallAgent`.
+
+### Pass dry-run explicitly
+
+The command reads CLI context and passes `dryRun`; the service does not read output mode or render events. This keeps the service testable while preserving the public dry-run result.
+
+## Risks / Trade-offs
+
+- **Risk: Mapping drift changes unmanaged details or lock data.** → Strengthen command-level structured assertions before migration.
+- **Risk: Another small service increases module count.** → Keep it limited to the exact uninstall lifecycle sequence and avoid generic abstractions.
+- **Trade-off: Installer errors remain boolean.** → Rich adapter errors remain a later, separately specified concern.
+
+## Migration Plan
+
+1. Add compatibility assertions to the existing uninstall command tests.
+2. Add failing direct tests for every service outcome.
+3. Implement the service with injectable default dependencies.
+4. Replace command-local lifecycle branches with outcome mapping.
+5. Run focused and full repository validation.
+
+Rollback deletes the service and restores command-local control flow; no data migration is involved.
+
+## Open Questions
+
+None.

--- a/openspec/changes/extract-uninstall-lifecycle-service/proposal.md
+++ b/openspec/changes/extract-uninstall-lifecycle-service/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`uninstallCommand` currently owns agent resolution, managed-state checks, dry-run policy, package-manager execution, and lifecycle lock classification in addition to public result mapping. Extracting those command-neutral decisions continues the approved compatibility-preserving lifecycle boundary without changing uninstall behavior.
+
+## What Changes
+
+- Add a focused uninstall lifecycle service for resolution, ownership checks, dry-run decisions, execution, and lock classification.
+- Keep action names, error and warning messages, result shapes, exit behavior, and human rendering in `uninstallCommand`.
+- Add direct service tests and strengthen command compatibility assertions.
+- Preserve the existing state format, package-manager uninstall behavior, unmanaged-install refusal, dry-run semantics, and lifecycle lock scope.
+- Make no breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `uninstall-lifecycle-service`: Defines the internal uninstall lifecycle boundary and its observable compatibility requirements.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Code: `src/commands/uninstall.ts` and a new `src/services/uninstall.ts`.
+- Tests: `test/commands/uninstall.test.ts` and a new focused service test.
+- No changes to public commands, schemas, configuration, state, catalog, installer adapters, or release behavior.

--- a/openspec/changes/extract-uninstall-lifecycle-service/specs/uninstall-lifecycle-service/spec.md
+++ b/openspec/changes/extract-uninstall-lifecycle-service/specs/uninstall-lifecycle-service/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Uninstall lifecycle extraction MUST preserve published behavior
+
+Quantex MUST preserve the existing `uninstall` action, target, data fields, warnings, error codes, error details, exit behavior, and persisted-state semantics while moving command-neutral uninstall decisions behind a service boundary.
+
+#### Scenario: Unknown agent remains unchanged
+
+- **WHEN** uninstall receives an unknown agent name
+- **THEN** Quantex returns the existing `AGENT_NOT_FOUND` result and input details
+
+#### Scenario: Unmanaged install remains protected
+
+- **WHEN** the target agent has no recorded Quantex install state
+- **THEN** Quantex returns `UNINSTALL_UNMANAGED`
+- **AND** does not invoke automatic uninstall
+
+#### Scenario: Dry run remains non-mutating
+
+- **WHEN** a managed target is uninstalled in dry-run mode
+- **THEN** Quantex returns the existing successful `DRY_RUN` result
+- **AND** does not invoke automatic uninstall
+
+#### Scenario: Managed uninstall preserves success and failure
+
+- **WHEN** the existing package-manager uninstall operation succeeds or fails
+- **THEN** Quantex preserves the existing success data or `UNINSTALL_FAILED` result
+
+#### Scenario: Lifecycle lock remains structured
+
+- **WHEN** uninstall cannot acquire the lifecycle lock
+- **THEN** Quantex returns the existing `RESOURCE_LOCKED` result and resource details
+
+### Requirement: Command output MUST remain outside the uninstall lifecycle service
+
+The uninstall lifecycle service MUST return command-neutral outcomes, while `uninstallCommand` remains responsible for public result construction, messages, exit behavior, and human rendering.
+
+#### Scenario: Command maps service outcome
+
+- **WHEN** the uninstall service returns a terminal lifecycle outcome
+- **THEN** `uninstallCommand` maps it to the existing public contract without exposing internal service types

--- a/openspec/changes/extract-uninstall-lifecycle-service/tasks.md
+++ b/openspec/changes/extract-uninstall-lifecycle-service/tasks.md
@@ -1,0 +1,23 @@
+## 1. Compatibility Baseline
+
+- [x] 1.1 Strengthen `test/commands/uninstall.test.ts` structured assertions for unmanaged, dry-run, success, failure, and lock outcomes.
+- [x] 1.2 Run the existing uninstall command tests before refactoring.
+
+## 2. Service TDD
+
+- [x] 2.1 Add failing `test/services/uninstall.test.ts` coverage for all service outcomes and unexpected error propagation.
+- [x] 2.2 Verify the service test fails because `src/services/uninstall.ts` does not exist.
+- [x] 2.3 Implement `runUninstallLifecycle(agentName, options, dependencies)` in `src/services/uninstall.ts`.
+- [x] 2.4 Verify the focused service tests pass.
+
+## 3. Command Migration
+
+- [x] 3.1 Refactor `src/commands/uninstall.ts` to map service outcomes while preserving messages and rendering.
+- [x] 3.2 Run focused service and command compatibility tests.
+- [x] 3.3 Remove duplicate lifecycle imports and branches from the command.
+
+## 4. Validation
+
+- [x] 4.1 Run lint, format check, typecheck, the full test suite, OpenSpec validation, and memory check.
+- [x] 4.2 Review the diff and mark all implementation tasks complete.
+- [x] 4.3 Commit the completed uninstall extraction without creating a PR.

--- a/openspec/changes/extract-update-execution-service/.openspec.yaml
+++ b/openspec/changes/extract-update-execution-service/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/extract-update-execution-service/design.md
+++ b/openspec/changes/extract-update-execution-service/design.md
@@ -1,0 +1,56 @@
+## Context
+
+`src/services/update.ts` already classifies inspections into up-to-date, manual, untracked, grouped managed, and fallback entries. The command then executes that plan while reading global CLI state, invoking package-manager operations, interpreting lifecycle locks, verifying self-updates, and emitting progress events. This mixes lifecycle execution with public output mapping and makes the execution contract difficult to test directly.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Move update-plan execution into a focused, directly testable service.
+- Preserve grouped execution order, fallback behavior, cancellation, dry-run, lock details, failure hints, and self-update verification.
+- Keep public output construction and rendering in the command.
+
+**Non-Goals:**
+
+- Changing update planning or agent update strategy selection.
+- Changing package-manager adapter return types, concurrency, lifecycle lock scope, or installer behavior.
+- Changing command schemas, result shapes, messages, or exit behavior.
+- Refactoring the self-upgrade subsystem or catalog loading in this change.
+
+## Decisions
+
+### Consume the existing plan without introducing another planner
+
+Create `executePlannedUpdates(plan, options, dependencies)` in `src/services/update-execution.ts`. The service consumes `PlannedAgentUpdates` and returns ordered results plus a failure flag. `src/services/update.ts` remains the sole owner of plan construction.
+
+### Make runtime policy explicit
+
+The command passes `dryRun`, `isCancelled`, and an optional `onProgress` callback. The service does not read CLI context, output mode, or user-output globals. This keeps cancellation and dry-run behavior testable without changing when the command observes them.
+
+### Keep output transport in the command
+
+The service returns domain result items and may include existing domain guidance such as manual-update messages and failure hints. It does not create `CommandResult` values or NDJSON events. The command maps progress callbacks and terminal execution state to the existing public contract.
+
+### Preserve dynamic default dependencies
+
+Default dependencies are resolved when `executePlannedUpdates` is called rather than captured at module initialization. This preserves the existing test seams and keeps direct injection available for service tests.
+
+## Risks / Trade-offs
+
+- **Risk: Ordered results or cancellation checkpoints drift during extraction.** → Add direct tests for initial classifications, grouped execution, fallback, and cancellation before moving implementation.
+- **Risk: Output events change when progress moves behind a callback.** → Keep event construction in the command and retain command-level structured-output tests.
+- **Risk: Self-update verification changes success classification.** → Test both unchanged and changed verified versions in the service.
+- **Trade-off: Adapter operations still return booleans.** → Rich adapter errors remain a later, separately specified concern.
+
+## Migration Plan
+
+1. Add failing direct tests for execution outcomes and explicit options.
+2. Implement the service using the existing planner and package-manager contracts.
+3. Replace command-local execution functions with service invocation and progress mapping.
+4. Run focused command/service tests and full repository validation.
+
+Rollback restores command-local execution and deletes the service; no state or data migration is involved.
+
+## Open Questions
+
+None.

--- a/openspec/changes/extract-update-execution-service/proposal.md
+++ b/openspec/changes/extract-update-execution-service/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Update planning already lives in `src/services/update.ts`, but `updateCommand` still owns grouped execution, fallback behavior, cancellation, dry-run handling, lifecycle lock classification, self-update verification, and progress emission. Extracting command-neutral execution completes the update lifecycle boundary while preserving the published CLI contract.
+
+## What Changes
+
+- Add a focused update execution service that consumes the existing update plan.
+- Pass dry-run, cancellation, and progress reporting through explicit service options.
+- Keep action names, structured results, error mapping, NDJSON event construction, and human rendering in `updateCommand`.
+- Add direct service tests and retain the existing command compatibility coverage.
+- Preserve grouped installer order, per-agent fallback, self-update version verification, lifecycle lock details, and cancellation behavior.
+- Make no breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `update-execution-service`: Defines the internal update execution boundary and its observable compatibility requirements.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Code: `src/commands/update.ts` and a new `src/services/update-execution.ts`.
+- Tests: `test/commands/update.test.ts` and a new focused service test.
+- No changes to public commands, schemas, configuration, state, catalog, update planning, installer adapters, or release behavior.

--- a/openspec/changes/extract-update-execution-service/specs/update-execution-service/spec.md
+++ b/openspec/changes/extract-update-execution-service/specs/update-execution-service/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Update execution extraction MUST preserve published behavior
+
+Quantex MUST preserve the existing `update` action, target, data fields, error codes, error details, progress ordering, exit behavior, and update semantics while moving command-neutral plan execution behind a service boundary.
+
+#### Scenario: Existing classifications remain ordered
+
+- **WHEN** an update plan contains up-to-date, skipped manual-check, or untracked-path entries
+- **THEN** Quantex reports the existing result status, version fields, and guidance in the existing order
+
+#### Scenario: Grouped update retains fallback behavior
+
+- **WHEN** a managed package group succeeds
+- **THEN** Quantex reports each grouped entry as updated
+- **AND WHEN** the group operation returns failure
+- **THEN** Quantex falls back to the existing per-agent update behavior
+
+#### Scenario: Dry run remains non-mutating
+
+- **WHEN** update execution runs in dry-run mode
+- **THEN** Quantex reports the existing planned results
+- **AND** does not invoke package-manager mutations
+
+#### Scenario: Cancellation stops remaining work
+
+- **WHEN** cancellation is observed between update operations
+- **THEN** Quantex stops executing remaining grouped and manual entries
+- **AND** preserves results already produced
+
+#### Scenario: Lifecycle lock remains structured
+
+- **WHEN** a grouped or individual update cannot acquire the lifecycle lock
+- **THEN** Quantex preserves the existing locked status, message, strategy, and resource details
+
+#### Scenario: Self-update remains verified
+
+- **WHEN** a self-update operation succeeds
+- **THEN** Quantex verifies the installed version using the existing version probe
+- **AND** preserves the existing up-to-date or updated classification
+
+### Requirement: Command output MUST remain outside the update execution service
+
+The update execution service MUST return domain execution results and report progress through an optional callback, while `updateCommand` remains responsible for public result construction, NDJSON event construction, messages, error mapping, and human rendering.
+
+#### Scenario: Command maps execution state
+
+- **WHEN** the update execution service reports progress or returns terminal state
+- **THEN** `updateCommand` maps it to the existing public events and result contract without exposing internal service options

--- a/openspec/changes/extract-update-execution-service/tasks.md
+++ b/openspec/changes/extract-update-execution-service/tasks.md
@@ -1,0 +1,23 @@
+## 1. Compatibility Baseline
+
+- [x] 1.1 Confirm the existing update command tests cover structured success, failure, dry-run, cancellation, lock, fallback, and self-update outcomes.
+- [x] 1.2 Run the existing update command tests before refactoring.
+
+## 2. Service TDD
+
+- [x] 2.1 Add failing `test/services/update-execution.test.ts` coverage for ordered classifications, grouped success and fallback, dry-run, cancellation, lock, and self-update verification.
+- [x] 2.2 Verify the service test fails because `src/services/update-execution.ts` does not exist.
+- [x] 2.3 Implement `executePlannedUpdates(plan, options, dependencies)` in `src/services/update-execution.ts`.
+- [x] 2.4 Verify the focused service tests pass.
+
+## 3. Command Migration
+
+- [x] 3.1 Refactor `src/commands/update.ts` to map service progress and terminal state while preserving messages and rendering.
+- [x] 3.2 Run focused service and command compatibility tests.
+- [x] 3.3 Remove duplicate execution imports, types, and functions from the command.
+
+## 4. Validation
+
+- [x] 4.1 Run lint, format check, typecheck, the full test suite, OpenSpec validation, and memory check.
+- [x] 4.2 Review the diff and mark all implementation tasks complete.
+- [x] 4.3 Commit the completed update extraction without creating a PR.

--- a/openspec/changes/separate-agent-catalog-loader/.openspec.yaml
+++ b/openspec/changes/separate-agent-catalog-loader/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/separate-agent-catalog-loader/design.md
+++ b/openspec/changes/separate-agent-catalog-loader/design.md
@@ -1,0 +1,50 @@
+## Context
+
+The generated `catalog-data.ts` snapshot imports every checked-in JSON entry. `catalog.ts` immediately parses that singleton, materializes runtime definitions, builds a name index, and exposes lookup functions. Parsing and materialization cannot currently be exercised independently from the repository snapshot.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Separate catalog data loading from current-snapshot ownership.
+- Keep schema validation and behavior-extension merging directly testable.
+- Preserve runtime definitions, ordering, named exports, and object identity.
+
+**Non-Goals:**
+
+- Loading external or user-provided catalogs at runtime.
+- Adding dynamic plugins, remote catalogs, hot reload, or mutable registry behavior.
+- Changing catalog JSON, schema, generated manifests, or agent metadata.
+
+## Decisions
+
+### Introduce a synchronous pure loader
+
+Add `loadAgentCatalog(data, behaviorExtensions?)`, which parses unknown input with the existing Zod schema, maps entries to `AgentDefinition`, and returns ordered agents plus canonical-name lookup. It performs no filesystem or generated-module access.
+
+### Keep the generated snapshot as the production adapter
+
+`catalog.ts` imports `catalogData`, calls the loader once, and preserves `getCatalogAgents` and `getCatalogAgent`. Generated named exports continue to resolve through that adapter, so callers and object identity remain unchanged.
+
+### Keep behavior extensions explicit
+
+The loader accepts an optional extension map for runtime-only functions such as custom version parsers. The production adapter passes the current empty extension set. This removes hidden module state without changing catalog data.
+
+## Risks / Trade-offs
+
+- **Risk: Loader copies change object identity or order.** → Retain one loaded snapshot instance and assert named exports reference the same objects.
+- **Risk: Validation behavior drifts.** → Reuse the existing `agentCatalogSchema` and add direct invalid-input coverage.
+- **Trade-off: The loader is exported internally but not exposed as a CLI feature.** → Keep it under `src/agents` and do not add external catalog discovery.
+
+## Migration Plan
+
+1. Run the existing catalog compatibility suite.
+2. Add failing direct loader tests.
+3. Implement the loader and migrate `catalog.ts` to a single loaded snapshot.
+4. Run focused and full repository validation, including generated manifest checks.
+
+Rollback moves the small loader functions back into `catalog.ts`; no data migration is involved.
+
+## Open Questions
+
+None.

--- a/openspec/changes/separate-agent-catalog-loader/proposal.md
+++ b/openspec/changes/separate-agent-catalog-loader/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`src/agents/catalog.ts` currently combines catalog parsing/materialization with binding to the checked-in generated snapshot. Separating a pure loader from the snapshot adapter makes catalog validation and behavior extensions independently testable while preserving the current generated catalog contract.
+
+## What Changes
+
+- Add a pure agent catalog loader that parses supplied catalog data and builds indexed runtime definitions.
+- Keep `catalog.ts` as the adapter that binds the generated `catalogData` snapshot to the loader.
+- Preserve catalog JSON files, schema, generated manifests, named exports, ordering, lookup behavior, and runtime object identity.
+- Add focused loader tests while retaining the existing catalog and manifest compatibility suite.
+- Make no breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `agent-catalog-loader`: Defines the internal loader/snapshot boundary and compatibility requirements.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Code: a new `src/agents/catalog-loader.ts` and a smaller `src/agents/catalog.ts`.
+- Tests: a new focused loader test and existing `test/agents.test.ts`.
+- No changes to public commands, catalog entries, JSON Schema, generated files, install/update metadata, or release behavior.

--- a/openspec/changes/separate-agent-catalog-loader/specs/agent-catalog-loader/spec.md
+++ b/openspec/changes/separate-agent-catalog-loader/specs/agent-catalog-loader/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Catalog loader extraction MUST preserve the runtime catalog
+
+Quantex MUST preserve catalog schema validation, entry ordering, runtime definitions, canonical lookup, generated named exports, and object identity while separating catalog loading from the checked-in generated snapshot.
+
+#### Scenario: Generated snapshot loads unchanged
+
+- **WHEN** Quantex initializes the checked-in generated catalog snapshot
+- **THEN** the loader returns the same ordered agent definitions and canonical lookups as before
+
+#### Scenario: Named exports retain identity
+
+- **WHEN** a caller imports a generated named agent export
+- **THEN** it references the same runtime object returned by catalog lookup and the full agent list
+
+#### Scenario: Invalid data is rejected
+
+- **WHEN** supplied catalog data violates the existing agent catalog schema
+- **THEN** the loader rejects it before creating runtime definitions
+
+#### Scenario: Runtime behavior extensions remain data-independent
+
+- **WHEN** a catalog entry receives a runtime-only behavior extension
+- **THEN** the loader merges that behavior without changing the serializable catalog snapshot
+
+### Requirement: Snapshot adapter MUST remain static
+
+The production catalog adapter MUST bind the checked-in generated snapshot once and MUST NOT introduce external, remote, mutable, or user-provided runtime catalog loading.
+
+#### Scenario: Production initialization
+
+- **WHEN** the agents module initializes
+- **THEN** it loads only the checked-in generated catalog snapshot through the pure loader

--- a/openspec/changes/separate-agent-catalog-loader/tasks.md
+++ b/openspec/changes/separate-agent-catalog-loader/tasks.md
@@ -1,0 +1,23 @@
+## 1. Compatibility Baseline
+
+- [x] 1.1 Run the existing agent catalog and generated-manifest tests.
+- [x] 1.2 Confirm ordered definitions, canonical lookup, named-export identity, schema validation, and manifest sync coverage.
+
+## 2. Loader TDD
+
+- [x] 2.1 Add failing direct tests for valid loading, invalid data, unknown lookup, ordering, and behavior-extension merging.
+- [x] 2.2 Verify failure because `src/agents/catalog-loader.ts` does not exist.
+- [x] 2.3 Implement `loadAgentCatalog(data, behaviorExtensions)` with the existing schema.
+- [x] 2.4 Verify focused loader tests pass.
+
+## 3. Snapshot Adapter Migration
+
+- [x] 3.1 Refactor `src/agents/catalog.ts` to bind generated `catalogData` through the loader once.
+- [x] 3.2 Run focused loader and existing catalog compatibility tests.
+- [x] 3.3 Confirm generated catalog files remain unchanged.
+
+## 4. Validation
+
+- [x] 4.1 Run lint, format check, typecheck, full tests, OpenSpec validation, memory check, and build.
+- [x] 4.2 Review the diff and mark implementation tasks complete.
+- [x] 4.3 Commit the completed loader extraction without creating a PR.

--- a/openspec/changes/separate-command-runtime-services/.openspec.yaml
+++ b/openspec/changes/separate-command-runtime-services/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-09

--- a/openspec/changes/separate-command-runtime-services/design.md
+++ b/openspec/changes/separate-command-runtime-services/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The runtime facade currently performs four different jobs: replay and persist idempotency records, race command work against deadlines and process signals, translate runtime failures into public output, and finalize successful work with passive self-update notices. These concerns share global CLI context and are covered only through the large facade test suite.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make timeout and signal races command-neutral and directly testable.
+- Make idempotency eligibility, lifecycle validation, metadata refresh, and persistence directly testable.
+- Leave public result/event construction and rendering in the runtime facade.
+- Preserve the exact execution order and compatibility contract.
+
+**Non-Goals:**
+
+- Changing CLI flags, timeout values, grace duration, cancellation-handler behavior, or signal support.
+- Changing idempotency storage format, TTL, target semantics, or lifecycle validity rules.
+- Replacing global CLI context in this change.
+- Adding retries, background execution, daemon behavior, or workflow orchestration.
+
+## Decisions
+
+### Represent cancellation as command-neutral outcomes
+
+Add `executeWithRuntimeCancellation` that returns `completed`, `timed-out`, or `signal-cancelled`. It receives the command function, timeout, cancellation-state reader, cancellation cleanup callback, and signal source dependencies. It does not create `CommandResult` values or emit output.
+
+The service retains the existing late-terminal grace rule: after a deadline, it waits up to `min(timeoutMs, 250)` for a concrete command result before performing cancellation cleanup and returning a timeout outcome.
+
+### Represent idempotency lookup as replay, conflict, or miss
+
+Add `resolveIdempotentExecution` that receives action, target, and explicit invocation metadata. It returns a command-neutral conflict, a refreshed replay result, or no match. A separate persistence function applies the existing success and dry-run rules.
+
+Lifecycle validity checks continue to use agent inspection and remain part of idempotency policy, not the CLI facade.
+
+### Keep output ownership in `command-runtime.ts`
+
+`executeCommandWithRuntime` remains the only public entry point. It maps timeout, signal, idempotency conflict, replay, and state-read outcomes to the existing JSON, NDJSON, and human output functions. Passive self-update notices remain a facade finalization concern.
+
+### Use explicit dependencies with dynamic defaults
+
+Both services expose injectable dependencies and resolve their default module functions at call time. This preserves existing ESM spy behavior while enabling direct unit tests.
+
+## Risks / Trade-offs
+
+- **Risk: Timeout and signal race ordering changes.** → Capture deadline, late completion, cleanup, signal, and listener-removal behavior in direct tests before migration.
+- **Risk: Idempotency replay metadata or lifecycle checks drift.** → Add direct tests for conflict, target mismatch, dry-run, stale lifecycle state, replay refresh, and persistence eligibility.
+- **Risk: Runtime output is emitted twice.** → Services return outcomes only; the facade remains the sole emitter.
+- **Trade-off: Global CLI context remains.** → This phase narrows its use to facade adaptation without expanding scope into a whole-context rewrite.
+
+## Migration Plan
+
+1. Run the existing runtime compatibility suite.
+2. Add failing tests for the two new command-neutral services.
+3. Implement cancellation and idempotency services.
+4. Replace command-local policies with service outcomes and preserve output mapping.
+5. Run focused and full repository validation.
+
+Rollback restores the prior private functions in `command-runtime.ts`; no persisted data migration is involved.
+
+## Open Questions
+
+None.

--- a/openspec/changes/separate-command-runtime-services/proposal.md
+++ b/openspec/changes/separate-command-runtime-services/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`command-runtime.ts` currently combines timeout races, process-signal cancellation, idempotency policy and persistence, lifecycle-state validation, public output emission, and passive update notices. Separating command-neutral runtime decisions from CLI output mapping makes the execution contract directly testable without changing any published behavior.
+
+## What Changes
+
+- Add a command-neutral cancellation service for deadlines, grace-period completion, process signals, and cancellation cleanup.
+- Add an idempotency service for replay eligibility, target matching, lifecycle validation, metadata refresh, and persistence decisions.
+- Keep `executeCommandWithRuntime` as the public composition and output adapter.
+- Preserve timeout, signal, idempotency, state-read error, NDJSON, human output, and passive self-update notice behavior.
+- Add focused service tests while retaining the existing runtime compatibility suite.
+- Make no breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `command-runtime-services`: Defines the internal timeout, cancellation, idempotency, and output boundaries and their compatibility requirements.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Code: `src/command-runtime.ts` and new focused modules under `src/services/`.
+- Tests: `test/command-runtime.test.ts` and new service tests.
+- No changes to CLI flags, result/event schemas, idempotency storage format, timeout values, error codes, state format, or release behavior.

--- a/openspec/changes/separate-command-runtime-services/specs/command-runtime-services/spec.md
+++ b/openspec/changes/separate-command-runtime-services/specs/command-runtime-services/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Runtime service extraction MUST preserve command behavior
+
+Quantex MUST preserve timeout, process-signal cancellation, idempotency replay, state-read failure, output, finalization, and passive self-update notice behavior while moving command-neutral runtime policies behind service boundaries.
+
+#### Scenario: Deadline preserves late terminal completion
+
+- **WHEN** the timeout deadline fires and primary work returns a terminal result within the existing grace period
+- **THEN** Quantex returns that terminal result
+- **AND** does not emit a timeout cancellation
+
+#### Scenario: Deadline cancellation remains structured
+
+- **WHEN** primary work does not complete within the deadline and grace period
+- **THEN** Quantex cancels registered operations
+- **AND** emits the existing cancelled event and `TIMEOUT` result
+
+#### Scenario: Process signal cancellation remains structured
+
+- **WHEN** the process receives `SIGINT` or `SIGTERM` during primary work
+- **THEN** Quantex cancels registered operations
+- **AND** emits the existing cancelled event and `CANCELLED` result
+
+#### Scenario: Idempotency behavior remains unchanged
+
+- **WHEN** an invocation supplies an idempotency key
+- **THEN** Quantex preserves existing conflict, target matching, dry-run exclusion, lifecycle validity, metadata refresh, and successful-result persistence rules
+
+#### Scenario: Runtime errors retain public mapping
+
+- **WHEN** the runtime encounters a state-read error, timeout, signal cancellation, idempotency conflict, or replay
+- **THEN** Quantex preserves the existing action, target, error details, result metadata, events, and human rendering
+
+### Requirement: Runtime services MUST remain output-neutral
+
+Cancellation and idempotency services MUST return command-neutral outcomes and MUST NOT emit `CommandResult`, NDJSON, or human output directly.
+
+#### Scenario: Facade maps service outcome
+
+- **WHEN** a runtime service returns an execution outcome
+- **THEN** `executeCommandWithRuntime` constructs and emits the existing public output exactly once

--- a/openspec/changes/separate-command-runtime-services/tasks.md
+++ b/openspec/changes/separate-command-runtime-services/tasks.md
@@ -1,0 +1,30 @@
+## 1. Compatibility Baseline
+
+- [x] 1.1 Run the existing command-runtime and state-read compatibility tests.
+- [x] 1.2 Confirm coverage for timeout, late completion, signal cancellation, idempotency, output, and passive notices.
+
+## 2. Cancellation Service TDD
+
+- [x] 2.1 Add failing tests for completion, timeout grace, cancellation cleanup, process signals, listener cleanup, and error propagation.
+- [x] 2.2 Verify failure because `src/services/runtime-cancellation.ts` does not exist.
+- [x] 2.3 Implement command-neutral cancellation outcomes with explicit dependencies.
+- [x] 2.4 Verify focused cancellation tests pass.
+
+## 3. Idempotency Service TDD
+
+- [x] 3.1 Add failing tests for miss, conflict, target mismatch, dry-run exclusion, lifecycle validity, replay metadata, and persistence eligibility.
+- [x] 3.2 Verify failure because `src/services/runtime-idempotency.ts` does not exist.
+- [x] 3.3 Implement command-neutral idempotency outcomes with explicit dependencies.
+- [x] 3.4 Verify focused idempotency tests pass.
+
+## 4. Runtime Facade Migration
+
+- [x] 4.1 Refactor `src/command-runtime.ts` to compose both services and own public output mapping.
+- [x] 4.2 Run focused service and existing facade compatibility tests.
+- [x] 4.3 Remove duplicate timeout, signal, and idempotency policy from the facade.
+
+## 5. Validation
+
+- [x] 5.1 Run lint, format check, typecheck, full tests, OpenSpec validation, and memory check.
+- [x] 5.2 Review the diff and mark implementation tasks complete.
+- [x] 5.3 Commit the completed runtime extraction without creating a PR.

--- a/src/agents/catalog-loader.ts
+++ b/src/agents/catalog-loader.ts
@@ -1,0 +1,50 @@
+import type { AgentDefinition, AgentVersionProbe } from './types'
+import { agentCatalogSchema } from './schema'
+
+export interface AgentBehaviorExtension {
+  versionProbeParser?: AgentVersionProbe['parser']
+}
+
+export type AgentBehaviorExtensions = Partial<Record<string, AgentBehaviorExtension>>
+
+export interface LoadedAgentCatalog {
+  agents: AgentDefinition[]
+  getAgent: (name: string) => AgentDefinition
+}
+
+export function loadAgentCatalog(data: unknown, behaviorExtensions: AgentBehaviorExtensions = {}): LoadedAgentCatalog {
+  const parsedCatalog = agentCatalogSchema.parse(data)
+  const agents = parsedCatalog.map(entry => toAgentDefinition(entry, behaviorExtensions[entry.name]))
+  const agentsByName = new Map(agents.map(agent => [agent.name, agent]))
+
+  return {
+    agents,
+    getAgent(name) {
+      const agent = agentsByName.get(name)
+      if (!agent) throw new Error(`Unknown catalog agent: ${name}`)
+      return agent
+    },
+  }
+}
+
+function toAgentDefinition(
+  entry: ReturnType<typeof agentCatalogSchema.parse>[number],
+  behavior: AgentBehaviorExtension | undefined,
+): AgentDefinition {
+  return {
+    ...entry,
+    versionProbe: mergeVersionProbe(entry.versionProbe, behavior),
+  }
+}
+
+function mergeVersionProbe(
+  versionProbe: AgentDefinition['versionProbe'],
+  behavior: AgentBehaviorExtension | undefined,
+): AgentDefinition['versionProbe'] {
+  if (!versionProbe && !behavior?.versionProbeParser) return undefined
+
+  return {
+    ...versionProbe,
+    ...(behavior?.versionProbeParser ? { parser: behavior.versionProbeParser } : {}),
+  }
+}

--- a/src/agents/catalog.ts
+++ b/src/agents/catalog.ts
@@ -1,48 +1,16 @@
-import type { AgentDefinition, AgentVersionProbe } from './types'
+import type { AgentDefinition } from './types'
+import { loadAgentCatalog } from './catalog-loader'
 import { catalogData } from './generated/catalog-data'
-import { agentCatalogSchema } from './schema'
 
 export { agentCatalogJsonSchema } from './schema'
 export type { AgentCatalogData, AgentCatalogEntry } from './schema'
 
-interface AgentBehaviorExtension {
-  versionProbeParser?: AgentVersionProbe['parser']
-}
-
-const behaviorExtensions: Partial<Record<string, AgentBehaviorExtension>> = {}
-
-const parsedCatalog = agentCatalogSchema.parse(catalogData)
-const agents = parsedCatalog.map(toAgentDefinition)
-const agentsByName = new Map(agents.map(agent => [agent.name, agent]))
+const loadedCatalog = loadAgentCatalog(catalogData)
 
 export function getCatalogAgents(): AgentDefinition[] {
-  return agents
+  return loadedCatalog.agents
 }
 
 export function getCatalogAgent(name: string): AgentDefinition {
-  const agent = agentsByName.get(name)
-  if (!agent) throw new Error(`Unknown catalog agent: ${name}`)
-  return agent
-}
-
-function toAgentDefinition(entry: (typeof parsedCatalog)[number]): AgentDefinition {
-  const behavior = behaviorExtensions[entry.name]
-  const versionProbe = mergeVersionProbe(entry.versionProbe, behavior)
-
-  return {
-    ...entry,
-    versionProbe,
-  }
-}
-
-function mergeVersionProbe(
-  versionProbe: AgentDefinition['versionProbe'],
-  behavior: AgentBehaviorExtension | undefined,
-): AgentDefinition['versionProbe'] {
-  if (!versionProbe && !behavior?.versionProbeParser) return undefined
-
-  return {
-    ...versionProbe,
-    ...(behavior?.versionProbeParser ? { parser: behavior.versionProbeParser } : {}),
-  }
+  return loadedCatalog.getAgent(name)
 }

--- a/src/command-runtime.ts
+++ b/src/command-runtime.ts
@@ -1,62 +1,13 @@
-import type { IdempotencyRecord } from './idempotency'
 import type { CommandResult, CommandTarget } from './output/types'
-
-function idempotencyTargetsMatch(stored?: CommandTarget, requested?: CommandTarget): boolean {
-  if (stored === undefined && requested === undefined) return true
-  if (stored === undefined || requested === undefined) return false
-  if (stored.kind !== requested.kind) return false
-  if (stored.kind === 'agent' && (!stored.name || !requested.name)) return false
-  return stored.name === requested.name
-}
-
-function isDryRunIdempotencyResult(result: CommandResult): boolean {
-  return result.warnings.some(warning => warning.code === 'DRY_RUN')
-}
-
-const agentPresenceRequiredActions = new Set(['install', 'ensure', 'update'])
-const agentAbsenceRequiredActions = new Set(['uninstall'])
-
-function getIdempotencyAgentNames(target?: CommandTarget): string[] | undefined {
-  if (target?.kind !== 'agent' || !target.name) return undefined
-
-  return target.name
-    .split(',')
-    .map(name => name.trim())
-    .filter(Boolean)
-}
-
-async function isStoredIdempotencyResultStillValid(record: IdempotencyRecord): Promise<boolean> {
-  if (!record.result.ok) return true
-
-  const agentNames = getIdempotencyAgentNames(record.target)
-  if (!agentNames || agentNames.length === 0) return true
-
-  if (agentPresenceRequiredActions.has(record.action)) {
-    for (const agentName of agentNames) {
-      const resolved = await resolveAgentInspection(agentName)
-      if (!resolved?.inspection.inPath) return false
-    }
-
-    return true
-  }
-
-  if (agentAbsenceRequiredActions.has(record.action)) {
-    for (const agentName of agentNames) {
-      const resolved = await resolveAgentInspection(agentName)
-      if (resolved?.inspection.inPath) return false
-    }
-
-    return true
-  }
-
-  return true
-}
-import process from 'node:process'
 import { cancelCliContextOperations, getCliContext } from './cli-context'
-import { loadIdempotencyRecord, saveIdempotencyRecord } from './idempotency'
 import { createErrorResult, emitCommandEvent, emitCommandResult } from './output'
 import { maybeRenderSelfUpdateNotice } from './self/update-notice'
-import { resolveAgentInspection } from './services/agents'
+import { executeWithRuntimeDeadline, executeWithSignalCancellation } from './services/runtime-cancellation'
+import {
+  persistIdempotentExecution,
+  resolveIdempotentExecution,
+  type RuntimeIdempotencyInvocation,
+} from './services/runtime-idempotency'
 import { getStateFilePath, StateFileError } from './state'
 import { pc } from './utils/color'
 import { createStateReadError } from './utils/lifecycle-errors'
@@ -78,238 +29,110 @@ export async function executeCommandWithRuntime<T>(options: ExecuteCommandOption
 }
 
 async function executeCommandWithRuntimeInternal<T>(options: ExecuteCommandOptions<T>): Promise<CommandResult<T>> {
-  const replayedResult = await replayIdempotentResult<T>(options.action, options.target)
-  if (replayedResult) return replayedResult
+  const idempotencyInvocation = createIdempotencyInvocation(options.action, options.target)
+  const idempotencyOutcome = await resolveIdempotentExecution<T>(idempotencyInvocation)
 
-  const timeoutMs = getCliContext().timeoutMs
+  if (idempotencyOutcome.kind === 'conflict') {
+    return emitIdempotencyConflict(options, idempotencyOutcome.existingAction, idempotencyOutcome.idempotencyKey)
+  }
 
-  if (timeoutMs === undefined)
-    return withSignalCancellation(options, () =>
-      options.run().then(result => finalizeSuccessfulRun(options.action, options.target, result)),
-    )
+  if (idempotencyOutcome.kind === 'replay') {
+    emitCommandResult(idempotencyOutcome.result, renderRuntimeHuman, { force: true })
+    return idempotencyOutcome.result
+  }
 
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const context = getCliContext()
+  const signalOutcome = await executeWithSignalCancellation({
+    cancelOperations: cancelCliContextOperations,
+    isCancelled: () => Boolean(getCliContext().cancelled),
+    run: async () => {
+      const deadlineOutcome = await executeWithRuntimeDeadline({
+        cancelOperations: cancelCliContextOperations,
+        isCancelled: () => Boolean(getCliContext().cancelled),
+        run: options.run,
+        timeoutMs: context.timeoutMs,
+      })
 
-  try {
-    const timeoutPromise = new Promise<CommandResult<T>>(resolve => {
-      timeoutId = setTimeout(() => {
-        resolve(createTimeoutCancellationResult(options, timeoutMs))
-      }, timeoutMs)
-    })
+      const result =
+        deadlineOutcome.kind === 'completed'
+          ? deadlineOutcome.result
+          : emitTimeoutCancellation(options, deadlineOutcome.timeoutMs)
 
-    // Race only the primary command work against the deadline. Post-run steps (idempotency
-    // persistence and passive self-update notice) must not consume the timeout budget.
-    return await withSignalCancellation(options, async () => {
-      const runPromise = runUntilTimeoutCancellation(options.run, () => timeoutPromise)
-      let result = await Promise.race([runPromise, timeoutPromise])
+      return finalizeRun(idempotencyInvocation, result)
+    },
+  })
 
-      if (!result.ok && result.error?.code === 'TIMEOUT') {
-        const lateResult = await waitForLateTerminalCompletion(runPromise, timeoutMs)
-        result = lateResult ?? (await emitTimeoutCancellation(options, timeoutMs))
-      }
+  if (signalOutcome.kind === 'signal-cancelled') {
+    return emitSignalCancellation(options, signalOutcome.signal)
+  }
 
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId)
-        timeoutId = undefined
-      }
-      return finalizeSuccessfulRun(options.action, options.target, result)
-    })
-  } finally {
-    if (timeoutId) clearTimeout(timeoutId)
+  return signalOutcome.result
+}
+
+function createIdempotencyInvocation(action: string, target?: CommandTarget): RuntimeIdempotencyInvocation {
+  const context = getCliContext()
+  return {
+    action,
+    dryRun: Boolean(context.dryRun),
+    idempotencyKey: context.idempotencyKey,
+    outputMode: context.outputMode,
+    runId: context.runId,
+    target,
   }
 }
 
-async function resolveStateReadError<T>(
-  options: ExecuteCommandOptions<T>,
-  error: StateFileError,
-): Promise<CommandResult<T>> {
-  return emitCommandResult(
-    createErrorResult<T>({
-      action: options.action,
-      ...createStateReadError(error, getStateFilePath(), options.target),
-    }),
-    renderStateReadHuman,
-  )
-}
-
-function renderStateReadHuman(result: Pick<CommandResult, 'error'>): void {
-  if (result.error) console.error(pc.red(result.error.message))
-}
-
-async function finalizeSuccessfulRun<T>(
-  action: string,
-  target: CommandTarget | undefined,
+async function finalizeRun<T>(
+  invocation: RuntimeIdempotencyInvocation,
   result: CommandResult<T>,
 ): Promise<CommandResult<T>> {
-  const storedResult = await storeIdempotentResult(action, target, result)
+  await persistIdempotentExecution(invocation, result)
 
   try {
     await maybeRenderSelfUpdateNotice({
-      action,
-      ok: storedResult.ok,
+      action: invocation.action,
+      ok: result.ok,
     })
   } catch {
     // Passive reminders must never fail the primary command path.
   }
 
-  return storedResult
-}
-
-function renderTimeoutHuman(result: Pick<CommandResult, 'error'>): void {
-  if (result.error) console.error(pc.red(result.error.message))
-}
-
-async function replayIdempotentResult<T>(
-  action: string,
-  target?: CommandTarget,
-): Promise<CommandResult<T> | undefined> {
-  const context = getCliContext()
-  if (!context.idempotencyKey) return undefined
-
-  const record = await loadIdempotencyRecord(context.idempotencyKey)
-  if (!record) return undefined
-
-  if (record.action !== action) {
-    return emitCommandResult(
-      createErrorResult<T>({
-        action,
-        error: {
-          code: 'INVALID_ARGUMENT',
-          details: {
-            existingAction: record.action,
-            idempotencyKey: context.idempotencyKey,
-          },
-          message: `Idempotency key ${context.idempotencyKey} was already used for ${record.action}.`,
-        },
-        target,
-      }),
-      renderTimeoutHuman,
-      { force: true },
-    )
-  }
-
-  if (!idempotencyTargetsMatch(record.target, target)) return undefined
-  if (isDryRunIdempotencyResult(record.result)) return undefined
-  if (!(await isStoredIdempotencyResultStillValid(record))) return undefined
-
-  const replayedResult = {
-    ...record.result,
-    meta: {
-      ...record.result.meta,
-      mode: context.outputMode,
-      runId: context.runId,
-      timestamp: new Date().toISOString(),
-    },
-  } as CommandResult<T>
-
-  emitCommandResult(replayedResult, renderTimeoutHuman, { force: true })
-  return replayedResult
-}
-
-async function storeIdempotentResult<T>(
-  action: string,
-  target: CommandTarget | undefined,
-  result: CommandResult<T>,
-): Promise<CommandResult<T>> {
-  const context = getCliContext()
-  if (context.idempotencyKey && result.ok && !context.dryRun && !isDryRunIdempotencyResult(result))
-    await saveIdempotencyRecord(context.idempotencyKey, { action, result, target })
-
   return result
 }
 
-async function withSignalCancellation<T>(
+function emitIdempotencyConflict<T>(
   options: ExecuteCommandOptions<T>,
-  run: () => Promise<CommandResult<T>>,
-): Promise<CommandResult<T>> {
-  let signalResultPromise: Promise<CommandResult<T>> | undefined
-  let cleanup: (() => void) | undefined
-
-  try {
-    const signalPromise = new Promise<CommandResult<T>>(resolve => {
-      const handleSignal = (signal: NodeJS.Signals): void => {
-        signalResultPromise ??= resolveSignalCancellation(options, signal)
-        void signalResultPromise.then(resolve)
-      }
-
-      const sigintHandler = (): void => handleSignal('SIGINT')
-      const sigtermHandler = (): void => handleSignal('SIGTERM')
-      process.once('SIGINT', sigintHandler)
-      process.once('SIGTERM', sigtermHandler)
-      cleanup = (): void => {
-        process.off('SIGINT', sigintHandler)
-        process.off('SIGTERM', sigtermHandler)
-      }
-    })
-
-    return await Promise.race([runUntilSignalCancellation(run, () => signalResultPromise), signalPromise])
-  } finally {
-    cleanup?.()
-  }
-}
-
-async function waitForLateTerminalCompletion<T>(
-  runPromise: Promise<CommandResult<T>>,
-  timeoutMs: number,
-): Promise<CommandResult<T> | undefined> {
-  const graceMs = Math.min(timeoutMs, 250)
-  const runResult = await Promise.race([
-    runPromise,
-    new Promise<undefined>(resolve => {
-      setTimeout(() => resolve(undefined), graceMs)
-    }),
-  ])
-
-  return runResult
-}
-
-async function runUntilTimeoutCancellation<T>(
-  run: () => Promise<CommandResult<T>>,
-  getTimeoutResult: () => Promise<CommandResult<T>>,
-): Promise<CommandResult<T>> {
-  try {
-    return await run()
-  } catch (error) {
-    if (getCliContext().cancelled) return getTimeoutResult()
-    throw error
-  }
-}
-
-async function runUntilSignalCancellation<T>(
-  run: () => Promise<CommandResult<T>>,
-  getSignalResult: () => Promise<CommandResult<T>> | undefined,
-): Promise<CommandResult<T>> {
-  try {
-    const result = await run()
-    const signalResult = getSignalResult()
-    if (getCliContext().cancelled && signalResult) return signalResult
-    return result
-  } catch (error) {
-    const signalResult = getSignalResult()
-    if (getCliContext().cancelled && signalResult) return signalResult
-    throw error
-  }
-}
-
-function createTimeoutCancellationResult<T>(options: ExecuteCommandOptions<T>, timeoutMs: number): CommandResult<T> {
-  return createErrorResult<T>({
-    action: options.action,
-    error: {
-      code: 'TIMEOUT',
-      details: {
-        timeoutMs,
+  existingAction: string,
+  idempotencyKey: string,
+): CommandResult<T> {
+  return emitCommandResult(
+    createErrorResult<T>({
+      action: options.action,
+      error: {
+        code: 'INVALID_ARGUMENT',
+        details: {
+          existingAction,
+          idempotencyKey,
+        },
+        message: `Idempotency key ${idempotencyKey} was already used for ${existingAction}.`,
       },
-      message: `Command timed out after ${timeoutMs}ms.`,
-    },
-    target: options.target,
-  })
+      target: options.target,
+    }),
+    renderRuntimeHuman,
+    { force: true },
+  )
 }
 
-async function emitTimeoutCancellation<T>(
-  options: ExecuteCommandOptions<T>,
-  timeoutMs: number,
-): Promise<CommandResult<T>> {
-  await cancelCliContextOperations()
+function resolveStateReadError<T>(options: ExecuteCommandOptions<T>, error: StateFileError): CommandResult<T> {
+  return emitCommandResult(
+    createErrorResult<T>({
+      action: options.action,
+      ...createStateReadError(error, getStateFilePath(), options.target),
+    }),
+    renderRuntimeHuman,
+  )
+}
+
+function emitTimeoutCancellation<T>(options: ExecuteCommandOptions<T>, timeoutMs: number): CommandResult<T> {
   emitCommandEvent(
     {
       action: options.action,
@@ -323,14 +146,24 @@ async function emitTimeoutCancellation<T>(
     { force: true },
   )
 
-  return emitCommandResult(createTimeoutCancellationResult(options, timeoutMs), renderTimeoutHuman, { force: true })
+  return emitCommandResult(
+    createErrorResult<T>({
+      action: options.action,
+      error: {
+        code: 'TIMEOUT',
+        details: {
+          timeoutMs,
+        },
+        message: `Command timed out after ${timeoutMs}ms.`,
+      },
+      target: options.target,
+    }),
+    renderRuntimeHuman,
+    { force: true },
+  )
 }
 
-async function resolveSignalCancellation<T>(
-  options: ExecuteCommandOptions<T>,
-  signal: NodeJS.Signals,
-): Promise<CommandResult<T>> {
-  await cancelCliContextOperations()
+function emitSignalCancellation<T>(options: ExecuteCommandOptions<T>, signal: 'SIGINT' | 'SIGTERM'): CommandResult<T> {
   emitCommandEvent(
     {
       action: options.action,
@@ -356,7 +189,11 @@ async function resolveSignalCancellation<T>(
       },
       target: options.target,
     }),
-    renderTimeoutHuman,
+    renderRuntimeHuman,
     { force: true },
   )
+}
+
+function renderRuntimeHuman(result: Pick<CommandResult, 'error'>): void {
+  if (result.error) console.error(pc.red(result.error.message))
 }

--- a/src/commands/ensure.ts
+++ b/src/commands/ensure.ts
@@ -1,11 +1,9 @@
 import type { CommandResult } from '../output/types'
+import type { InstallEnsureLifecycleOutcome } from '../services/install-ensure'
 import { createErrorResult, createSuccessResult, emitCommandEvent, emitCommandResult } from '../output'
-import { installAgent, trackInstalledAgent } from '../package-manager'
-import { resolveAgentInspection } from '../services/agents'
+import { runInstallEnsureLifecycle } from '../services/install-ensure'
 import { pc } from '../utils/color'
-import { getAdoptableExistingInstallMethod } from '../utils/install'
 import { createResourceLockedError } from '../utils/lifecycle-errors'
-import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
 
 interface EnsureCommandData {
@@ -22,229 +20,183 @@ interface EnsureCommandData {
 }
 
 export async function ensureCommand(agentName: string): Promise<CommandResult<EnsureCommandData>> {
-  const resolved = await resolveAgentInspection(agentName)
-  if (!resolved) {
-    return emitCommandResult(
-      createErrorResult<EnsureCommandData>({
-        action: 'ensure',
-        error: {
-          code: 'AGENT_NOT_FOUND',
-          details: {
-            input: agentName,
-          },
-          message: `Unknown agent: ${agentName}`,
+  const outcome = await runInstallEnsureLifecycle(agentName, {
+    dryRun: isDryRunEnabled(),
+    onMutationStart: emitEnsureStarted,
+  })
+
+  return emitCommandResult(createEnsureResult(agentName, outcome), renderEnsureHuman)
+}
+
+function createEnsureResult(
+  agentName: string,
+  outcome: InstallEnsureLifecycleOutcome,
+): CommandResult<EnsureCommandData> {
+  if (outcome.kind === 'agent-not-found') {
+    return createErrorResult<EnsureCommandData>({
+      action: 'ensure',
+      error: {
+        code: 'AGENT_NOT_FOUND',
+        details: {
+          input: outcome.input,
         },
-        target: {
-          kind: 'agent',
-          name: agentName,
-        },
-      }),
-      renderEnsureHuman,
-    )
+        message: `Unknown agent: ${outcome.input}`,
+      },
+      target: {
+        kind: 'agent',
+        name: agentName,
+      },
+    })
   }
 
-  const { agent, inspection } = resolved
-  if (inspection.inPath) {
-    if (inspection.installedState) {
-      return emitCommandResult(
-        createSuccessResult<EnsureCommandData>({
-          action: 'ensure',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: false,
-            installed: true,
-          },
-          target: {
-            kind: 'agent',
-            name: agent.name,
-          },
-          warnings: [
-            {
-              code: 'ALREADY_INSTALLED',
-              message: `${agent.displayName} is already installed.`,
-            },
-          ],
-        }),
-        renderEnsureHuman,
-      )
-    }
+  const { agent } = outcome
+  const target = {
+    kind: 'agent' as const,
+    name: agent.name,
+  }
+  const agentData = {
+    displayName: agent.displayName,
+    name: agent.name,
+  }
 
-    const adoptableMethod = getAdoptableExistingInstallMethod(
-      inspection.methods,
-      inspection.resolvedBinaryPath ?? inspection.binaryPath,
-    )
-    if (adoptableMethod) {
-      if (isDryRunEnabled()) {
-        return emitCommandResult(
-          createSuccessResult<EnsureCommandData>({
-            action: 'ensure',
-            data: {
-              agent: {
-                displayName: agent.displayName,
-                name: agent.name,
-              },
-              changed: false,
-              installed: true,
-            },
-            target: {
-              kind: 'agent',
-              name: agent.name,
-            },
-            warnings: [
-              {
-                code: 'DRY_RUN',
-                message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
-              },
-            ],
-          }),
-          renderEnsureHuman,
-        )
-      }
-
-      emitCommandEvent({
+  switch (outcome.kind) {
+    case 'already-installed':
+      return createSuccessResult<EnsureCommandData>({
         action: 'ensure',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
-        },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
-        type: 'started',
-      })
-
-      try {
-        const installedState = await trackInstalledAgent(agent, adoptableMethod)
-        if (!installedState) {
-          return emitCommandResult(
-            createErrorResult<EnsureCommandData>({
-              action: 'ensure',
-              error: {
-                code: 'CANCELLED',
-                message: 'Ensure was cancelled before tracking could complete.',
-              },
-              target: {
-                kind: 'agent',
-                name: agent.name,
-              },
-            }),
-            renderEnsureHuman,
-          )
-        }
-
-        return emitCommandResult(
-          createSuccessResult<EnsureCommandData>({
-            action: 'ensure',
-            data: {
-              agent: {
-                displayName: agent.displayName,
-                name: agent.name,
-              },
-              changed: true,
-              installState: {
-                installType: installedState.installType,
-                packageName: installedState.packageName,
-              },
-              installed: true,
-            },
-            target: {
-              kind: 'agent',
-              name: agent.name,
-            },
-            warnings: [
-              {
-                code: 'TRACKED_EXISTING_INSTALL',
-                message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
-              },
-            ],
-          }),
-          renderEnsureHuman,
-        )
-      } catch (error) {
-        if (isResourceLockError(error)) {
-          return emitCommandResult(
-            createErrorResult<EnsureCommandData>({
-              action: 'ensure',
-              data: {
-                agent: {
-                  displayName: agent.displayName,
-                  name: agent.name,
-                },
-                changed: false,
-                installed: true,
-              },
-              ...createResourceLockedError(error, {
-                kind: 'agent',
-                name: agent.name,
-              }),
-            }),
-            renderEnsureHuman,
-          )
-        }
-
-        throw error
-      }
-    }
-
-    return emitCommandResult(
-      createSuccessResult<EnsureCommandData>({
-        action: 'ensure',
-        data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
+          agent: agentData,
           changed: false,
           installed: true,
         },
-        target: {
-          kind: 'agent',
-          name: agent.name,
+        target,
+        warnings: [
+          {
+            code: 'ALREADY_INSTALLED',
+            message: `${agent.displayName} is already installed.`,
+          },
+        ],
+      })
+    case 'would-track-existing':
+      return createSuccessResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: true,
         },
+        target,
+        warnings: [
+          {
+            code: 'DRY_RUN',
+            message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
+          },
+        ],
+      })
+    case 'tracked-existing':
+      return createSuccessResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: true,
+          installState: {
+            installType: outcome.installedState.installType,
+            packageName: outcome.installedState.packageName,
+          },
+          installed: true,
+        },
+        target,
+        warnings: [
+          {
+            code: 'TRACKED_EXISTING_INSTALL',
+            message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
+          },
+        ],
+      })
+    case 'tracking-cancelled':
+      return createErrorResult<EnsureCommandData>({
+        action: 'ensure',
+        error: {
+          code: 'CANCELLED',
+          message: 'Ensure was cancelled before tracking could complete.',
+        },
+        target,
+      })
+    case 'untracked-existing':
+      return createSuccessResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: true,
+        },
+        target,
         warnings: [
           {
             code: 'UNTRACKED_EXISTING_INSTALL',
             message: `${agent.displayName} is already installed but not tracked by Quantex. Quantex could not safely determine the supported install source, so the existing install remains unmanaged.`,
           },
         ],
-      }),
-      renderEnsureHuman,
-    )
-  }
-
-  if (isDryRunEnabled()) {
-    return emitCommandResult(
-      createSuccessResult<EnsureCommandData>({
+      })
+    case 'would-install':
+      return createSuccessResult<EnsureCommandData>({
         action: 'ensure',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
+          agent: agentData,
           changed: false,
           installed: false,
         },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
+        target,
         warnings: [
           {
             code: 'DRY_RUN',
             message: `Dry run: would install ${agent.displayName}.`,
           },
         ],
-      }),
-      renderEnsureHuman,
-    )
+      })
+    case 'installed':
+      return createSuccessResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: true,
+          installState: outcome.installedState
+            ? {
+                installType: outcome.installedState.installType,
+                packageName: outcome.installedState.packageName,
+              }
+            : undefined,
+          installed: true,
+        },
+        target,
+      })
+    case 'install-failed':
+      return createErrorResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: false,
+        },
+        error: {
+          code: 'INSTALL_FAILED',
+          message: `Failed to install ${agent.displayName}.`,
+        },
+        target,
+      })
+    case 'resource-locked':
+      return createErrorResult<EnsureCommandData>({
+        action: 'ensure',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: outcome.installed,
+        },
+        ...createResourceLockedError(outcome.error, target),
+      })
   }
+}
 
+function emitEnsureStarted(agent: { displayName: string; name: string }): void {
   emitCommandEvent({
     action: 'ensure',
     data: {
@@ -259,84 +211,6 @@ export async function ensureCommand(agentName: string): Promise<CommandResult<En
     },
     type: 'started',
   })
-
-  let result
-  try {
-    result = await installAgent(agent)
-  } catch (error) {
-    if (isResourceLockError(error)) {
-      return emitCommandResult(
-        createErrorResult<EnsureCommandData>({
-          action: 'ensure',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: false,
-            installed: false,
-          },
-          ...createResourceLockedError(error, {
-            kind: 'agent',
-            name: agent.name,
-          }),
-        }),
-        renderEnsureHuman,
-      )
-    }
-
-    throw error
-  }
-
-  if (result.success) {
-    return emitCommandResult(
-      createSuccessResult<EnsureCommandData>({
-        action: 'ensure',
-        data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
-          changed: true,
-          installState: result.installedState
-            ? {
-                installType: result.installedState.installType,
-                packageName: result.installedState.packageName,
-              }
-            : undefined,
-          installed: true,
-        },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
-      }),
-      renderEnsureHuman,
-    )
-  }
-
-  return emitCommandResult(
-    createErrorResult<EnsureCommandData>({
-      action: 'ensure',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        changed: false,
-        installed: false,
-      },
-      error: {
-        code: 'INSTALL_FAILED',
-        message: `Failed to install ${agent.displayName}.`,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-    }),
-    renderEnsureHuman,
-  )
 }
 
 function renderEnsureHuman(result: {

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,12 +1,10 @@
 import type { CommandError, CommandResult, CommandWarning } from '../output/types'
+import type { InstallEnsureLifecycleOutcome } from '../services/install-ensure'
 import { getCliContext } from '../cli-context'
 import { createErrorResult, createSuccessResult, emitCommandEvent, emitCommandResult } from '../output'
-import { installAgent, trackInstalledAgent } from '../package-manager'
-import { resolveAgentInspection } from '../services/agents'
+import { runInstallEnsureLifecycle } from '../services/install-ensure'
 import { pc } from '../utils/color'
-import { getAdoptableExistingInstallMethod } from '../utils/install'
 import { createResourceLockedError } from '../utils/lifecycle-errors'
-import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
 
 interface InstallCommandData {
@@ -172,16 +170,27 @@ async function performSingleInstall(
     })
   }
 
-  const resolved = await resolveAgentInspection(agentName)
-  if (!resolved) {
+  const outcome = await runInstallEnsureLifecycle(agentName, {
+    dryRun: isDryRunEnabled(),
+    onMutationStart: agent => emitInstallStarted(agent, options.emitStartedEvent),
+  })
+
+  return createInstallResult(agentName, outcome)
+}
+
+function createInstallResult(
+  agentName: string,
+  outcome: InstallEnsureLifecycleOutcome,
+): CommandResult<InstallCommandData> {
+  if (outcome.kind === 'agent-not-found') {
     return createErrorResult<InstallCommandData>({
       action: 'install',
       error: {
         code: 'AGENT_NOT_FOUND',
         details: {
-          input: agentName,
+          input: outcome.input,
         },
-        message: `Unknown agent: ${agentName}`,
+        message: `Unknown agent: ${outcome.input}`,
       },
       target: {
         kind: 'agent',
@@ -190,23 +199,26 @@ async function performSingleInstall(
     })
   }
 
-  const { agent, inspection } = resolved
-  if (inspection.inPath) {
-    if (inspection.installedState) {
+  const { agent } = outcome
+  const target = {
+    kind: 'agent' as const,
+    name: agent.name,
+  }
+  const agentData = {
+    displayName: agent.displayName,
+    name: agent.name,
+  }
+
+  switch (outcome.kind) {
+    case 'already-installed':
       return createSuccessResult<InstallCommandData>({
         action: 'install',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
+          agent: agentData,
           changed: false,
           installed: true,
         },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
+        target,
         warnings: [
           {
             code: 'ALREADY_INSTALLED',
@@ -214,220 +226,124 @@ async function performSingleInstall(
           },
         ],
       })
-    }
-
-    const adoptableMethod = getAdoptableExistingInstallMethod(
-      inspection.methods,
-      inspection.resolvedBinaryPath ?? inspection.binaryPath,
-    )
-    if (adoptableMethod) {
-      if (isDryRunEnabled()) {
-        return createSuccessResult<InstallCommandData>({
-          action: 'install',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: false,
-            installed: true,
-          },
-          target: {
-            kind: 'agent',
-            name: agent.name,
-          },
-          warnings: [
-            {
-              code: 'DRY_RUN',
-              message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
-            },
-          ],
-        })
-      }
-
-      emitInstallStarted(agent, options.emitStartedEvent)
-
-      try {
-        const installedState = await trackInstalledAgent(agent, adoptableMethod)
-        if (!installedState) {
-          return createErrorResult<InstallCommandData>({
-            action: 'install',
-            error: {
-              code: 'CANCELLED',
-              message: 'Install was cancelled before tracking could complete.',
-            },
-            target: {
-              kind: 'agent',
-              name: agent.name,
-            },
-          })
-        }
-
-        return createSuccessResult<InstallCommandData>({
-          action: 'install',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: true,
-            installState: {
-              installType: installedState.installType,
-              packageName: installedState.packageName,
-            },
-            installed: true,
-          },
-          target: {
-            kind: 'agent',
-            name: agent.name,
-          },
-          warnings: [
-            {
-              code: 'TRACKED_EXISTING_INSTALL',
-              message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
-            },
-          ],
-        })
-      } catch (error) {
-        if (isResourceLockError(error)) {
-          return createErrorResult<InstallCommandData>({
-            action: 'install',
-            data: {
-              agent: {
-                displayName: agent.displayName,
-                name: agent.name,
-              },
-              changed: false,
-              installed: true,
-            },
-            ...createResourceLockedError(error, {
-              kind: 'agent',
-              name: agent.name,
-            }),
-          })
-        }
-
-        throw error
-      }
-    }
-
-    return createSuccessResult<InstallCommandData>({
-      action: 'install',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        changed: false,
-        installed: true,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-      warnings: [
-        {
-          code: 'UNTRACKED_EXISTING_INSTALL',
-          message: `${agent.displayName} is already installed but not tracked by Quantex. Quantex could not safely determine the supported install source, so the existing install remains unmanaged.`,
-        },
-      ],
-    })
-  }
-
-  if (isDryRunEnabled()) {
-    return createSuccessResult<InstallCommandData>({
-      action: 'install',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        changed: false,
-        installed: false,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-      warnings: [
-        {
-          code: 'DRY_RUN',
-          message: `Dry run: would install ${agent.displayName}.`,
-        },
-      ],
-    })
-  }
-
-  emitInstallStarted(agent, options.emitStartedEvent)
-
-  let result
-  try {
-    result = await installAgent(agent)
-  } catch (error) {
-    if (isResourceLockError(error)) {
-      return createErrorResult<InstallCommandData>({
+    case 'would-track-existing':
+      return createSuccessResult<InstallCommandData>({
         action: 'install',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
+          agent: agentData,
+          changed: false,
+          installed: true,
+        },
+        target,
+        warnings: [
+          {
+            code: 'DRY_RUN',
+            message: `Dry run: would record the existing ${agent.displayName} install in Quantex state.`,
           },
+        ],
+      })
+    case 'tracked-existing':
+      return createSuccessResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: true,
+          installState: {
+            installType: outcome.installedState.installType,
+            packageName: outcome.installedState.packageName,
+          },
+          installed: true,
+        },
+        target,
+        warnings: [
+          {
+            code: 'TRACKED_EXISTING_INSTALL',
+            message: `${agent.displayName} is already installed. Quantex is now tracking the existing install.`,
+          },
+        ],
+      })
+    case 'tracking-cancelled':
+      return createErrorResult<InstallCommandData>({
+        action: 'install',
+        error: {
+          code: 'CANCELLED',
+          message: 'Install was cancelled before tracking could complete.',
+        },
+        target,
+      })
+    case 'untracked-existing':
+      return createSuccessResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: true,
+        },
+        target,
+        warnings: [
+          {
+            code: 'UNTRACKED_EXISTING_INSTALL',
+            message: `${agent.displayName} is already installed but not tracked by Quantex. Quantex could not safely determine the supported install source, so the existing install remains unmanaged.`,
+          },
+        ],
+      })
+    case 'would-install':
+      return createSuccessResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
           changed: false,
           installed: false,
         },
-        ...createResourceLockedError(error, {
-          kind: 'agent',
-          name: agent.name,
-        }),
+        target,
+        warnings: [
+          {
+            code: 'DRY_RUN',
+            message: `Dry run: would install ${agent.displayName}.`,
+          },
+        ],
       })
-    }
-
-    throw error
-  }
-
-  if (result.success) {
-    return createSuccessResult<InstallCommandData>({
-      action: 'install',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
+    case 'installed':
+      return createSuccessResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: true,
+          installState: outcome.installedState
+            ? {
+                installType: outcome.installedState.installType,
+                packageName: outcome.installedState.packageName,
+              }
+            : undefined,
+          installed: true,
         },
-        changed: true,
-        installState: result.installedState
-          ? {
-              installType: result.installedState.installType,
-              packageName: result.installedState.packageName,
-            }
-          : undefined,
-        installed: true,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-    })
+        target,
+      })
+    case 'install-failed':
+      return createErrorResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: false,
+        },
+        error: {
+          code: 'INSTALL_FAILED',
+          message: `Failed to install ${agent.displayName}.`,
+        },
+        target,
+      })
+    case 'resource-locked':
+      return createErrorResult<InstallCommandData>({
+        action: 'install',
+        data: {
+          agent: agentData,
+          changed: false,
+          installed: outcome.installed,
+        },
+        ...createResourceLockedError(outcome.error, target),
+      })
   }
-
-  return createErrorResult<InstallCommandData>({
-    action: 'install',
-    data: {
-      agent: {
-        displayName: agent.displayName,
-        name: agent.name,
-      },
-      changed: false,
-      installed: false,
-    },
-    error: {
-      code: 'INSTALL_FAILED',
-      message: `Failed to install ${agent.displayName}.`,
-    },
-    target: {
-      kind: 'agent',
-      name: agent.name,
-    },
-  })
 }
 
 function emitInstallStarted(

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,12 +1,10 @@
 import type { AgentDefinition } from '../agents'
 import type { CommandResult } from '../output/types'
+import type { UninstallLifecycleOutcome } from '../services/uninstall'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
-import { uninstallAgent } from '../package-manager'
-import { resolveAgent } from '../services/agents'
-import { getInstalledAgentState } from '../state'
+import { runUninstallLifecycle } from '../services/uninstall'
 import { pc } from '../utils/color'
 import { createResourceLockedError } from '../utils/lifecycle-errors'
-import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
 
 interface UninstallCommandData {
@@ -18,126 +16,94 @@ interface UninstallCommandData {
 }
 
 export async function uninstallCommand(agentName: string): Promise<CommandResult<UninstallCommandData>> {
-  const agent = resolveAgent(agentName)
-  if (!agent) {
-    return emitCommandResult(
-      createErrorResult<UninstallCommandData>({
-        action: 'uninstall',
-        error: {
-          code: 'AGENT_NOT_FOUND',
-          details: {
-            input: agentName,
-          },
-          message: `Unknown agent: ${agentName}`,
+  const outcome = await runUninstallLifecycle(agentName, {
+    dryRun: isDryRunEnabled(),
+  })
+
+  return emitCommandResult(createUninstallResult(agentName, outcome), renderUninstallHuman)
+}
+
+function createUninstallResult(
+  agentName: string,
+  outcome: UninstallLifecycleOutcome,
+): CommandResult<UninstallCommandData> {
+  if (outcome.kind === 'agent-not-found') {
+    return createErrorResult<UninstallCommandData>({
+      action: 'uninstall',
+      error: {
+        code: 'AGENT_NOT_FOUND',
+        details: {
+          input: outcome.input,
         },
-        target: {
-          kind: 'agent',
-          name: agentName,
-        },
-      }),
-      renderUninstallHuman,
-    )
+        message: `Unknown agent: ${outcome.input}`,
+      },
+      target: {
+        kind: 'agent',
+        name: agentName,
+      },
+    })
   }
 
-  const installedState = await getInstalledAgentState(agent.name)
-  if (!installedState) {
-    return emitCommandResult(createUnmanagedUninstallResult(agentName, agent), renderUninstallHuman)
+  const { agent } = outcome
+  const target = {
+    kind: 'agent' as const,
+    name: agent.name,
+  }
+  const agentData = {
+    displayName: agent.displayName,
+    name: agent.name,
   }
 
-  if (isDryRunEnabled()) {
-    return emitCommandResult(
-      createSuccessResult<UninstallCommandData>({
+  switch (outcome.kind) {
+    case 'unmanaged':
+      return createUnmanagedUninstallResult(outcome.input, agent)
+    case 'would-uninstall':
+      return createSuccessResult<UninstallCommandData>({
         action: 'uninstall',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
+          agent: agentData,
           changed: false,
         },
-        target: {
-          kind: 'agent',
-          name: agent.name,
-        },
+        target,
         warnings: [
           {
             code: 'DRY_RUN',
             message: `Dry run: would uninstall ${agent.displayName}.`,
           },
         ],
-      }),
-      renderUninstallHuman,
-    )
-  }
-
-  let success
-  try {
-    success = await uninstallAgent(agent)
-  } catch (error) {
-    if (isResourceLockError(error)) {
-      return emitCommandResult(
-        createErrorResult<UninstallCommandData>({
-          action: 'uninstall',
-          data: {
-            agent: {
-              displayName: agent.displayName,
-              name: agent.name,
-            },
-            changed: false,
-          },
-          ...createResourceLockedError(error, {
-            kind: 'agent',
-            name: agent.name,
-          }),
-        }),
-        renderUninstallHuman,
-      )
-    }
-
-    throw error
-  }
-
-  if (success) {
-    return emitCommandResult(
-      createSuccessResult<UninstallCommandData>({
+      })
+    case 'uninstalled':
+      return createSuccessResult<UninstallCommandData>({
         action: 'uninstall',
         data: {
-          agent: {
-            displayName: agent.displayName,
-            name: agent.name,
-          },
+          agent: agentData,
           changed: true,
         },
-        target: {
-          kind: 'agent',
-          name: agent.name,
+        target,
+      })
+    case 'uninstall-failed':
+      return createErrorResult<UninstallCommandData>({
+        action: 'uninstall',
+        data: {
+          agent: agentData,
+          changed: false,
         },
-      }),
-      renderUninstallHuman,
-    )
+        error: {
+          code: 'UNINSTALL_FAILED',
+          message: `Failed to uninstall ${agent.displayName}.`,
+        },
+        target,
+      })
+    case 'resource-locked':
+      return createErrorResult<UninstallCommandData>({
+        action: 'uninstall',
+        data: {
+          agent: agentData,
+          changed: false,
+        },
+        ...createResourceLockedError(outcome.error, target),
+      })
   }
-
-  return emitCommandResult(
-    createErrorResult<UninstallCommandData>({
-      action: 'uninstall',
-      data: {
-        agent: {
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        changed: false,
-      },
-      error: {
-        code: 'UNINSTALL_FAILED',
-        message: `Failed to uninstall ${agent.displayName}.`,
-      },
-      target: {
-        kind: 'agent',
-        name: agent.name,
-      },
-    }),
-    renderUninstallHuman,
-  )
 }
 
 function createUnmanagedUninstallResult(agentName: string, agent: AgentDefinition) {

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,41 +1,16 @@
-import type { AgentDefinition, InstallMethod, ManagedInstallType } from '../agents'
+import type { AgentDefinition } from '../agents'
 import type { CommandResult } from '../output/types'
-import type { ManagedPackageSpec } from '../package-manager'
-import type { InstalledAgentState } from '../state'
-import {
-  getAgentUpdateFailureHint,
-  getAgentUpdateStrategy,
-  getManualAgentUpdateMessage,
-  getUntrackedPathAgentUpdateMessage,
-} from '../agent-update'
 import { getCliContext } from '../cli-context'
 import { createErrorResult, createSuccessResult, emitCommandEvent, emitCommandResult } from '../output'
-import { updateAgent, updateAgentsByType } from '../package-manager'
 import { resolveAgent } from '../services/agents'
 import { planAgentUpdates, planSingleAgentUpdate } from '../services/update'
+import { executePlannedUpdates, type UpdateResultItem } from '../services/update-execution'
 import { pc } from '../utils/color'
-import { canAutoUpdateAgent } from '../utils/install'
-import { isResourceLockError } from '../utils/lock'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
-import { getInstalledVersion } from '../utils/version'
-
-type UpdateStatus = 'failed' | 'locked' | 'manual-required' | 'planned' | 'up-to-date' | 'updated'
 
 interface UpdateCommandData {
   results: UpdateResultItem[]
   scope: 'all' | 'single'
-}
-
-interface UpdateResultItem {
-  displayName: string
-  hint?: string
-  installedVersion?: string
-  latestVersion?: string
-  message?: string
-  name: string
-  resource?: string
-  status: UpdateStatus
-  strategy?: string
 }
 
 export async function updateCommand(
@@ -97,7 +72,7 @@ async function updateAllAgents(): Promise<CommandResult<UpdateCommandData>> {
   })
 
   const plan = await planAgentUpdates()
-  const execution = await executePlannedUpdates(plan)
+  const execution = await executePlannedUpdates(plan, createUpdateExecutionOptions())
 
   if (getCliContext().cancelled) {
     return emitCommandResult(
@@ -187,7 +162,7 @@ async function updateSingleAgent(agent: AgentDefinition): Promise<CommandResult<
     )
   }
 
-  const execution = await executePlannedUpdates(plan)
+  const execution = await executePlannedUpdates(plan, createUpdateExecutionOptions())
   const lockedResult = getSingleLockedResult(execution.results)
 
   if (lockedResult) {
@@ -253,249 +228,21 @@ async function updateSingleAgent(agent: AgentDefinition): Promise<CommandResult<
   )
 }
 
-async function executePlannedUpdates(
-  plan: Awaited<ReturnType<typeof planAgentUpdates>>,
-): Promise<{ hasFailures: boolean; results: UpdateResultItem[] }> {
-  const results: UpdateResultItem[] = []
-
-  for (const inspection of plan.upToDate) {
-    pushUpdateResult(results, {
-      displayName: inspection.agent.displayName,
-      installedVersion: inspection.installedVersion,
-      latestVersion: inspection.latestVersion,
-      name: inspection.agent.name,
-      status: 'up-to-date',
-    })
-  }
-
-  for (const inspection of plan.skippedManualCheck) {
-    pushUpdateResult(results, {
-      displayName: inspection.agent.displayName,
-      message: getManualAgentUpdateMessage(inspection.agent),
-      name: inspection.agent.name,
-      status: 'manual-required',
-    })
-  }
-
-  for (const inspection of plan.untrackedInPath) {
-    pushUpdateResult(results, {
-      displayName: inspection.agent.displayName,
-      message: getUntrackedPathAgentUpdateMessage(inspection.agent),
-      name: inspection.agent.name,
-      status: 'manual-required',
-    })
-  }
-
-  for (const bucket of plan.grouped) {
-    if (getCliContext().cancelled) break
-
-    const groupResults = await updateGroupedAgents(bucket.type, bucket.packages, bucket.updates)
-    for (const result of groupResults) pushUpdateResult(results, result)
-
-    if (getCliContext().cancelled) break
-  }
-
-  for (const entry of plan.manual) {
-    if (getCliContext().cancelled) break
-
-    pushUpdateResult(results, await performUpdate(entry.agent, entry.state, entry.inspection.methods, entry.inspection))
-  }
-
+function createUpdateExecutionOptions() {
   return {
-    hasFailures: results.some(result => result.status === 'failed' || result.status === 'locked'),
-    results,
-  }
-}
-
-function pushUpdateResult(results: UpdateResultItem[], result: UpdateResultItem): void {
-  results.push(result)
-  emitCommandEvent({
-    action: 'update',
-    data: result,
-    target: {
-      kind: 'agent',
-      name: result.name,
+    dryRun: isDryRunEnabled(),
+    isCancelled: () => Boolean(getCliContext().cancelled),
+    onProgress: (result: UpdateResultItem) => {
+      emitCommandEvent({
+        action: 'update',
+        data: result,
+        target: {
+          kind: 'agent',
+          name: result.name,
+        },
+        type: 'progress',
+      })
     },
-    type: 'progress',
-  })
-}
-
-async function updateGroupedAgents(
-  type: ManagedInstallType,
-  packages: ManagedPackageSpec[],
-  updates: Array<{
-    agent: AgentDefinition
-    inspection: { installedVersion?: string; latestVersion?: string; methods?: InstallMethod[] }
-    state?: InstalledAgentState
-    strategy: 'managed' | 'manual-hint' | 'self-update'
-  }>,
-): Promise<UpdateResultItem[]> {
-  if (updates.length === 0) return []
-
-  if (isDryRunEnabled()) {
-    return updates.map(({ agent, inspection, strategy }) => ({
-      displayName: agent.displayName,
-      installedVersion: inspection.installedVersion,
-      latestVersion: inspection.latestVersion,
-      message: `Dry run: would update ${agent.displayName}.`,
-      name: agent.name,
-      status: 'planned',
-      strategy: strategy === 'managed' ? `managed/${type}` : strategy,
-    }))
-  }
-
-  try {
-    const success = await updateAgentsByType(type, packages)
-
-    if (success) {
-      return updates.map(({ agent, inspection, strategy }) => ({
-        displayName: agent.displayName,
-        installedVersion: inspection.installedVersion,
-        latestVersion: inspection.latestVersion,
-        name: agent.name,
-        status: 'updated',
-        strategy: strategy === 'managed' ? `managed/${type}` : strategy,
-      }))
-    }
-
-    const fallbackResults: UpdateResultItem[] = []
-    for (const { agent, inspection, state } of updates) {
-      if (getCliContext().cancelled) break
-
-      fallbackResults.push(await performUpdate(agent, state, inspection.methods, inspection))
-    }
-    return fallbackResults
-  } catch (error) {
-    if (!isResourceLockError(error)) throw error
-
-    return updates.map(({ agent, inspection, strategy }) => ({
-      displayName: agent.displayName,
-      installedVersion: inspection.installedVersion,
-      latestVersion: inspection.latestVersion,
-      message: error.message,
-      name: agent.name,
-      resource: error.resource,
-      status: 'locked',
-      strategy: strategy === 'managed' ? `managed/${type}` : strategy,
-    }))
-  }
-}
-
-async function performUpdate(
-  agent: AgentDefinition,
-  installedState?: InstalledAgentState,
-  methods?: InstallMethod[],
-  inspection?: { installedVersion?: string; latestVersion?: string; methods?: InstallMethod[] },
-): Promise<UpdateResultItem> {
-  if (getCliContext().cancelled) {
-    return {
-      displayName: agent.displayName,
-      installedVersion: inspection?.installedVersion,
-      latestVersion: inspection?.latestVersion,
-      message: 'Update was cancelled before it could start.',
-      name: agent.name,
-      status: 'failed',
-    }
-  }
-
-  const resolvedMethods = methods ?? inspection?.methods ?? []
-  const strategy = getAgentUpdateStrategy({
-    agent,
-    installedState,
-    methods: resolvedMethods,
-  })
-  const installedVersion = inspection?.installedVersion
-  const latestVersion = inspection?.latestVersion
-
-  if (strategy === 'manual-hint' && !canAutoUpdateAgent(agent, installedState)) {
-    return {
-      displayName: agent.displayName,
-      installedVersion,
-      latestVersion,
-      message: getManualAgentUpdateMessage(agent),
-      name: agent.name,
-      status: 'manual-required',
-      strategy,
-    }
-  }
-
-  if (isDryRunEnabled()) {
-    return {
-      displayName: agent.displayName,
-      installedVersion,
-      latestVersion,
-      message: `Dry run: would update ${agent.displayName}.`,
-      name: agent.name,
-      status: 'planned',
-      strategy,
-    }
-  }
-
-  let result
-  try {
-    result = await updateAgent(agent, installedState)
-  } catch (error) {
-    if (isResourceLockError(error)) {
-      return {
-        displayName: agent.displayName,
-        installedVersion,
-        latestVersion,
-        message: error.message,
-        name: agent.name,
-        resource: error.resource,
-        status: 'locked',
-        strategy,
-      }
-    }
-
-    throw error
-  }
-
-  if (result.success) {
-    if (strategy === 'self-update') {
-      const verifiedVersion = await getInstalledVersion(agent.binaryName, agent.versionProbe)
-
-      if (installedVersion && verifiedVersion) {
-        if (verifiedVersion === installedVersion) {
-          return {
-            displayName: agent.displayName,
-            installedVersion: verifiedVersion,
-            latestVersion: verifiedVersion,
-            name: agent.name,
-            status: 'up-to-date',
-            strategy,
-          }
-        }
-
-        return {
-          displayName: agent.displayName,
-          installedVersion,
-          latestVersion: verifiedVersion,
-          name: agent.name,
-          status: 'updated',
-          strategy,
-        }
-      }
-    }
-
-    return {
-      displayName: agent.displayName,
-      installedVersion,
-      latestVersion,
-      name: agent.name,
-      status: 'updated',
-      strategy,
-    }
-  }
-
-  return {
-    displayName: agent.displayName,
-    hint: getAgentUpdateFailureHint(agent, strategy),
-    installedVersion,
-    latestVersion,
-    name: agent.name,
-    status: 'failed',
-    strategy,
   }
 }
 

--- a/src/services/install-ensure.ts
+++ b/src/services/install-ensure.ts
@@ -1,0 +1,170 @@
+import type { AgentDefinition } from '../agents'
+import type { InstalledAgentState } from '../state'
+import type { ResourceLockError } from '../utils/lock'
+import { installAgent, trackInstalledAgent } from '../package-manager'
+import { getAdoptableExistingInstallMethod } from '../utils/install'
+import { isResourceLockError } from '../utils/lock'
+import { resolveAgentInspection } from './agents'
+
+export interface InstallEnsureLifecycleDependencies {
+  getAdoptableExistingInstallMethod: typeof getAdoptableExistingInstallMethod
+  installAgent: typeof installAgent
+  isResourceLockError: typeof isResourceLockError
+  resolveAgentInspection: typeof resolveAgentInspection
+  trackInstalledAgent: typeof trackInstalledAgent
+}
+
+export interface InstallEnsureLifecycleOptions {
+  dryRun: boolean
+  onMutationStart?: (agent: AgentDefinition) => void
+}
+
+type ResolvedLifecycleOutcome =
+  | {
+      agent: AgentDefinition
+      kind: 'already-installed' | 'install-failed' | 'tracking-cancelled' | 'untracked-existing'
+    }
+  | {
+      agent: AgentDefinition
+      kind: 'would-install' | 'would-track-existing'
+    }
+  | {
+      agent: AgentDefinition
+      installedState: InstalledAgentState
+      kind: 'tracked-existing'
+    }
+  | {
+      agent: AgentDefinition
+      installedState?: InstalledAgentState
+      kind: 'installed'
+    }
+  | {
+      agent: AgentDefinition
+      error: ResourceLockError
+      installed: boolean
+      kind: 'resource-locked'
+    }
+
+export type InstallEnsureLifecycleOutcome =
+  | {
+      input: string
+      kind: 'agent-not-found'
+    }
+  | ResolvedLifecycleOutcome
+
+function createDefaultDependencies(): InstallEnsureLifecycleDependencies {
+  return {
+    getAdoptableExistingInstallMethod,
+    installAgent,
+    isResourceLockError,
+    resolveAgentInspection,
+    trackInstalledAgent,
+  }
+}
+
+export async function runInstallEnsureLifecycle(
+  agentName: string,
+  options: InstallEnsureLifecycleOptions,
+  dependencies: InstallEnsureLifecycleDependencies = createDefaultDependencies(),
+): Promise<InstallEnsureLifecycleOutcome> {
+  const resolved = await dependencies.resolveAgentInspection(agentName)
+  if (!resolved) {
+    return {
+      input: agentName,
+      kind: 'agent-not-found',
+    }
+  }
+
+  const { agent, inspection } = resolved
+  if (inspection.inPath) {
+    if (inspection.installedState) {
+      return {
+        agent,
+        kind: 'already-installed',
+      }
+    }
+
+    const adoptableMethod = dependencies.getAdoptableExistingInstallMethod(
+      inspection.methods,
+      inspection.resolvedBinaryPath ?? inspection.binaryPath,
+    )
+    if (!adoptableMethod) {
+      return {
+        agent,
+        kind: 'untracked-existing',
+      }
+    }
+
+    if (options.dryRun) {
+      return {
+        agent,
+        kind: 'would-track-existing',
+      }
+    }
+
+    options.onMutationStart?.(agent)
+
+    try {
+      const installedState = await dependencies.trackInstalledAgent(agent, adoptableMethod)
+      if (!installedState) {
+        return {
+          agent,
+          kind: 'tracking-cancelled',
+        }
+      }
+
+      return {
+        agent,
+        installedState,
+        kind: 'tracked-existing',
+      }
+    } catch (error) {
+      if (dependencies.isResourceLockError(error)) {
+        return {
+          agent,
+          error,
+          installed: true,
+          kind: 'resource-locked',
+        }
+      }
+
+      throw error
+    }
+  }
+
+  if (options.dryRun) {
+    return {
+      agent,
+      kind: 'would-install',
+    }
+  }
+
+  options.onMutationStart?.(agent)
+
+  try {
+    const result = await dependencies.installAgent(agent)
+    if (!result.success) {
+      return {
+        agent,
+        kind: 'install-failed',
+      }
+    }
+
+    return {
+      agent,
+      installedState: result.installedState,
+      kind: 'installed',
+    }
+  } catch (error) {
+    if (dependencies.isResourceLockError(error)) {
+      return {
+        agent,
+        error,
+        installed: false,
+        kind: 'resource-locked',
+      }
+    }
+
+    throw error
+  }
+}

--- a/src/services/runtime-cancellation.ts
+++ b/src/services/runtime-cancellation.ts
@@ -1,0 +1,205 @@
+import process from 'node:process'
+
+type SupportedSignal = 'SIGINT' | 'SIGTERM'
+type SignalHandler = () => void
+
+export type RuntimeDeadlineOutcome<T> =
+  | {
+      kind: 'completed'
+      result: T
+    }
+  | {
+      kind: 'timed-out'
+      timeoutMs: number
+    }
+
+export type RuntimeSignalOutcome<T> =
+  | {
+      kind: 'completed'
+      result: T
+    }
+  | {
+      kind: 'signal-cancelled'
+      signal: SupportedSignal
+    }
+
+export type RuntimeCancellationOutcome<T> =
+  | RuntimeDeadlineOutcome<T>
+  | Extract<RuntimeSignalOutcome<T>, { kind: 'signal-cancelled' }>
+
+export interface RuntimeCancellationOptions<T> {
+  cancelOperations: () => Promise<void> | void
+  isCancelled: () => boolean
+  run: () => Promise<T>
+  timeoutMs?: number
+}
+
+export interface RuntimeCancellationDependencies {
+  clearTimeout: typeof clearTimeout
+  offSignal: (signal: SupportedSignal, handler: SignalHandler) => void
+  onSignal: (signal: SupportedSignal, handler: SignalHandler) => void
+  setTimeout: typeof setTimeout
+}
+
+function createDefaultDependencies(): RuntimeCancellationDependencies {
+  return {
+    clearTimeout,
+    offSignal: (signal, handler) => process.off(signal, handler),
+    onSignal: (signal, handler) => process.once(signal, handler),
+    setTimeout,
+  }
+}
+
+export async function executeWithRuntimeCancellation<T>(
+  options: RuntimeCancellationOptions<T>,
+  dependencies: RuntimeCancellationDependencies = createDefaultDependencies(),
+): Promise<RuntimeCancellationOutcome<T>> {
+  const signalOutcome = await executeWithSignalCancellation(
+    {
+      ...options,
+      run: () => executeWithRuntimeDeadline(options, dependencies),
+    },
+    dependencies,
+  )
+
+  return signalOutcome.kind === 'completed' ? signalOutcome.result : signalOutcome
+}
+
+export async function executeWithRuntimeDeadline<T>(
+  options: RuntimeCancellationOptions<T>,
+  dependencies: RuntimeCancellationDependencies = createDefaultDependencies(),
+): Promise<RuntimeDeadlineOutcome<T>> {
+  if (options.timeoutMs === undefined) {
+    return {
+      kind: 'completed',
+      result: await options.run(),
+    }
+  }
+
+  const timeoutMs = options.timeoutMs
+  const timeoutMarker = { kind: 'timeout-marker' } as const
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    const timeoutPromise = new Promise<typeof timeoutMarker>(resolve => {
+      timeoutId = dependencies.setTimeout(() => resolve(timeoutMarker), timeoutMs)
+    })
+    const runPromise = runUntilTimeoutCancellation(options, timeoutPromise, timeoutMarker)
+    const firstResult = await Promise.race([runPromise, timeoutPromise])
+
+    if (firstResult.kind === 'run-result') {
+      return {
+        kind: 'completed',
+        result: firstResult.result,
+      }
+    }
+
+    const lateResult = await waitForLateTerminalCompletion(runPromise, timeoutMs, dependencies)
+    if (lateResult?.kind === 'run-result') {
+      return {
+        kind: 'completed',
+        result: lateResult.result,
+      }
+    }
+
+    await options.cancelOperations()
+    return {
+      kind: 'timed-out',
+      timeoutMs,
+    }
+  } finally {
+    if (timeoutId !== undefined) dependencies.clearTimeout(timeoutId)
+  }
+}
+
+async function runUntilTimeoutCancellation<T>(
+  options: RuntimeCancellationOptions<T>,
+  timeoutPromise: Promise<{ kind: 'timeout-marker' }>,
+  timeoutMarker: { kind: 'timeout-marker' },
+): Promise<{ kind: 'run-result'; result: T } | { kind: 'timeout-marker' }> {
+  try {
+    return {
+      kind: 'run-result',
+      result: await options.run(),
+    }
+  } catch (error) {
+    if (options.isCancelled()) return timeoutPromise.then(() => timeoutMarker)
+    throw error
+  }
+}
+
+async function waitForLateTerminalCompletion<T>(
+  runPromise: Promise<{ kind: 'run-result'; result: T } | { kind: 'timeout-marker' }>,
+  timeoutMs: number,
+  dependencies: RuntimeCancellationDependencies,
+): Promise<{ kind: 'run-result'; result: T } | { kind: 'timeout-marker' } | undefined> {
+  const graceMs = Math.min(timeoutMs, 250)
+  return Promise.race([
+    runPromise,
+    new Promise<undefined>(resolve => {
+      dependencies.setTimeout(() => resolve(undefined), graceMs)
+    }),
+  ])
+}
+
+export async function executeWithSignalCancellation<T>(
+  options: RuntimeCancellationOptions<T>,
+  dependencies: RuntimeCancellationDependencies = createDefaultDependencies(),
+): Promise<RuntimeSignalOutcome<T>> {
+  let signalOutcomePromise: Promise<RuntimeSignalOutcome<T>> | undefined
+  let cleanup: (() => void) | undefined
+
+  const signalPromise = new Promise<RuntimeSignalOutcome<T>>(resolve => {
+    const handleSignal = (signal: SupportedSignal): void => {
+      signalOutcomePromise ??= Promise.resolve()
+        .then(options.cancelOperations)
+        .then(() => ({
+          kind: 'signal-cancelled' as const,
+          signal,
+        }))
+      void signalOutcomePromise.then(resolve)
+    }
+
+    const sigintHandler = (): void => handleSignal('SIGINT')
+    const sigtermHandler = (): void => handleSignal('SIGTERM')
+    dependencies.onSignal('SIGINT', sigintHandler)
+    dependencies.onSignal('SIGTERM', sigtermHandler)
+    cleanup = () => {
+      dependencies.offSignal('SIGINT', sigintHandler)
+      dependencies.offSignal('SIGTERM', sigtermHandler)
+    }
+  })
+
+  try {
+    return await Promise.race([
+      runUntilSignalCancellation(
+        options,
+        () => options.run(),
+        () => signalOutcomePromise,
+      ),
+      signalPromise,
+    ])
+  } finally {
+    cleanup?.()
+  }
+}
+
+async function runUntilSignalCancellation<T>(
+  options: RuntimeCancellationOptions<T>,
+  run: () => Promise<T>,
+  getSignalOutcome: () => Promise<RuntimeSignalOutcome<T>> | undefined,
+): Promise<RuntimeSignalOutcome<T>> {
+  try {
+    const result: RuntimeSignalOutcome<T> = {
+      kind: 'completed',
+      result: await run(),
+    }
+    const signalOutcome = getSignalOutcome()
+    if (options.isCancelled() && signalOutcome) return signalOutcome
+    return result
+  } catch (error) {
+    const signalOutcome = getSignalOutcome()
+    if (options.isCancelled() && signalOutcome) return signalOutcome
+    throw error
+  }
+}

--- a/src/services/runtime-idempotency.ts
+++ b/src/services/runtime-idempotency.ts
@@ -1,0 +1,149 @@
+import type { OutputMode } from '../cli-context'
+import type { IdempotencyRecord } from '../idempotency'
+import type { CommandResult, CommandTarget } from '../output/types'
+import * as idempotencyStore from '../idempotency'
+import * as agentService from './agents'
+
+export interface RuntimeIdempotencyInvocation {
+  action: string
+  dryRun: boolean
+  idempotencyKey?: string
+  outputMode: OutputMode
+  runId: string
+  target?: CommandTarget
+}
+
+export type RuntimeIdempotencyOutcome<T> =
+  | {
+      kind: 'conflict'
+      existingAction: string
+      idempotencyKey: string
+    }
+  | {
+      kind: 'miss'
+    }
+  | {
+      kind: 'replay'
+      result: CommandResult<T>
+    }
+
+export interface RuntimeIdempotencyDependencies {
+  loadIdempotencyRecord: typeof idempotencyStore.loadIdempotencyRecord
+  now: () => string
+  resolveAgentInspection: typeof agentService.resolveAgentInspection
+  saveIdempotencyRecord: typeof idempotencyStore.saveIdempotencyRecord
+}
+
+function createDefaultDependencies(): RuntimeIdempotencyDependencies {
+  return {
+    loadIdempotencyRecord: idempotencyStore.loadIdempotencyRecord,
+    now: () => new Date().toISOString(),
+    resolveAgentInspection: agentService.resolveAgentInspection,
+    saveIdempotencyRecord: idempotencyStore.saveIdempotencyRecord,
+  }
+}
+
+export async function resolveIdempotentExecution<T>(
+  invocation: RuntimeIdempotencyInvocation,
+  dependencies: RuntimeIdempotencyDependencies = createDefaultDependencies(),
+): Promise<RuntimeIdempotencyOutcome<T>> {
+  if (!invocation.idempotencyKey) return { kind: 'miss' }
+
+  const record = await dependencies.loadIdempotencyRecord(invocation.idempotencyKey)
+  if (!record) return { kind: 'miss' }
+
+  if (record.action !== invocation.action) {
+    return {
+      existingAction: record.action,
+      idempotencyKey: invocation.idempotencyKey,
+      kind: 'conflict',
+    }
+  }
+
+  if (!idempotencyTargetsMatch(record.target, invocation.target)) return { kind: 'miss' }
+  if (isDryRunIdempotencyResult(record.result)) return { kind: 'miss' }
+  if (!(await isStoredIdempotencyResultStillValid(record, dependencies))) return { kind: 'miss' }
+
+  return {
+    kind: 'replay',
+    result: {
+      ...record.result,
+      meta: {
+        ...record.result.meta,
+        mode: invocation.outputMode,
+        runId: invocation.runId,
+        timestamp: dependencies.now(),
+      },
+    } as CommandResult<T>,
+  }
+}
+
+export async function persistIdempotentExecution<T>(
+  invocation: RuntimeIdempotencyInvocation,
+  result: CommandResult<T>,
+  dependencies: RuntimeIdempotencyDependencies = createDefaultDependencies(),
+): Promise<void> {
+  if (!invocation.idempotencyKey || !result.ok || invocation.dryRun || isDryRunIdempotencyResult(result)) {
+    return
+  }
+
+  await dependencies.saveIdempotencyRecord(invocation.idempotencyKey, {
+    action: invocation.action,
+    result,
+    target: invocation.target,
+  })
+}
+
+function idempotencyTargetsMatch(stored?: CommandTarget, requested?: CommandTarget): boolean {
+  if (stored === undefined && requested === undefined) return true
+  if (stored === undefined || requested === undefined) return false
+  if (stored.kind !== requested.kind) return false
+  if (stored.kind === 'agent' && (!stored.name || !requested.name)) return false
+  return stored.name === requested.name
+}
+
+function isDryRunIdempotencyResult(result: CommandResult): boolean {
+  return result.warnings.some(warning => warning.code === 'DRY_RUN')
+}
+
+const agentPresenceRequiredActions = new Set(['install', 'ensure', 'update'])
+const agentAbsenceRequiredActions = new Set(['uninstall'])
+
+function getIdempotencyAgentNames(target?: CommandTarget): string[] | undefined {
+  if (target?.kind !== 'agent' || !target.name) return undefined
+
+  return target.name
+    .split(',')
+    .map(name => name.trim())
+    .filter(Boolean)
+}
+
+async function isStoredIdempotencyResultStillValid(
+  record: IdempotencyRecord,
+  dependencies: RuntimeIdempotencyDependencies,
+): Promise<boolean> {
+  if (!record.result.ok) return true
+
+  const agentNames = getIdempotencyAgentNames(record.target)
+  if (!agentNames || agentNames.length === 0) return true
+
+  if (agentPresenceRequiredActions.has(record.action)) {
+    for (const agentName of agentNames) {
+      const resolved = await dependencies.resolveAgentInspection(agentName)
+      if (!resolved?.inspection.inPath) return false
+    }
+
+    return true
+  }
+
+  if (agentAbsenceRequiredActions.has(record.action)) {
+    for (const agentName of agentNames) {
+      const resolved = await dependencies.resolveAgentInspection(agentName)
+      if (resolved?.inspection.inPath) return false
+    }
+
+    return true
+  }
+
+  return true
+}

--- a/src/services/uninstall.ts
+++ b/src/services/uninstall.ts
@@ -1,0 +1,97 @@
+import type { AgentDefinition } from '../agents'
+import type { ResourceLockError } from '../utils/lock'
+import { uninstallAgent } from '../package-manager'
+import { getInstalledAgentState } from '../state'
+import { isResourceLockError } from '../utils/lock'
+import { resolveAgent } from './agents'
+
+export interface UninstallLifecycleDependencies {
+  getInstalledAgentState: typeof getInstalledAgentState
+  isResourceLockError: typeof isResourceLockError
+  resolveAgent: typeof resolveAgent
+  uninstallAgent: typeof uninstallAgent
+}
+
+export interface UninstallLifecycleOptions {
+  dryRun: boolean
+}
+
+type ResolvedUninstallOutcome =
+  | {
+      agent: AgentDefinition
+      kind: 'uninstall-failed' | 'uninstalled' | 'would-uninstall'
+    }
+  | {
+      agent: AgentDefinition
+      input: string
+      kind: 'unmanaged'
+    }
+  | {
+      agent: AgentDefinition
+      error: ResourceLockError
+      kind: 'resource-locked'
+    }
+
+export type UninstallLifecycleOutcome =
+  | {
+      input: string
+      kind: 'agent-not-found'
+    }
+  | ResolvedUninstallOutcome
+
+function createDefaultDependencies(): UninstallLifecycleDependencies {
+  return {
+    getInstalledAgentState,
+    isResourceLockError,
+    resolveAgent,
+    uninstallAgent,
+  }
+}
+
+export async function runUninstallLifecycle(
+  agentName: string,
+  options: UninstallLifecycleOptions,
+  dependencies: UninstallLifecycleDependencies = createDefaultDependencies(),
+): Promise<UninstallLifecycleOutcome> {
+  const agent = dependencies.resolveAgent(agentName)
+  if (!agent) {
+    return {
+      input: agentName,
+      kind: 'agent-not-found',
+    }
+  }
+
+  const installedState = await dependencies.getInstalledAgentState(agent.name)
+  if (!installedState) {
+    return {
+      agent,
+      input: agentName,
+      kind: 'unmanaged',
+    }
+  }
+
+  if (options.dryRun) {
+    return {
+      agent,
+      kind: 'would-uninstall',
+    }
+  }
+
+  try {
+    const success = await dependencies.uninstallAgent(agent)
+    return {
+      agent,
+      kind: success ? 'uninstalled' : 'uninstall-failed',
+    }
+  } catch (error) {
+    if (dependencies.isResourceLockError(error)) {
+      return {
+        agent,
+        error,
+        kind: 'resource-locked',
+      }
+    }
+
+    throw error
+  }
+}

--- a/src/services/update-execution.ts
+++ b/src/services/update-execution.ts
@@ -1,0 +1,296 @@
+import type { AgentUpdateStrategy } from '../agent-update'
+import type { PendingAgentUpdate, PlannedAgentUpdates } from './update'
+import * as agentUpdate from '../agent-update'
+import * as packageManager from '../package-manager'
+import * as installUtils from '../utils/install'
+import * as lockUtils from '../utils/lock'
+import * as versionUtils from '../utils/version'
+
+export type UpdateStatus = 'failed' | 'locked' | 'manual-required' | 'planned' | 'up-to-date' | 'updated'
+
+export interface UpdateResultItem {
+  displayName: string
+  hint?: string
+  installedVersion?: string
+  latestVersion?: string
+  message?: string
+  name: string
+  resource?: string
+  status: UpdateStatus
+  strategy?: string
+}
+
+export interface UpdateExecution {
+  hasFailures: boolean
+  results: UpdateResultItem[]
+}
+
+export interface UpdateExecutionOptions {
+  dryRun: boolean
+  isCancelled: () => boolean
+  onProgress?: (result: UpdateResultItem) => void
+}
+
+export interface UpdateExecutionDependencies {
+  canAutoUpdateAgent: typeof installUtils.canAutoUpdateAgent
+  getAgentUpdateFailureHint: typeof agentUpdate.getAgentUpdateFailureHint
+  getAgentUpdateStrategy: typeof agentUpdate.getAgentUpdateStrategy
+  getInstalledVersion: typeof versionUtils.getInstalledVersion
+  getManualAgentUpdateMessage: typeof agentUpdate.getManualAgentUpdateMessage
+  getUntrackedPathAgentUpdateMessage: typeof agentUpdate.getUntrackedPathAgentUpdateMessage
+  isResourceLockError: typeof lockUtils.isResourceLockError
+  updateAgent: typeof packageManager.updateAgent
+  updateAgentsByType: typeof packageManager.updateAgentsByType
+}
+
+function createDefaultDependencies(): UpdateExecutionDependencies {
+  return {
+    canAutoUpdateAgent: installUtils.canAutoUpdateAgent,
+    getAgentUpdateFailureHint: agentUpdate.getAgentUpdateFailureHint,
+    getAgentUpdateStrategy: agentUpdate.getAgentUpdateStrategy,
+    getInstalledVersion: versionUtils.getInstalledVersion,
+    getManualAgentUpdateMessage: agentUpdate.getManualAgentUpdateMessage,
+    getUntrackedPathAgentUpdateMessage: agentUpdate.getUntrackedPathAgentUpdateMessage,
+    isResourceLockError: lockUtils.isResourceLockError,
+    updateAgent: packageManager.updateAgent,
+    updateAgentsByType: packageManager.updateAgentsByType,
+  }
+}
+
+export async function executePlannedUpdates(
+  plan: PlannedAgentUpdates,
+  options: UpdateExecutionOptions,
+  dependencies: UpdateExecutionDependencies = createDefaultDependencies(),
+): Promise<UpdateExecution> {
+  const results: UpdateResultItem[] = []
+  const pushResult = (result: UpdateResultItem): void => {
+    results.push(result)
+    options.onProgress?.(result)
+  }
+
+  for (const inspection of plan.upToDate) {
+    pushResult({
+      displayName: inspection.agent.displayName,
+      installedVersion: inspection.installedVersion,
+      latestVersion: inspection.latestVersion,
+      name: inspection.agent.name,
+      status: 'up-to-date',
+    })
+  }
+
+  for (const inspection of plan.skippedManualCheck) {
+    pushResult({
+      displayName: inspection.agent.displayName,
+      message: dependencies.getManualAgentUpdateMessage(inspection.agent),
+      name: inspection.agent.name,
+      status: 'manual-required',
+    })
+  }
+
+  for (const inspection of plan.untrackedInPath) {
+    pushResult({
+      displayName: inspection.agent.displayName,
+      message: dependencies.getUntrackedPathAgentUpdateMessage(inspection.agent),
+      name: inspection.agent.name,
+      status: 'manual-required',
+    })
+  }
+
+  for (const bucket of plan.grouped) {
+    if (options.isCancelled()) break
+
+    const groupResults = await updateGroupedAgents(bucket, options, dependencies)
+    for (const result of groupResults) pushResult(result)
+
+    if (options.isCancelled()) break
+  }
+
+  for (const entry of plan.manual) {
+    if (options.isCancelled()) break
+
+    pushResult(await performUpdate(entry, options, dependencies))
+  }
+
+  return {
+    hasFailures: results.some(result => result.status === 'failed' || result.status === 'locked'),
+    results,
+  }
+}
+
+async function updateGroupedAgents(
+  bucket: PlannedAgentUpdates['grouped'][number],
+  options: UpdateExecutionOptions,
+  dependencies: UpdateExecutionDependencies,
+): Promise<UpdateResultItem[]> {
+  if (bucket.updates.length === 0) return []
+
+  if (options.dryRun) {
+    return bucket.updates.map(({ agent, inspection, strategy }) => ({
+      displayName: agent.displayName,
+      installedVersion: inspection.installedVersion,
+      latestVersion: inspection.latestVersion,
+      message: `Dry run: would update ${agent.displayName}.`,
+      name: agent.name,
+      status: 'planned',
+      strategy: formatGroupedStrategy(strategy, bucket.type),
+    }))
+  }
+
+  try {
+    const success = await dependencies.updateAgentsByType(bucket.type, bucket.packages)
+
+    if (success) {
+      return bucket.updates.map(({ agent, inspection, strategy }) => ({
+        displayName: agent.displayName,
+        installedVersion: inspection.installedVersion,
+        latestVersion: inspection.latestVersion,
+        name: agent.name,
+        status: 'updated',
+        strategy: formatGroupedStrategy(strategy, bucket.type),
+      }))
+    }
+
+    const fallbackResults: UpdateResultItem[] = []
+    for (const update of bucket.updates) {
+      if (options.isCancelled()) break
+
+      fallbackResults.push(await performUpdate(update, options, dependencies))
+    }
+    return fallbackResults
+  } catch (error) {
+    if (!dependencies.isResourceLockError(error)) throw error
+
+    return bucket.updates.map(({ agent, inspection, strategy }) => ({
+      displayName: agent.displayName,
+      installedVersion: inspection.installedVersion,
+      latestVersion: inspection.latestVersion,
+      message: error.message,
+      name: agent.name,
+      resource: error.resource,
+      status: 'locked',
+      strategy: formatGroupedStrategy(strategy, bucket.type),
+    }))
+  }
+}
+
+async function performUpdate(
+  update: PendingAgentUpdate,
+  options: UpdateExecutionOptions,
+  dependencies: UpdateExecutionDependencies,
+): Promise<UpdateResultItem> {
+  const { agent, inspection, state: installedState } = update
+
+  if (options.isCancelled()) {
+    return {
+      displayName: agent.displayName,
+      installedVersion: inspection.installedVersion,
+      latestVersion: inspection.latestVersion,
+      message: 'Update was cancelled before it could start.',
+      name: agent.name,
+      status: 'failed',
+    }
+  }
+
+  const strategy = dependencies.getAgentUpdateStrategy({
+    agent,
+    installedState,
+    methods: inspection.methods,
+  })
+  const installedVersion = inspection.installedVersion
+  const latestVersion = inspection.latestVersion
+
+  if (strategy === 'manual-hint' && !dependencies.canAutoUpdateAgent(agent, installedState)) {
+    return {
+      displayName: agent.displayName,
+      installedVersion,
+      latestVersion,
+      message: dependencies.getManualAgentUpdateMessage(agent),
+      name: agent.name,
+      status: 'manual-required',
+      strategy,
+    }
+  }
+
+  if (options.dryRun) {
+    return {
+      displayName: agent.displayName,
+      installedVersion,
+      latestVersion,
+      message: `Dry run: would update ${agent.displayName}.`,
+      name: agent.name,
+      status: 'planned',
+      strategy,
+    }
+  }
+
+  let result
+  try {
+    result = await dependencies.updateAgent(agent, installedState)
+  } catch (error) {
+    if (dependencies.isResourceLockError(error)) {
+      return {
+        displayName: agent.displayName,
+        installedVersion,
+        latestVersion,
+        message: error.message,
+        name: agent.name,
+        resource: error.resource,
+        status: 'locked',
+        strategy,
+      }
+    }
+
+    throw error
+  }
+
+  if (result.success) {
+    if (strategy === 'self-update') {
+      const verifiedVersion = await dependencies.getInstalledVersion(agent.binaryName, agent.versionProbe)
+
+      if (installedVersion && verifiedVersion) {
+        if (verifiedVersion === installedVersion) {
+          return {
+            displayName: agent.displayName,
+            installedVersion: verifiedVersion,
+            latestVersion: verifiedVersion,
+            name: agent.name,
+            status: 'up-to-date',
+            strategy,
+          }
+        }
+
+        return {
+          displayName: agent.displayName,
+          installedVersion,
+          latestVersion: verifiedVersion,
+          name: agent.name,
+          status: 'updated',
+          strategy,
+        }
+      }
+    }
+
+    return {
+      displayName: agent.displayName,
+      installedVersion,
+      latestVersion,
+      name: agent.name,
+      status: 'updated',
+      strategy,
+    }
+  }
+
+  return {
+    displayName: agent.displayName,
+    hint: dependencies.getAgentUpdateFailureHint(agent, strategy),
+    installedVersion,
+    latestVersion,
+    name: agent.name,
+    status: 'failed',
+    strategy,
+  }
+}
+
+function formatGroupedStrategy(strategy: AgentUpdateStrategy, type: string): string {
+  return strategy === 'managed' ? `managed/${type}` : strategy
+}

--- a/test/catalog-loader.test.ts
+++ b/test/catalog-loader.test.ts
@@ -1,0 +1,50 @@
+import type { AgentCatalogEntry } from '../src/agents/schema'
+import { describe, expect, it, vi } from 'vitest'
+import { loadAgentCatalog } from '../src/agents/catalog-loader'
+import { catalogData } from '../src/agents/generated/catalog-data'
+
+describe('loadAgentCatalog', () => {
+  it('preserves supplied entry order and canonical object identity', () => {
+    const source = [catalogData[1], catalogData[0]]
+    const loaded = loadAgentCatalog(source)
+
+    expect(loaded.agents.map(agent => agent.name)).toEqual(source.map(agent => agent.name))
+    expect(loaded.getAgent(source[0].name)).toBe(loaded.agents[0])
+    expect(loaded.getAgent(source[1].name)).toBe(loaded.agents[1])
+  })
+
+  it('rejects data that violates the existing catalog schema', () => {
+    expect(() =>
+      loadAgentCatalog([
+        {
+          ...catalogData[0],
+          platforms: {
+            plan9: [{ type: 'npm' }],
+          },
+        },
+      ]),
+    ).toThrow()
+  })
+
+  it('throws a stable error for an unknown canonical name', () => {
+    const loaded = loadAgentCatalog([catalogData[0]])
+
+    expect(() => loaded.getAgent('missing')).toThrow('Unknown catalog agent: missing')
+  })
+
+  it('merges runtime-only behavior without mutating serializable data', () => {
+    const source = structuredClone(catalogData[0]) as unknown as AgentCatalogEntry
+    const parser = vi.fn(() => '1.2.3')
+    const loaded = loadAgentCatalog([source], {
+      [source.name]: {
+        versionProbeParser: parser,
+      },
+    })
+
+    expect(loaded.agents[0].versionProbe).toEqual({
+      ...source.versionProbe,
+      parser,
+    })
+    expect(source.versionProbe).not.toHaveProperty('parser')
+  })
+})

--- a/test/commands/ensure.test.ts
+++ b/test/commands/ensure.test.ts
@@ -6,6 +6,7 @@ import { ensureCommand } from '../../src/commands/ensure'
 import * as pm from '../../src/package-manager'
 import * as state from '../../src/state'
 import * as detect from '../../src/utils/detect'
+import { ResourceLockError } from '../../src/utils/lock'
 
 const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
 const installSpy = vi.spyOn(pm, 'installAgent')
@@ -176,5 +177,103 @@ describe('ensureCommand', () => {
     expect(payload.data.changed).toBe(true)
     expect(payload.data.installed).toBe(true)
     expect(payload.meta.runId).toBe('ensure-run-id')
+  })
+
+  it('returns a dry-run plan without invoking installAgent', async () => {
+    setCliContext({
+      dryRun: true,
+      interactive: false,
+      outputMode: 'json',
+      runId: 'ensure-dry-run-id',
+    })
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+
+    const result = await ensureCommand('test-agent')
+
+    expect(result).toMatchObject({
+      action: 'ensure',
+      data: {
+        changed: false,
+        installed: false,
+      },
+      ok: true,
+      warnings: [
+        {
+          code: 'DRY_RUN',
+        },
+      ],
+    })
+    expect(installSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves install failure data when the installer returns false', async () => {
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+    installSpy.mockResolvedValue({ success: false })
+
+    const result = await ensureCommand('test-agent')
+
+    expect(result).toMatchObject({
+      action: 'ensure',
+      data: {
+        changed: false,
+        installed: false,
+      },
+      error: {
+        code: 'INSTALL_FAILED',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'test-agent',
+      },
+    })
+  })
+
+  it('returns the stable cancellation result when tracking cannot complete', async () => {
+    agentSpy.mockReturnValue(scriptOnlyAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    trackSpy.mockResolvedValue(null)
+
+    const result = await ensureCommand('script-agent')
+
+    expect(result).toMatchObject({
+      action: 'ensure',
+      error: {
+        code: 'CANCELLED',
+        message: 'Ensure was cancelled before tracking could complete.',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'script-agent',
+      },
+    })
+    expect(installSpy).not.toHaveBeenCalled()
+  })
+
+  it('returns a stable conflict when installation cannot acquire the lifecycle lock', async () => {
+    agentSpy.mockReturnValue(testAgent)
+    binaryInPathSpy.mockResolvedValue(false)
+    installSpy.mockRejectedValue(new ResourceLockError('agent lifecycle', '/tmp/agent-lifecycle.lock'))
+
+    const result = await ensureCommand('test-agent')
+
+    expect(result).toMatchObject({
+      action: 'ensure',
+      data: {
+        changed: false,
+        installed: false,
+      },
+      error: {
+        code: 'RESOURCE_LOCKED',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'test-agent',
+      },
+    })
   })
 })

--- a/test/commands/install.test.ts
+++ b/test/commands/install.test.ts
@@ -117,7 +117,7 @@ describe('installCommand', () => {
       command: expectedScriptInstallCommand,
     })
 
-    await installCommand('script-agent')
+    const result = await installCommand('script-agent')
 
     expect(trackSpy).toHaveBeenCalledWith(
       scriptOnlyAgent,
@@ -127,6 +127,30 @@ describe('installCommand', () => {
       }),
     )
     expect(installSpy).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      action: 'install',
+      data: {
+        agent: {
+          displayName: 'Script Agent',
+          name: 'script-agent',
+        },
+        changed: true,
+        installState: {
+          installType: 'script',
+        },
+        installed: true,
+      },
+      ok: true,
+      target: {
+        kind: 'agent',
+        name: 'script-agent',
+      },
+      warnings: [
+        {
+          code: 'TRACKED_EXISTING_INSTALL',
+        },
+      ],
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Quantex is now tracking the existing install'))
   })
 
@@ -134,11 +158,46 @@ describe('installCommand', () => {
     agentSpy.mockReturnValue(testAgent)
     binaryInPathSpy.mockResolvedValue(true)
 
-    await installCommand('test-agent')
+    const result = await installCommand('test-agent')
 
     expect(trackSpy).not.toHaveBeenCalled()
     expect(installSpy).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      action: 'install',
+      data: {
+        changed: false,
+        installed: true,
+      },
+      ok: true,
+      warnings: [
+        {
+          code: 'UNTRACKED_EXISTING_INSTALL',
+        },
+      ],
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('not tracked by Quantex'))
+  })
+
+  it('returns the stable cancellation result when tracking cannot complete', async () => {
+    agentSpy.mockReturnValue(scriptOnlyAgent)
+    binaryInPathSpy.mockResolvedValue(true)
+    trackSpy.mockResolvedValue(null)
+
+    const result = await installCommand('script-agent')
+
+    expect(result).toMatchObject({
+      action: 'install',
+      error: {
+        code: 'CANCELLED',
+        message: 'Install was cancelled before tracking could complete.',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'script-agent',
+      },
+    })
+    expect(installSpy).not.toHaveBeenCalled()
   })
 
   it('calls installAgent and shows success', async () => {
@@ -166,6 +225,18 @@ describe('installCommand', () => {
     const result = await installCommand('test-agent')
 
     expect(result.error?.code).toBe('RESOURCE_LOCKED')
+    expect(result).toMatchObject({
+      action: 'install',
+      data: {
+        changed: false,
+        installed: false,
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'test-agent',
+      },
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('agent lifecycle lock'))
   })
 

--- a/test/commands/uninstall.test.ts
+++ b/test/commands/uninstall.test.ts
@@ -63,8 +63,23 @@ describe('uninstallCommand', () => {
     agentSpy.mockReturnValue(testAgent)
     installedStateSpy.mockResolvedValue(managedInstalledState)
     uninstallSpy.mockResolvedValue(true)
-    await uninstallCommand('test-agent')
+    const result = await uninstallCommand('test-agent')
     expect(uninstallSpy).toHaveBeenCalledWith(testAgent)
+    expect(result).toMatchObject({
+      action: 'uninstall',
+      data: {
+        agent: {
+          displayName: 'Test Agent',
+          name: 'test-agent',
+        },
+        changed: true,
+      },
+      ok: true,
+      target: {
+        kind: 'agent',
+        name: 'test-agent',
+      },
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('uninstalled successfully'))
   })
 
@@ -73,7 +88,16 @@ describe('uninstallCommand', () => {
     installedStateSpy.mockResolvedValue(managedInstalledState)
     uninstallSpy.mockResolvedValue(false)
     const result = await uninstallCommand('test-agent')
-    expect(result.error?.code).toBe('UNINSTALL_FAILED')
+    expect(result).toMatchObject({
+      action: 'uninstall',
+      data: {
+        changed: false,
+      },
+      error: {
+        code: 'UNINSTALL_FAILED',
+      },
+      ok: false,
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to uninstall'))
   })
 
@@ -108,7 +132,20 @@ describe('uninstallCommand', () => {
 
     const result = await uninstallCommand('test-agent')
 
-    expect(result.error?.code).toBe('RESOURCE_LOCKED')
+    expect(result).toMatchObject({
+      action: 'uninstall',
+      data: {
+        changed: false,
+      },
+      error: {
+        code: 'RESOURCE_LOCKED',
+      },
+      ok: false,
+      target: {
+        kind: 'agent',
+        name: 'test-agent',
+      },
+    })
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('agent lifecycle lock'))
   })
 
@@ -128,9 +165,18 @@ describe('uninstallCommand', () => {
 
     const result = await uninstallCommand('test-agent')
 
-    expect(result.ok).toBe(true)
-    expect(result.data?.changed).toBe(false)
-    expect(result.warnings[0]?.code).toBe('DRY_RUN')
+    expect(result).toMatchObject({
+      action: 'uninstall',
+      data: {
+        changed: false,
+      },
+      ok: true,
+      warnings: [
+        {
+          code: 'DRY_RUN',
+        },
+      ],
+    })
     expect(uninstallSpy).not.toHaveBeenCalled()
   })
 

--- a/test/services/install-ensure.test.ts
+++ b/test/services/install-ensure.test.ts
@@ -1,0 +1,277 @@
+import type { AgentDefinition, InstallMethod } from '../../src/agents'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runInstallEnsureLifecycle, type InstallEnsureLifecycleDependencies } from '../../src/services/install-ensure'
+import { ResourceLockError } from '../../src/utils/lock'
+
+const testAgent: AgentDefinition = {
+  binaryName: 'test-bin',
+  displayName: 'Test Agent',
+  homepage: 'https://example.com',
+  name: 'test-agent',
+  packages: {
+    npm: 'test-pkg',
+  },
+  platforms: {
+    linux: [{ type: 'bun' }],
+    macos: [{ type: 'bun' }],
+    windows: [{ type: 'bun' }],
+  },
+}
+
+const scriptMethod: InstallMethod = {
+  command: 'curl https://example.com/install | bash',
+  type: 'script',
+}
+
+function createInspection(
+  overrides: Partial<{
+    inPath: boolean
+    installedState: {
+      agentName: string
+      installType: 'bun'
+      packageName: string
+    }
+    methods: InstallMethod[]
+  }> = {},
+) {
+  return {
+    agent: testAgent,
+    inspection: {
+      agent: testAgent,
+      inPath: overrides.inPath ?? false,
+      installedState: overrides.installedState,
+      lifecycle: overrides.installedState ? ('managed' as const) : ('unmanaged' as const),
+      methods: overrides.methods ?? testAgent.platforms.macos!,
+      sourceLabel: 'Unknown',
+      updateLabel: 'Manual',
+    },
+  }
+}
+
+function createDependencies(): InstallEnsureLifecycleDependencies {
+  return {
+    getAdoptableExistingInstallMethod: vi.fn(),
+    installAgent: vi.fn(),
+    isResourceLockError: (error): error is ResourceLockError => error instanceof ResourceLockError,
+    resolveAgentInspection: vi.fn(),
+    trackInstalledAgent: vi.fn(),
+  }
+}
+
+describe('runInstallEnsureLifecycle', () => {
+  let dependencies: InstallEnsureLifecycleDependencies
+
+  beforeEach(() => {
+    dependencies = createDependencies()
+  })
+
+  it('returns agent-not-found without attempting a mutation', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(undefined)
+
+    const result = await runInstallEnsureLifecycle('missing-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      input: 'missing-agent',
+      kind: 'agent-not-found',
+    })
+    expect(dependencies.installAgent).not.toHaveBeenCalled()
+    expect(dependencies.trackInstalledAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns already-installed for a managed existing install', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+        installedState: {
+          agentName: 'test-agent',
+          installType: 'bun',
+          packageName: 'test-pkg',
+        },
+      }),
+    )
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'already-installed',
+    })
+    expect(dependencies.installAgent).not.toHaveBeenCalled()
+    expect(dependencies.trackInstalledAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns would-track-existing for an adoptable dry run', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+        methods: [scriptMethod],
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(scriptMethod)
+    const onMutationStart = vi.fn()
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: true, onMutationStart }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'would-track-existing',
+    })
+    expect(onMutationStart).not.toHaveBeenCalled()
+    expect(dependencies.trackInstalledAgent).not.toHaveBeenCalled()
+  })
+
+  it('tracks an adoptable existing install after announcing the mutation', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+        methods: [scriptMethod],
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(scriptMethod)
+    vi.mocked(dependencies.trackInstalledAgent).mockResolvedValue({
+      agentName: 'test-agent',
+      command: scriptMethod.command,
+      installType: 'script',
+    })
+    const onMutationStart = vi.fn()
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false, onMutationStart }, dependencies)
+
+    expect(onMutationStart).toHaveBeenCalledWith(testAgent)
+    expect(dependencies.trackInstalledAgent).toHaveBeenCalledWith(testAgent, scriptMethod)
+    expect(result).toMatchObject({
+      agent: testAgent,
+      installedState: {
+        agentName: 'test-agent',
+        installType: 'script',
+      },
+      kind: 'tracked-existing',
+    })
+  })
+
+  it('returns tracking-cancelled when adopted state is not persisted', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+        methods: [scriptMethod],
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(scriptMethod)
+    vi.mocked(dependencies.trackInstalledAgent).mockResolvedValue(null)
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'tracking-cancelled',
+    })
+  })
+
+  it('returns untracked-existing when no install source is safely adoptable', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath: true,
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(undefined)
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'untracked-existing',
+    })
+    expect(dependencies.installAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns would-install for a missing agent dry run', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(createInspection())
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: true }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'would-install',
+    })
+    expect(dependencies.installAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns installed with persisted install state after installation succeeds', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(createInspection())
+    vi.mocked(dependencies.installAgent).mockResolvedValue({
+      installedState: {
+        agentName: 'test-agent',
+        installType: 'bun',
+        packageName: 'test-pkg',
+      },
+      success: true,
+    })
+    const onMutationStart = vi.fn()
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false, onMutationStart }, dependencies)
+
+    expect(onMutationStart).toHaveBeenCalledWith(testAgent)
+    expect(result).toMatchObject({
+      agent: testAgent,
+      installedState: {
+        installType: 'bun',
+        packageName: 'test-pkg',
+      },
+      kind: 'installed',
+    })
+  })
+
+  it('returns install-failed when installation reports failure', async () => {
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(createInspection())
+    vi.mocked(dependencies.installAgent).mockResolvedValue({ success: false })
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'install-failed',
+    })
+  })
+
+  it.each([
+    {
+      expectedInstalled: true,
+      inPath: true,
+      operation: 'track',
+    },
+    {
+      expectedInstalled: false,
+      inPath: false,
+      operation: 'install',
+    },
+  ])('returns resource-locked when $operation cannot acquire the lock', async ({ expectedInstalled, inPath }) => {
+    const error = new ResourceLockError('agent lifecycle', '/tmp/agent-lifecycle.lock')
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(
+      createInspection({
+        inPath,
+        methods: [scriptMethod],
+      }),
+    )
+    vi.mocked(dependencies.getAdoptableExistingInstallMethod).mockReturnValue(scriptMethod)
+
+    if (inPath) vi.mocked(dependencies.trackInstalledAgent).mockRejectedValue(error)
+    else vi.mocked(dependencies.installAgent).mockRejectedValue(error)
+
+    const result = await runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      error,
+      installed: expectedInstalled,
+      kind: 'resource-locked',
+    })
+  })
+
+  it('propagates unexpected installation errors', async () => {
+    const error = new Error('unexpected')
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue(createInspection())
+    vi.mocked(dependencies.installAgent).mockRejectedValue(error)
+
+    await expect(runInstallEnsureLifecycle('test-agent', { dryRun: false }, dependencies)).rejects.toBe(error)
+  })
+})

--- a/test/services/runtime-cancellation.test.ts
+++ b/test/services/runtime-cancellation.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  executeWithRuntimeCancellation,
+  type RuntimeCancellationDependencies,
+} from '../../src/services/runtime-cancellation'
+
+function createDependencies() {
+  const listeners = new Map<NodeJS.Signals, () => void>()
+  const dependencies: RuntimeCancellationDependencies = {
+    clearTimeout,
+    offSignal: vi.fn((signal, handler) => {
+      if (listeners.get(signal) === handler) listeners.delete(signal)
+    }),
+    onSignal: vi.fn((signal, handler) => {
+      listeners.set(signal, handler)
+    }),
+    setTimeout,
+  }
+
+  return {
+    dependencies,
+    emit(signal: NodeJS.Signals): void {
+      listeners.get(signal)?.()
+    },
+    listeners,
+  }
+}
+
+describe('executeWithRuntimeCancellation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns a completed outcome and removes signal listeners', async () => {
+    const { dependencies, listeners } = createDependencies()
+    const cancelOperations = vi.fn()
+
+    const result = await executeWithRuntimeCancellation(
+      {
+        cancelOperations,
+        isCancelled: () => false,
+        run: async () => 'done',
+      },
+      dependencies,
+    )
+
+    expect(result).toEqual({
+      kind: 'completed',
+      result: 'done',
+    })
+    expect(cancelOperations).not.toHaveBeenCalled()
+    expect(listeners.size).toBe(0)
+  })
+
+  it('cancels operations and returns timeout after the deadline and grace period', async () => {
+    const { dependencies } = createDependencies()
+    const cancelOperations = vi.fn()
+    const execution = executeWithRuntimeCancellation(
+      {
+        cancelOperations,
+        isCancelled: () => false,
+        run: () => new Promise<string>(() => {}),
+        timeoutMs: 100,
+      },
+      dependencies,
+    )
+
+    await vi.advanceTimersByTimeAsync(200)
+
+    await expect(execution).resolves.toEqual({
+      kind: 'timed-out',
+      timeoutMs: 100,
+    })
+    expect(cancelOperations).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves a terminal result that arrives within the timeout grace period', async () => {
+    const { dependencies } = createDependencies()
+    const cancelOperations = vi.fn()
+    const execution = executeWithRuntimeCancellation(
+      {
+        cancelOperations,
+        isCancelled: () => false,
+        run: () =>
+          new Promise<string>(resolve => {
+            setTimeout(() => resolve('late-result'), 150)
+          }),
+        timeoutMs: 100,
+      },
+      dependencies,
+    )
+
+    await vi.advanceTimersByTimeAsync(150)
+
+    await expect(execution).resolves.toEqual({
+      kind: 'completed',
+      result: 'late-result',
+    })
+    expect(cancelOperations).not.toHaveBeenCalled()
+  })
+
+  it.each(['SIGINT', 'SIGTERM'] as const)('cancels operations for %s and removes listeners', async signal => {
+    const { dependencies, emit, listeners } = createDependencies()
+    const cancelOperations = vi.fn()
+    const execution = executeWithRuntimeCancellation(
+      {
+        cancelOperations,
+        isCancelled: () => true,
+        run: () => new Promise<string>(() => {}),
+      },
+      dependencies,
+    )
+
+    emit(signal)
+
+    await expect(execution).resolves.toEqual({
+      kind: 'signal-cancelled',
+      signal,
+    })
+    expect(cancelOperations).toHaveBeenCalledTimes(1)
+    expect(listeners.size).toBe(0)
+  })
+
+  it('propagates command errors and removes signal listeners', async () => {
+    const { dependencies, listeners } = createDependencies()
+    const error = new Error('failed')
+
+    await expect(
+      executeWithRuntimeCancellation(
+        {
+          cancelOperations: vi.fn(),
+          isCancelled: () => false,
+          run: async () => {
+            throw error
+          },
+        },
+        dependencies,
+      ),
+    ).rejects.toBe(error)
+    expect(listeners.size).toBe(0)
+  })
+})

--- a/test/services/runtime-idempotency.test.ts
+++ b/test/services/runtime-idempotency.test.ts
@@ -1,0 +1,249 @@
+import type { CommandResult, CommandTarget } from '../../src/output/types'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  persistIdempotentExecution,
+  resolveIdempotentExecution,
+  type RuntimeIdempotencyDependencies,
+  type RuntimeIdempotencyInvocation,
+} from '../../src/services/runtime-idempotency'
+
+const target: CommandTarget = {
+  kind: 'agent',
+  name: 'codex',
+}
+
+function createResult(overrides: Partial<CommandResult> = {}): CommandResult {
+  return {
+    action: 'install',
+    error: null,
+    meta: {
+      mode: 'json',
+      runId: 'stored-run',
+      schemaVersion: '1',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      version: '1.0.0',
+    },
+    ok: true,
+    target,
+    warnings: [],
+    ...overrides,
+  }
+}
+
+function createInvocation(overrides: Partial<RuntimeIdempotencyInvocation> = {}): RuntimeIdempotencyInvocation {
+  return {
+    action: 'install',
+    dryRun: false,
+    idempotencyKey: 'job-1',
+    outputMode: 'ndjson',
+    runId: 'current-run',
+    target,
+    ...overrides,
+  }
+}
+
+function createDependencies(): RuntimeIdempotencyDependencies {
+  return {
+    loadIdempotencyRecord: vi.fn(),
+    now: vi.fn(() => '2026-07-09T00:00:00.000Z'),
+    resolveAgentInspection: vi.fn(),
+    saveIdempotencyRecord: vi.fn(),
+  }
+}
+
+function createStoredRecord(
+  overrides: Partial<{
+    action: string
+    result: CommandResult
+    target: CommandTarget
+  }> = {},
+) {
+  return {
+    action: overrides.action ?? 'install',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    expiresAt: '2027-01-01T00:00:00.000Z',
+    result: overrides.result ?? createResult(),
+    target: overrides.target ?? target,
+  }
+}
+
+describe('runtime idempotency service', () => {
+  let dependencies: RuntimeIdempotencyDependencies
+
+  beforeEach(() => {
+    dependencies = createDependencies()
+  })
+
+  it('returns a miss without loading storage when no key is supplied', async () => {
+    const result = await resolveIdempotentExecution(createInvocation({ idempotencyKey: undefined }), dependencies)
+
+    expect(result).toEqual({ kind: 'miss' })
+    expect(dependencies.loadIdempotencyRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns a command-neutral conflict when a key belongs to another action', async () => {
+    vi.mocked(dependencies.loadIdempotencyRecord).mockResolvedValue(
+      createStoredRecord({
+        action: 'uninstall',
+      }),
+    )
+
+    const result = await resolveIdempotentExecution(createInvocation(), dependencies)
+
+    expect(result).toEqual({
+      existingAction: 'uninstall',
+      idempotencyKey: 'job-1',
+      kind: 'conflict',
+    })
+  })
+
+  it('returns a miss for a different target', async () => {
+    vi.mocked(dependencies.loadIdempotencyRecord).mockResolvedValue(
+      createStoredRecord({
+        target: {
+          kind: 'agent',
+          name: 'claude',
+        },
+      }),
+    )
+
+    await expect(resolveIdempotentExecution(createInvocation(), dependencies)).resolves.toEqual({
+      kind: 'miss',
+    })
+  })
+
+  it('does not replay a stored dry-run result', async () => {
+    vi.mocked(dependencies.loadIdempotencyRecord).mockResolvedValue(
+      createStoredRecord({
+        result: createResult({
+          warnings: [
+            {
+              code: 'DRY_RUN',
+              message: 'No changes were made.',
+            },
+          ],
+        }),
+      }),
+    )
+
+    await expect(resolveIdempotentExecution(createInvocation(), dependencies)).resolves.toEqual({
+      kind: 'miss',
+    })
+  })
+
+  it.each([
+    {
+      action: 'install',
+      inPath: false,
+    },
+    {
+      action: 'uninstall',
+      inPath: true,
+    },
+  ])('does not replay stale $action lifecycle success', async ({ action, inPath }) => {
+    vi.mocked(dependencies.loadIdempotencyRecord).mockResolvedValue(
+      createStoredRecord({
+        action,
+        result: createResult({ action }),
+      }),
+    )
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue({
+      agent: {} as never,
+      inspection: {
+        inPath,
+      } as never,
+    })
+
+    await expect(resolveIdempotentExecution(createInvocation({ action }), dependencies)).resolves.toEqual({
+      kind: 'miss',
+    })
+  })
+
+  it('refreshes replay metadata for the current invocation', async () => {
+    vi.mocked(dependencies.loadIdempotencyRecord).mockResolvedValue(createStoredRecord())
+    vi.mocked(dependencies.resolveAgentInspection).mockResolvedValue({
+      agent: {} as never,
+      inspection: {
+        inPath: true,
+      } as never,
+    })
+
+    const result = await resolveIdempotentExecution(createInvocation(), dependencies)
+
+    expect(result).toEqual({
+      kind: 'replay',
+      result: expect.objectContaining({
+        meta: expect.objectContaining({
+          mode: 'ndjson',
+          runId: 'current-run',
+          timestamp: '2026-07-09T00:00:00.000Z',
+        }),
+      }),
+    })
+  })
+
+  it.each([
+    {
+      dryRun: false,
+      key: 'job-1',
+      result: createResult(),
+      saves: true,
+    },
+    {
+      dryRun: false,
+      key: undefined,
+      result: createResult(),
+      saves: false,
+    },
+    {
+      dryRun: true,
+      key: 'job-1',
+      result: createResult(),
+      saves: false,
+    },
+    {
+      dryRun: false,
+      key: 'job-1',
+      result: createResult({
+        error: {
+          code: 'INSTALL_FAILED',
+          message: 'failed',
+        },
+        ok: false,
+      }),
+      saves: false,
+    },
+    {
+      dryRun: false,
+      key: 'job-1',
+      result: createResult({
+        warnings: [
+          {
+            code: 'DRY_RUN',
+            message: 'No changes were made.',
+          },
+        ],
+      }),
+      saves: false,
+    },
+  ])('persists only eligible successful results: $saves', async ({ dryRun, key, result, saves }) => {
+    await persistIdempotentExecution(
+      createInvocation({
+        dryRun,
+        idempotencyKey: key,
+      }),
+      result,
+      dependencies,
+    )
+
+    if (saves) {
+      expect(dependencies.saveIdempotencyRecord).toHaveBeenCalledWith('job-1', {
+        action: 'install',
+        result,
+        target,
+      })
+    } else {
+      expect(dependencies.saveIdempotencyRecord).not.toHaveBeenCalled()
+    }
+  })
+})

--- a/test/services/uninstall.test.ts
+++ b/test/services/uninstall.test.ts
@@ -1,0 +1,137 @@
+import type { AgentDefinition } from '../../src/agents'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runUninstallLifecycle, type UninstallLifecycleDependencies } from '../../src/services/uninstall'
+import { ResourceLockError } from '../../src/utils/lock'
+
+const testAgent: AgentDefinition = {
+  binaryName: 'test-bin',
+  displayName: 'Test Agent',
+  homepage: 'https://example.com',
+  name: 'test-agent',
+  packages: {
+    npm: 'test-pkg',
+  },
+  platforms: {
+    linux: [{ type: 'bun' }],
+    macos: [{ type: 'bun' }],
+    windows: [{ type: 'bun' }],
+  },
+}
+
+function createDependencies(): UninstallLifecycleDependencies {
+  return {
+    getInstalledAgentState: vi.fn(),
+    isResourceLockError: (error): error is ResourceLockError => error instanceof ResourceLockError,
+    resolveAgent: vi.fn(),
+    uninstallAgent: vi.fn(),
+  }
+}
+
+describe('runUninstallLifecycle', () => {
+  let dependencies: UninstallLifecycleDependencies
+
+  beforeEach(() => {
+    dependencies = createDependencies()
+  })
+
+  it('returns agent-not-found without inspecting state', async () => {
+    vi.mocked(dependencies.resolveAgent).mockReturnValue(undefined)
+
+    const result = await runUninstallLifecycle('missing-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      input: 'missing-agent',
+      kind: 'agent-not-found',
+    })
+    expect(dependencies.getInstalledAgentState).not.toHaveBeenCalled()
+  })
+
+  it('returns unmanaged without invoking uninstall', async () => {
+    vi.mocked(dependencies.resolveAgent).mockReturnValue(testAgent)
+    vi.mocked(dependencies.getInstalledAgentState).mockResolvedValue(undefined)
+
+    const result = await runUninstallLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      input: 'test-agent',
+      kind: 'unmanaged',
+    })
+    expect(dependencies.uninstallAgent).not.toHaveBeenCalled()
+  })
+
+  it('returns would-uninstall for a managed dry run', async () => {
+    vi.mocked(dependencies.resolveAgent).mockReturnValue(testAgent)
+    vi.mocked(dependencies.getInstalledAgentState).mockResolvedValue({
+      agentName: 'test-agent',
+      installType: 'bun',
+      packageName: 'test-pkg',
+    })
+
+    const result = await runUninstallLifecycle('test-agent', { dryRun: true }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind: 'would-uninstall',
+    })
+    expect(dependencies.uninstallAgent).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      kind: 'uninstalled',
+      success: true,
+    },
+    {
+      kind: 'uninstall-failed',
+      success: false,
+    },
+  ] as const)('returns $kind when package-manager success is $success', async ({ kind, success }) => {
+    vi.mocked(dependencies.resolveAgent).mockReturnValue(testAgent)
+    vi.mocked(dependencies.getInstalledAgentState).mockResolvedValue({
+      agentName: 'test-agent',
+      installType: 'bun',
+      packageName: 'test-pkg',
+    })
+    vi.mocked(dependencies.uninstallAgent).mockResolvedValue(success)
+
+    const result = await runUninstallLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      kind,
+    })
+  })
+
+  it('returns resource-locked with the original error', async () => {
+    const error = new ResourceLockError('agent lifecycle', '/tmp/agent-lifecycle.lock')
+    vi.mocked(dependencies.resolveAgent).mockReturnValue(testAgent)
+    vi.mocked(dependencies.getInstalledAgentState).mockResolvedValue({
+      agentName: 'test-agent',
+      installType: 'bun',
+      packageName: 'test-pkg',
+    })
+    vi.mocked(dependencies.uninstallAgent).mockRejectedValue(error)
+
+    const result = await runUninstallLifecycle('test-agent', { dryRun: false }, dependencies)
+
+    expect(result).toEqual({
+      agent: testAgent,
+      error,
+      kind: 'resource-locked',
+    })
+  })
+
+  it('propagates unexpected uninstall errors', async () => {
+    const error = new Error('unexpected')
+    vi.mocked(dependencies.resolveAgent).mockReturnValue(testAgent)
+    vi.mocked(dependencies.getInstalledAgentState).mockResolvedValue({
+      agentName: 'test-agent',
+      installType: 'bun',
+      packageName: 'test-pkg',
+    })
+    vi.mocked(dependencies.uninstallAgent).mockRejectedValue(error)
+
+    await expect(runUninstallLifecycle('test-agent', { dryRun: false }, dependencies)).rejects.toBe(error)
+  })
+})

--- a/test/services/update-execution.test.ts
+++ b/test/services/update-execution.test.ts
@@ -1,0 +1,332 @@
+import type { AgentDefinition } from '../../src/agents'
+import type { AgentInspection } from '../../src/inspection'
+import type { PendingAgentUpdate, PlannedAgentUpdates } from '../../src/services/update'
+import type { InstalledAgentState } from '../../src/state'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  executePlannedUpdates,
+  type UpdateExecutionDependencies,
+  type UpdateResultItem,
+} from '../../src/services/update-execution'
+import { ResourceLockError } from '../../src/utils/lock'
+
+const testAgent: AgentDefinition = {
+  binaryName: 'test-bin',
+  displayName: 'Test Agent',
+  homepage: 'https://example.com/test-agent',
+  name: 'test-agent',
+  packages: {
+    npm: 'test-pkg',
+  },
+  platforms: {
+    linux: [{ type: 'bun' }],
+    macos: [{ type: 'bun' }],
+    windows: [{ type: 'bun' }],
+  },
+}
+
+function createAgent(name: string, overrides: Partial<AgentDefinition> = {}): AgentDefinition {
+  return {
+    ...testAgent,
+    binaryName: `${name}-bin`,
+    displayName: name,
+    name,
+    ...overrides,
+  }
+}
+
+function createInspection(agent: AgentDefinition, overrides: Partial<AgentInspection> = {}): AgentInspection {
+  return {
+    agent,
+    inPath: true,
+    installedVersion: '1.0.0',
+    latestVersion: '2.0.0',
+    lifecycle: 'managed',
+    methods: agent.platforms.macos ?? [],
+    sourceLabel: 'Bun',
+    updateLabel: 'Managed',
+    ...overrides,
+  }
+}
+
+function createPendingUpdate(agent: AgentDefinition, overrides: Partial<PendingAgentUpdate> = {}): PendingAgentUpdate {
+  const inspection = createInspection(agent)
+  return {
+    agent,
+    inspection,
+    installerType: 'bun',
+    package: {
+      packageName: agent.packages?.npm ?? `${agent.name}-pkg`,
+    },
+    strategy: 'managed',
+    ...overrides,
+  }
+}
+
+function createPlan(overrides: Partial<PlannedAgentUpdates> = {}): PlannedAgentUpdates {
+  return {
+    entries: [],
+    grouped: [],
+    manual: [],
+    skippedManualCheck: [],
+    untrackedInPath: [],
+    upToDate: [],
+    ...overrides,
+  }
+}
+
+function createDependencies(): UpdateExecutionDependencies {
+  return {
+    canAutoUpdateAgent: vi.fn(() => true),
+    getAgentUpdateFailureHint: vi.fn(() => undefined),
+    getAgentUpdateStrategy: vi.fn(() => 'managed' as const),
+    getInstalledVersion: vi.fn(async () => undefined),
+    getManualAgentUpdateMessage: vi.fn(agent => `manual:${agent.name}`),
+    getUntrackedPathAgentUpdateMessage: vi.fn(agent => `untracked:${agent.name}`),
+    isResourceLockError: (error): error is ResourceLockError => error instanceof ResourceLockError,
+    updateAgent: vi.fn(async () => ({ success: true })),
+    updateAgentsByType: vi.fn(async () => true),
+  }
+}
+
+describe('executePlannedUpdates', () => {
+  let dependencies: UpdateExecutionDependencies
+
+  beforeEach(() => {
+    dependencies = createDependencies()
+  })
+
+  it('reports initial classifications in their existing order', async () => {
+    const upToDate = createAgent('up-to-date')
+    const skipped = createAgent('skipped')
+    const untracked = createAgent('untracked')
+    const progress: UpdateResultItem[] = []
+
+    const result = await executePlannedUpdates(
+      createPlan({
+        skippedManualCheck: [createInspection(skipped)],
+        untrackedInPath: [createInspection(untracked)],
+        upToDate: [createInspection(upToDate, { latestVersion: '1.0.0' })],
+      }),
+      {
+        dryRun: false,
+        isCancelled: () => false,
+        onProgress: item => progress.push(item),
+      },
+      dependencies,
+    )
+
+    expect(result).toEqual({
+      hasFailures: false,
+      results: [
+        {
+          displayName: 'up-to-date',
+          installedVersion: '1.0.0',
+          latestVersion: '1.0.0',
+          name: 'up-to-date',
+          status: 'up-to-date',
+        },
+        {
+          displayName: 'skipped',
+          message: 'manual:skipped',
+          name: 'skipped',
+          status: 'manual-required',
+        },
+        {
+          displayName: 'untracked',
+          message: 'untracked:untracked',
+          name: 'untracked',
+          status: 'manual-required',
+        },
+      ],
+    })
+    expect(progress).toEqual(result.results)
+  })
+
+  it('executes a managed group once and reports every entry', async () => {
+    const first = createPendingUpdate(createAgent('first'))
+    const second = createPendingUpdate(createAgent('second'))
+
+    const result = await executePlannedUpdates(
+      createPlan({
+        grouped: [
+          {
+            packages: [first.package!, second.package!],
+            type: 'bun',
+            updates: [first, second],
+          },
+        ],
+      }),
+      { dryRun: false, isCancelled: () => false },
+      dependencies,
+    )
+
+    expect(dependencies.updateAgentsByType).toHaveBeenCalledWith('bun', [first.package, second.package])
+    expect(dependencies.updateAgent).not.toHaveBeenCalled()
+    expect(result.results.map(item => item.status)).toEqual(['updated', 'updated'])
+  })
+
+  it('falls back to sequential per-agent updates when grouped execution reports failure', async () => {
+    const first = createPendingUpdate(createAgent('first'))
+    const second = createPendingUpdate(createAgent('second'))
+    vi.mocked(dependencies.updateAgentsByType).mockResolvedValue(false)
+
+    const result = await executePlannedUpdates(
+      createPlan({
+        grouped: [
+          {
+            packages: [first.package!, second.package!],
+            type: 'bun',
+            updates: [first, second],
+          },
+        ],
+      }),
+      { dryRun: false, isCancelled: () => false },
+      dependencies,
+    )
+
+    expect(dependencies.updateAgent).toHaveBeenNthCalledWith(1, first.agent, undefined)
+    expect(dependencies.updateAgent).toHaveBeenNthCalledWith(2, second.agent, undefined)
+    expect(result.results.map(item => item.status)).toEqual(['updated', 'updated'])
+  })
+
+  it('returns planned results without invoking mutations during dry-run', async () => {
+    const grouped = createPendingUpdate(createAgent('grouped'))
+    const manual = createPendingUpdate(createAgent('manual'))
+
+    const result = await executePlannedUpdates(
+      createPlan({
+        grouped: [
+          {
+            packages: [grouped.package!],
+            type: 'bun',
+            updates: [grouped],
+          },
+        ],
+        manual: [manual],
+      }),
+      { dryRun: true, isCancelled: () => false },
+      dependencies,
+    )
+
+    expect(dependencies.updateAgentsByType).not.toHaveBeenCalled()
+    expect(dependencies.updateAgent).not.toHaveBeenCalled()
+    expect(result.results.map(item => item.status)).toEqual(['planned', 'planned'])
+  })
+
+  it('stops before later groups and manual entries after cancellation', async () => {
+    const first = createPendingUpdate(createAgent('first'))
+    const second = createPendingUpdate(createAgent('second'), {
+      installerType: 'npm',
+      package: { packageName: 'second-pkg' },
+    })
+    const manual = createPendingUpdate(createAgent('manual'))
+    let cancelled = false
+
+    const result = await executePlannedUpdates(
+      createPlan({
+        grouped: [
+          {
+            packages: [first.package!],
+            type: 'bun',
+            updates: [first],
+          },
+          {
+            packages: [second.package!],
+            type: 'npm',
+            updates: [second],
+          },
+        ],
+        manual: [manual],
+      }),
+      {
+        dryRun: false,
+        isCancelled: () => cancelled,
+        onProgress: () => {
+          cancelled = true
+        },
+      },
+      dependencies,
+    )
+
+    expect(dependencies.updateAgentsByType).toHaveBeenCalledTimes(1)
+    expect(dependencies.updateAgentsByType).toHaveBeenCalledWith('bun', [first.package])
+    expect(dependencies.updateAgent).not.toHaveBeenCalled()
+    expect(result.results.map(item => item.name)).toEqual(['first'])
+  })
+
+  it('preserves lifecycle lock details for individual updates', async () => {
+    const error = new ResourceLockError('agent lifecycle', '/tmp/agent-lifecycle.lock')
+    const update = createPendingUpdate(testAgent, {
+      state: {
+        agentName: testAgent.name,
+        command: 'test-bin update',
+        installType: 'script',
+      } satisfies InstalledAgentState,
+      strategy: 'self-update',
+    })
+    vi.mocked(dependencies.getAgentUpdateStrategy).mockReturnValue('self-update')
+    vi.mocked(dependencies.updateAgent).mockRejectedValue(error)
+
+    const result = await executePlannedUpdates(
+      createPlan({ manual: [update] }),
+      { dryRun: false, isCancelled: () => false },
+      dependencies,
+    )
+
+    expect(result).toEqual({
+      hasFailures: true,
+      results: [
+        {
+          displayName: 'Test Agent',
+          installedVersion: '1.0.0',
+          latestVersion: '2.0.0',
+          message: error.message,
+          name: 'test-agent',
+          resource: 'agent lifecycle',
+          status: 'locked',
+          strategy: 'self-update',
+        },
+      ],
+    })
+  })
+
+  it.each([
+    {
+      expected: {
+        installedVersion: '1.0.0',
+        latestVersion: '1.0.0',
+        status: 'up-to-date',
+      },
+      verifiedVersion: '1.0.0',
+    },
+    {
+      expected: {
+        installedVersion: '1.0.0',
+        latestVersion: '2.0.0',
+        status: 'updated',
+      },
+      verifiedVersion: '2.0.0',
+    },
+  ] as const)('classifies a verified self-update as $expected.status', async ({ expected, verifiedVersion }) => {
+    const agent = createAgent('self-updating', {
+      selfUpdate: {
+        command: ['self-updating-bin', 'update'],
+      },
+    })
+    const update = createPendingUpdate(agent, {
+      strategy: 'self-update',
+    })
+    vi.mocked(dependencies.getAgentUpdateStrategy).mockReturnValue('self-update')
+    vi.mocked(dependencies.getInstalledVersion).mockResolvedValue(verifiedVersion)
+
+    const result = await executePlannedUpdates(
+      createPlan({ manual: [update] }),
+      { dryRun: false, isCancelled: () => false },
+      dependencies,
+    )
+
+    expect(dependencies.getInstalledVersion).toHaveBeenCalledWith(agent.binaryName, agent.versionProbe)
+    expect(result.results[0]).toMatchObject(expected)
+  })
+})


### PR DESCRIPTION
## Summary

Separate lifecycle and runtime execution policies from CLI presentation while preserving the existing public contract.

- move install/ensure, uninstall, and update execution into focused services
- separate timeout/signal cancellation and idempotency from runtime output mapping
- split the pure agent-catalog loader from the checked-in generated snapshot
- retain the existing inspect/resolve/list/info and self-upgrade boundaries after audit
- add direct service tests and compatibility assertions without changing commands, schemas, state, or catalog data

## Linked Artifacts

- Issue: none; implementation follows the approved architecture discussion
- ADR: none; no new long-lived product decision beyond the OpenSpec contracts
- OpenSpec: `extract-install-ensure-lifecycle-service`, `extract-uninstall-lifecycle-service`, `extract-update-execution-service`, `separate-command-runtime-services`, `separate-agent-catalog-loader`
- Discussion: current implementation thread

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (67 files, 745 tests)
- [x] `bun run build`
- [x] `bun run build:bin` (Linux x64/arm64, macOS x64/arm64, Windows x64)
- [x] `bun run package:check`
- [ ] Not run, explained below

`bun run test:sandbox` requires a locally installed and authenticated Modal CLI. The command was attempted and stopped at that external prerequisite before running sandbox scenarios.

## Release Intent

- Release: not applicable - compatibility-preserving internal refactor with no user-facing behavior or contract change

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec changes remain active by design until merge and are queued for agent-driven archive closure.
- [x] Release is not applicable.

## Notes

The existing `managed-installer-cancellation.e2e` can intermittently exceed its 10-second local test limit or miss the fake installer startup log under machine load. Its standard isolated run and the immediately following full suite both passed; this PR does not change that test timeout.

Reviewers should focus on preservation of result/event mapping in `src/command-runtime.ts` and lifecycle command adapters. The new services intentionally do not emit CLI output.
