### PR TITLE
ci: enable lifecycle integration PR gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,7 +42,7 @@ Describe the change and why it exists.
 
 - [ ] Working tree was clean after commit.
 - [ ] Branch was pushed and this PR is the active delivery artifact.
-- [ ] OpenSpec change is not needed, still active by design until merge, already archived, or queued for agent-driven archive closure.
+- [ ] OpenSpec change is not needed, still active until this merge, active across milestone merges by design, queued for agent-driven archive closure after completion, or already archived.
 - [ ] Release is not applicable, delegated to release automation, or verified.
 
 ## Notes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - main
       - beta
+      - codex/redesign-lifecycle-integration
 
   workflow_dispatch:
 

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -101,6 +101,9 @@ jobs:
 
       - name: Validate PR merge commit policy
         env:
+          PR_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
           PR_COMMITS_JSON: ${{ steps.commits.outputs.commits_json }}
+          PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_IS_VALIDATED_RELEASE_PR: ${{ steps.release-pr.outputs.validated == 'true' }}
+          PR_SAME_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: bun run scripts/pr-merge-commit-policy.ts

--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - beta
+      - codex/redesign-lifecycle-integration
 
   push:
     branches:

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -56,6 +56,10 @@ Use explicit closure language when handing work between agents, reviewers, and a
 
 Agents should not summarize a task as simply "done" when the current state is only local implementation or PR delivery. If the next step belongs to CI, reviewer approval, release automation, or agent-driven OpenSpec archive closure, name that owner explicitly.
 
+## Long-lived integration delivery
+
+When a large compatibility-preserving redesign needs staged review without exposing partial internals to the release line, follow [Lifecycle Integration Delivery](./runbooks/lifecycle-integration-delivery.md). The temporary integration branch is a protected aggregation target, not a release channel. Every milestone keeps an independent plan, commit, PR, validation, review, and OpenSpec task update; final promotion and post-promotion archive closure remain separate operations.
+
 ## Pull request body preflight
 
 PR descriptions are part of the delivery contract, not a best-effort summary. Before creating or editing a PR body, agents should:
@@ -191,7 +195,7 @@ For non-trivial behavior or durable-process changes, use Superpowers plus the ce
 - OpenSpec CLI: proposal, design, spec, task, status, instructions, validation, and archive state transitions
 - [Quantex Task Start](./runbooks/quantex-task-start.md): copy-paste start prompt for fresh agent conversations when a native slash or skill launcher is unavailable
 
-On protected branches, archive closure is an explicit agent-driven follow-up. A fresh agent session should be able to resume from Superpowers + `skills/quantex-agent-runtime/SKILL.md`, inspect active OpenSpec changes, archive completed work, validate, and deliver the archive PR.
+On protected branches, archive closure is an explicit agent-driven follow-up. A fresh agent session should be able to resume from Superpowers + `skills/quantex-agent-runtime/SKILL.md`, inspect active OpenSpec changes, archive completed work, validate, and deliver the archive PR. For an umbrella change delivered through a protected integration branch, each milestone merge closes only that milestone; archive eligibility begins only after the umbrella completion and promotion conditions are satisfied.
 
 Agents should use `openspec status --change <id> --json` and `openspec instructions <artifact> --change <id> --json` when they need to determine the next artifact or implementation step.
 

--- a/docs/runbooks/lifecycle-integration-delivery.md
+++ b/docs/runbooks/lifecycle-integration-delivery.md
@@ -1,0 +1,149 @@
+# Lifecycle Integration Delivery
+
+Use this runbook only while the active OpenSpec changes `redesign-lifecycle-engine` and `support-integration-branch-delivery` are being delivered through the temporary protected branch `codex/redesign-lifecycle-integration`.
+
+The branch aggregates reviewed redesign milestones. It is not a release channel and must not publish an npm package, create a GitHub Release, or receive a Release PR. `main` remains the stable release source; `beta` remains the prerelease source.
+
+## Fixed topology
+
+```text
+main
+└── codex/redesign-lifecycle-integration
+    ├── codex/redesign-<milestone-a>
+    ├── codex/redesign-<milestone-b>
+    └── codex/redesign-<milestone-c>
+```
+
+- Ordinary milestone PR: one commit, milestone branch -> integration.
+- Periodic synchronization: exact same-repository `main -> integration` PR, merge commit required.
+- Final promotion: exact same-repository `integration -> main` PR, merge commit required.
+- Forks, lookalike refs, temporary sync refs, and other multi-commit topologies do not receive an exception.
+
+If an exact `main -> integration` PR has conflicts, stop. Do not push integration directly, disable its ruleset, or broaden the exception ad hoc. Create or amend an OpenSpec change for a verifiable conflict-resolution topology first.
+
+## Setup
+
+### 1. Create the empty integration ref
+
+Fetch the live remote and create integration from the exact current `origin/main` tip:
+
+```bash
+git fetch origin --prune
+git branch codex/redesign-lifecycle-integration origin/main
+git push --set-upstream origin codex/redesign-lifecycle-integration
+git fetch origin --prune
+git rev-list --left-right --count origin/main...origin/codex/redesign-lifecycle-integration
+```
+
+The initial comparison must be `0 0`. This one-time unprotected push must not contain redesign work.
+
+### 2. Merge the process-only bootstrap
+
+Deliver `support-integration-branch-delivery` to `main` as an ordinary single-commit PR. Its allowed scope is workflow targeting/tests, PR topology policy/tests, OpenSpec delivery contracts, and this workflow documentation. It must not contain lifecycle engine implementation.
+
+The bootstrap adds the exact integration ref only to the `pull_request` base filters of CI and Sandbox Tests. It does not add integration to either workflow's `push` filter and does not change the Release `main`/`beta` allowlist.
+
+### 3. Fast-forward before protection
+
+After the bootstrap merges, perform the only direct integration update:
+
+```bash
+git fetch origin --prune
+git merge-base --is-ancestor origin/codex/redesign-lifecycle-integration origin/main
+git push origin origin/main:refs/heads/codex/redesign-lifecycle-integration
+git fetch origin --prune
+git rev-list --left-right --count origin/main...origin/codex/redesign-lifecycle-integration
+```
+
+The comparison must again be `0 0`. Confirm integration now contains the bootstrap workflow and policy before enabling protection.
+
+### 4. Create the temporary ruleset
+
+Create `protect-lifecycle-integration` for the exact integration ref. Mirror the live `protect-main` pull-request and non-fast-forward rules plus these six live required contexts:
+
+- `classify`
+- `lint`
+- `test (ubuntu-latest)`
+- `test (windows-latest)`
+- `test (macos-latest)`
+- `sandbox-tests`
+
+PR Governance continues to run for every PR through its unfiltered trigger, but it is separate from those six ruleset contexts. Once the ruleset is active, do not update integration directly.
+
+## Milestone runtime
+
+### Start a milestone
+
+Before every milestone, fetch both refs and inspect drift:
+
+```bash
+git fetch origin --prune
+git rev-list --left-right --count origin/main...origin/codex/redesign-lifecycle-integration
+```
+
+If `main` has advanced, complete the exact main-sync flow below before branching. Then create a new worktree and branch from the refreshed integration ref. Each milestone must have its own implementation plan, TDD evidence, validation, spec review, quality review, PR, and precise OpenSpec task updates.
+
+### Deliver a milestone
+
+1. Normalize the milestone branch to one conventional commit.
+2. Validate the PR body from `.github/pull_request_template.md` with `bun run pr:body:check`.
+3. Set the PR base to `codex/redesign-lifecycle-integration`.
+4. Wait for all six ruleset contexts and the separate PR Governance workflow.
+5. Merge through an existing ordinary merge method.
+6. Verify the merge and update only OpenSpec tasks whose full wording is satisfied.
+
+A milestone merge is not archive eligibility. Both umbrella changes remain active, accepted deltas remain under `openspec/changes/`, and release/archive closure stay pending.
+
+### Sync the latest main
+
+Use only the exact same-repository head/base pair:
+
+```text
+head: main
+base: codex/redesign-lifecycle-integration
+```
+
+The PR may contain multiple commits because each commit was already accepted on protected `main`. All integration checks still run. Merge with a merge commit, never squash or rebase, then verify:
+
+```bash
+git fetch origin --prune
+git merge-base --is-ancestor origin/main origin/codex/redesign-lifecycle-integration
+```
+
+Record the approved base/head tips and the resulting two-parent merge SHA.
+
+## Final promotion
+
+Do not open the final PR until all of these conditions hold:
+
+- `redesign-lifecycle-engine` reports exactly `74/74` based on genuine implementation and the clarified task 11.6 readiness contract.
+- Actual current-spec synchronization and archive execution have not run early.
+- All milestone PRs are merged and none remains open.
+- A final exact main-sync has completed and current `main` is an ancestor of integration.
+- Compatibility, unit, platform, sandbox, build, binary, package, release-artifact, and release-smoke evidence is green.
+- The complete integration comparison contains only accepted redesign work.
+
+Create the exact same-repository `integration -> main` PR. It may contain multiple reviewed milestone commits, but it must merge with a merge commit after the normal `main` required checks and final code review pass. Verify the merge parents against the approved refreshed tips.
+
+Only the resulting `main` push may enter normal stable release classification. Integration itself must not publish.
+
+## Post-promotion teardown
+
+Keep integration available until the promotion and any release recovery are complete. Then:
+
+1. Open a process-only cleanup PR to `main` that removes the temporary integration PR targets and multi-commit policy exceptions and updates this runbook/runtime guidance.
+2. Verify the cleanup does not create product release intent.
+3. Remove `protect-lifecycle-integration`, then delete the integration ref after confirming it is an ancestor of `main` and no recovery use remains.
+4. Synchronize accepted delta specs into `openspec/specs/`.
+5. Run the repo-native archive-closure flow for both active changes and deliver the archive follow-up through protected `main`.
+6. Remove merged milestone worktrees and local branches only after remote and archive closure are verified.
+
+Promotion, release, teardown, and archive are separate closure states. Report each one explicitly.
+
+## Rollback
+
+- Before promotion: stop new milestone PRs and retain integration for diagnosis; `main` remains unchanged.
+- During final review: fix through another ordinary PR to integration while its PR triggers and ruleset still exist.
+- After promotion: use the normal protected-`main` revert and release-recovery flow; retain integration until recovery no longer needs it.
+
+Never use `beta` as an integration substitute and never add integration to Release workflow triggers or manual release choices.

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -25,6 +25,7 @@ This repository uses OpenSpec for behavior contracts and non-trivial change plan
 - after the implementation PR lands, the change is still only "implemented"
 - treat the change as fully "done" only after specs are synced and `openspec archive <name> --yes` has moved it into `openspec/changes/archive/`
 - protected branches close that final gap through an explicit agent-driven archive follow-up, not repository bot automation
+- for an active umbrella delivered through milestones, a milestone merge is not archive eligibility; update genuine task progress and keep the change active until its completion and promotion conditions are satisfied
 
 Prefer Superpowers for agent behavior and the official OpenSpec CLI for OpenSpec state transitions. This repository should store OpenSpec artifacts, not grow custom project-management commands unless they directly serve Quantex users.
 
@@ -80,6 +81,7 @@ Do not reintroduce full per-agent OPSX command bodies without a new OpenSpec cha
 Archive timing:
 
 - do not archive an active change before its implementation PR has merged
+- do not archive an umbrella change after an intermediate milestone merge; keep its delta under the active change until all accepted requirements and promotion conditions are satisfied
 - sync any accepted spec delta into `openspec/specs/` before archiving
 - run `bun run openspec:validate` before and after archive operations
 - on `main` and `beta`, an agent should open an archive follow-up PR for completed active changes so merge/release success does not leave project memory half-closed

--- a/openspec/changes/support-integration-branch-delivery/.openspec.yaml
+++ b/openspec/changes/support-integration-branch-delivery/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-10

--- a/openspec/changes/support-integration-branch-delivery/design.md
+++ b/openspec/changes/support-integration-branch-delivery/design.md
@@ -1,0 +1,158 @@
+## Context
+
+`redesign-lifecycle-engine` is an active umbrella change delivered through reviewed milestones. It is currently tracked independently at `8/74`; its task numbers, checkboxes, 74-task denominator, implementation scope, and completion credit remain owned by that change. Its current task `11.6` couples current-spec synchronization/archive execution to completion, which would make a pre-promotion `74/74` gate circular when archive execution is required to remain post-promotion. This delivery change permits only a semantic clarification of `11.6` so pre-promotion follow-up readiness can be completed without executing archive closure early. The default branch remains the stable release line, and the existing Release workflow recognizes only `main` and `beta`.
+
+The delivery mechanism needs repository workflow support before lifecycle code can rely on it. The temporary branch `codex/redesign-lifecycle-integration` has therefore been created from an exact `origin/main` commit with no product delta. A single process-only bootstrap pull request can safely teach the existing `main` CI and governance checks about the temporary topology. After that bootstrap merges, the integration ref can be synchronized exactly to the resulting `main` tip before protection is enabled.
+
+This design crosses GitHub Actions, PR governance, release routing, repository rulesets, runbook/runtime guidance, and OpenSpec closure. It does not change Quantex CLI behavior.
+
+Stakeholders are maintainers delivering lifecycle milestones, reviewers protecting `main`, release automation, and agents responsible for OpenSpec/archive closure.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Aggregate lifecycle redesign milestones on a temporary protected branch without making that branch a release line.
+- Apply the same six live `protect-main` required contexts to integration and `main`, while keeping PR Governance as a separate all-PR workflow.
+- Preserve the repository's single-commit default and allow multi-commit history only for two exact, same-repository synchronization/promotion topologies.
+- Make setup, steady-state operation, final promotion, teardown, spec synchronization, and archive closure one explicit lifecycle.
+- Keep the redesign umbrella change independent and require genuine `74/74` completion before final promotion.
+
+**Non-Goals:**
+
+- Creating a permanent `develop` branch, a second release channel, or a workflow orchestration product.
+- Publishing from integration, generating integration Release PRs, or deriving an npm tag/channel from integration.
+- Merging any lifecycle redesign implementation into `main` through the bootstrap pull request.
+- Replacing the existing six contexts, weakening `main` protection, or adding integration `push` triggers to CI or Sandbox Tests.
+- Renumbering `redesign-lifecycle-engine` tasks, changing its checkbox count or 74-task denominator, expanding its implementation scope, or awarding completion credit before the clarified criteria are met. Only task `11.6` wording may be clarified to separate post-promotion follow-up readiness from later execution.
+
+## Decisions
+
+### 1. Use a temporary protected aggregation branch, not a second release line
+
+The exact integration ref is `codex/redesign-lifecycle-integration`. It exists only for the lifecycle redesign delivery window. Milestone pull requests target this branch; ordinary product work continues to target the normal protected release branches.
+
+Integration is never a release source. It is absent from Release `workflow_run` branches, manual target choices and validation, release-please target selection, and Release PR base acceptance; those positive entry allowlists prevent release-target resolution and npm tag/channel derivation from receiving it. A successful integration pull request or merge can prove code quality but cannot publish a GitHub Release or npm package.
+
+The current production release surfaces already use a positive `main`/`beta` allowlist. Bootstrap therefore adds regression coverage first and keeps those production workflow/resolver paths unchanged when the tests prove the boundary. A production release change is allowed only when a focused regression test exposes a concrete path that accepts integration, and then only the smallest correction to restore the existing allowlist is in scope.
+
+Direct milestone merges to `main` were rejected because they would expose partially integrated internals to the release line. A permanent development branch was rejected because it would create an enduring second governance and documentation surface. A prerelease channel was rejected because this work needs aggregation, not publication.
+
+### 2. Bootstrap through one process-only `main` pull request, then protect the synchronized ref
+
+Setup has a one-time sequence:
+
+1. Create the integration ref from an exact observed `origin/main` SHA and verify the remote comparison is `0` commits ahead and `0` behind.
+2. Deliver one process-only bootstrap pull request to `main`. It may change CI/Sandbox pull-request triggers and tests, PR policy tests/logic, release regression tests, runbook/runtime rules, this OpenSpec change, and the narrow `redesign-lifecycle-engine` task `11.6` semantic clarification. It MUST NOT contain lifecycle redesign implementation or change redesign task numbering, checkbox count, denominator, scope, or completion credit.
+3. Let the existing `main` required checks validate that bootstrap pull request and merge it through the ordinary single-commit path.
+4. Before applying the temporary ruleset, synchronize the still-unprotected integration ref to the exact post-bootstrap `main` tip and again verify `0` ahead and `0` behind. This is initialization, not the recurring main-sync exception.
+5. Create a temporary integration ruleset that requires pull requests and the six live `protect-main` contexts listed below. After this point, no direct integration updates are allowed.
+
+Creating the ruleset before post-bootstrap synchronization was rejected because the integration base would not yet contain the workflow and policy that are meant to protect it. Copying unreviewed workflow commits directly onto the protected branch was rejected because `main` must validate the durable process first.
+
+### 3. Reuse the live `protect-main` contexts without adding integration pushes
+
+Live ruleset `protect-main` requires these six exact check contexts:
+
+- `classify`
+- `lint`
+- `test (ubuntu-latest)`
+- `test (windows-latest)`
+- `test (macos-latest)`
+- `sandbox-tests`
+
+The CI and Sandbox Tests `pull_request` base allowlists each gain the exact integration ref so all six contexts can be produced. Their `push` branches remain exactly `main` and `beta`; integration is not added. This prevents direct pushes from becoming an alternative integration path and avoids duplicate post-merge runs.
+
+PR Governance already uses an unfiltered `pull_request` trigger and continues to run for every pull request, including integration. It remains an important policy check but is not one of the six live required status contexts and MUST NOT be represented as such in the temporary ruleset.
+
+A separate integration workflow was rejected because duplicated job names and logic would drift from `main`. Adding integration to either workflow's `push` filter was rejected because it provides no additional merge gate and could be mistaken for a release-adjacent signal.
+
+### 4. Identify the only two multi-commit exceptions from immutable PR topology
+
+Ordinary pull requests continue to contain exactly one commit when evaluated by PR Governance. A multiple-commit pull request is permitted only when all repository identity and ref predicates match one of these shapes:
+
+| Multi-commit operation | Base repository/ref | Head repository/ref | Required merge method |
+|---|---|---|---|
+| Periodic main sync | this repository / `codex/redesign-lifecycle-integration` | this same repository / `main` | merge commit |
+| Final promotion | this repository / `main` | this same repository / `codex/redesign-lifecycle-integration` | merge commit |
+
+Forks, lookalike branch names, reversed refs, other bases, and other heads do not qualify. PR Governance receives base/head repository identity and exact refs from the pull-request payload and tests both allowed shapes and near misses. Release-please validation remains separate and does not create another integration exception.
+
+This change does not impose a merge method on ordinary single-commit milestone or product pull requests; their existing repository governance remains authoritative. The merge-commit mandate applies only when one of the two exact exceptions actually contains multiple commits.
+
+Before a recurring main-sync merge, the operator refreshes both remote refs and verifies the PR contains only commits newly accepted on `main`. Before final promotion, the operator refreshes both refs, verifies `origin/main` is an ancestor of the integration head, verifies there are no open lifecycle milestone pull requests, and verifies that the comparison contains only the accepted redesign delta. After each exceptional merge, the operator verifies the resulting protected-branch commit has two parents with the expected base and head tips.
+
+Squashing these two operations was rejected because it would destroy ancestry and make later synchronization ambiguous. Rebasing was rejected because it would rewrite already reviewed milestone commits. Branch-name-only detection was rejected because a fork could imitate the ref name.
+
+### 5. Gate final promotion on redesign completion, not milestone count
+
+Milestone merges into integration close only that milestone's PR and validation state. They do not make either OpenSpec change archive-eligible. `redesign-lifecycle-engine` stays active while its counter advances from `8/74`; this delivery change stays active throughout the branch lifecycle.
+
+Before final promotion, Phase 0/1 may clarify only redesign task `11.6` so its checkbox means that the explicit post-promotion current-spec synchronization and archive follow-up is ready: owner, command path, ordering, validation, and protected-branch delivery are identified. The clarification MUST retain task number `11.6`, one checkbox, the 74-task denominator, implementation scope, and honest completion credit, and the clarification edit itself MUST leave the checkbox incomplete. It MUST NOT perform, claim, or require current-spec synchronization or archive execution before promotion.
+
+This makes the gate acyclic: the other 73 redesign tasks complete on their existing terms, then clarified `11.6` may complete when post-promotion follow-up readiness is real, producing `74/74`. Actual current-spec synchronization and archive execution remain owned by this change's post-promotion teardown tasks.
+
+Final promotion may open only after all of the following are true:
+
+- `redesign-lifecycle-engine` reports exactly `74/74`: the other 73 tasks are complete on their existing terms and clarified `11.6` has genuine post-promotion follow-up readiness, without early spec synchronization or archive execution;
+- all redesign validation and final release-artifact gates required by that change pass;
+- integration has received a final same-repository `main` sync and contains the latest protected `main` tip;
+- no lifecycle milestone pull request remains open;
+- the final `integration -> main` comparison has been reviewed as the complete accepted redesign and contains no unrelated product work.
+
+The exact integration-to-`main` pull request then uses a merge commit and the normal `main` required checks. Integration itself still does not release. Once the promotion merge exists on `main`, normal `main` release classification and automation decide whether and how the product delta releases.
+
+Archiving at `74/74` before promotion was rejected because implementation/readiness completion is not merge closure. Archiving on a milestone merge was rejected because the umbrella contract spans all milestones.
+
+### 6. Treat teardown and archive closure as post-promotion work
+
+The final promotion is followed by an explicit teardown:
+
+1. Verify the promotion merge on `main` and record its two-parent topology.
+2. Deliver a process-only cleanup pull request to `main` that removes integration-specific CI targeting and temporary PR-policy exceptions, and updates runtime/runbook guidance to the completed state. It MUST NOT publish a release by itself.
+3. Remove the temporary integration ruleset, then delete the temporary integration branch after the cleanup is merged and no recovery use remains.
+4. Reconcile accepted delta requirements into current specs, preserving only the durable conditional/closure rules and keeping transient execution evidence in the archived changes or runbook history.
+5. Run the repo-native archive-closure flow for both `redesign-lifecycle-engine` and `support-integration-branch-delivery`, validate the resulting OpenSpec state, and deliver the archive follow-up through the normal protected-branch PR path.
+
+Neither active change is archive-eligible before final promotion, workflow cleanup, ruleset/branch cleanup, and current-spec synchronization are complete. Release closure and archive closure are reported separately; a successful release does not archive either change automatically.
+
+Leaving dormant integration triggers and policy exceptions in place was rejected because the branch is intentionally temporary. Automatic bot-driven archive PRs were rejected because the repository requires agent-owned archive closure.
+
+## Risks / Trade-offs
+
+- [The temporary branch diverges from new `main` fixes] -> Use only the exact same-repository `main -> integration` PR topology, require the six contexts, merge with a merge commit, and perform a final sync before promotion.
+- [A broad multi-commit exemption weakens PR governance] -> Match repository identity plus both exact refs, test near misses, and remove the exemption during teardown.
+- [Integration accidentally becomes releasable] -> Keep a positive `main`/`beta` release allowlist at every entry point and add negative tests proving workflow, manual, and Release PR gates stop integration before resolver and npm-channel paths.
+- [The initial ruleset protects stale workflow content] -> Create protection only after the post-bootstrap exact synchronization is verified `0/0`.
+- [Partial redesign reaches `main`] -> Allow only process/bootstrap changes before the `74/74` gate and review the complete final comparison.
+- [Task `11.6` creates a promotion/archive dependency cycle] -> Clarify only its readiness semantics without renumbering, changing the denominator or scope, awarding early credit, or executing post-promotion work before promotion.
+- [Two active changes are archived too early] -> Model milestone merge, final promotion, release, teardown, spec sync, and archive as distinct closure states.
+- [Merge commits complicate history] -> Permit them for only the two ancestry-preserving operations; keep all milestone and ordinary pull requests single-commit.
+
+## Migration Plan
+
+### Setup
+
+1. Add focused failing CI/Sandbox trigger and PR-policy tests for the exact branch/topology, plus release regression tests that prove the existing positive `main`/`beta` allowlist.
+2. Implement the smallest CI/Sandbox and PR-policy changes that satisfy those tests, keep production release routing unchanged unless a regression exposes a gap, clarify redesign task `11.6`, and update the operator runbook and central runtime rules.
+3. Validate and deliver the process-only bootstrap pull request to `main`; reject it if lifecycle implementation appears in the diff.
+4. Synchronize integration to the exact resulting `main` tip while it is still unprotected; verify the remote comparison is `0/0`.
+5. Create the temporary ruleset with pull requests and the six required contexts, then verify branch settings from the live repository.
+
+### Runtime
+
+1. Deliver lifecycle milestones as ordinary single-commit pull requests to integration.
+2. When `main` advances, open the exact same-repository `main -> integration` pull request, pass all six contexts, and merge it with a merge commit.
+3. Continue reporting milestone closure separately while both OpenSpec changes remain active.
+
+### Final promotion and teardown
+
+1. Confirm the other 73 redesign tasks and clarified `11.6` follow-up readiness produce genuine `74/74`, then verify full validation, final main sync, clean PR inventory, and the complete comparison; do not execute spec sync/archive yet.
+2. Merge the exact integration-to-`main` promotion pull request with a merge commit and let normal `main` release automation evaluate the promoted product delta.
+3. Merge the process-only workflow/policy cleanup, remove the temporary ruleset and branch, synchronize current specs, and archive both changes through an explicit follow-up.
+
+Rollback before final promotion is to stop new milestone PRs, retain integration for diagnosis, and leave `main` unchanged. Rollback after promotion follows the normal protected-`main` revert/release process; the integration branch is retained until cleanup confirms it is no longer required for recovery.
+
+## Open Questions
+
+None. The exact branch names, six contexts, two allowed multi-commit topologies, non-release boundary, `74/74` gate, and post-promotion teardown/archive order are fixed by this change.

--- a/openspec/changes/support-integration-branch-delivery/proposal.md
+++ b/openspec/changes/support-integration-branch-delivery/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+The lifecycle-engine redesign spans multiple reviewed milestones, but sending each intermediate implementation directly to `main` would expose the release line to a partially integrated architecture. Quantex needs a temporary, protected, explicitly non-release integration path whose bootstrap and eventual removal are themselves governed without changing the redesign implementation contract or its 74-task denominator beyond the narrow task `11.6` readiness clarification defined below.
+
+This is a durable delivery-process change, so it requires an independent OpenSpec change before workflow, policy, runbook, or repository-ruleset implementation begins.
+
+## What Changes
+
+- Establish `codex/redesign-lifecycle-integration` as a temporary, protected aggregation branch initialized from the exact current `origin/main` commit and accepting changes only through pull requests after initialization.
+- Permit one process-only bootstrap pull request to `main` so the existing `main` checks can validate the new CI, governance, release exclusion, runbook, and runtime rules before lifecycle implementation uses the integration branch. The bootstrap pull request MUST NOT contain lifecycle redesign implementation.
+- Give pull requests whose base is exactly the integration branch the six live `protect-main` required contexts: `classify`, `lint`, `test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`, and `sandbox-tests`. CI and Sandbox Tests MUST add the integration ref only to their `pull_request` base filters, never to their `push` filters. PR Governance continues to run for every pull request without a base filter, but it is not one of the six ruleset contexts.
+- Preserve single-commit pull requests by default while permitting multiple commits only for the verified same-repository `main` to integration synchronization topology and the exact integration to `main` final-promotion topology; both exceptions require merge commits.
+- Prove with regression tests that the existing positive `main`/`beta` release allowlist excludes integration from Release `workflow_run`, manual release targets, Release PR targets, and npm tag or channel derivation. Production release routing changes only if those tests expose a concrete gap.
+- Permit one narrow semantic clarification to `redesign-lifecycle-engine` task `11.6`: keep its number, checkbox, 74-task denominator, implementation scope, and completion credit unchanged while defining the task as readiness for the post-promotion spec-sync/archive follow-up. The clarification itself MUST NOT check the task early. The other 73 tasks plus later completed follow-up readiness may produce `74/74`; actual spec synchronization and archive execution remain post-promotion work.
+- Keep this delivery change active across setup, milestone delivery, periodic `main` synchronization, final promotion, workflow/ruleset/branch teardown, current-spec synchronization, and post-promotion archive closure. Keep `redesign-lifecycle-engine` independent and active until its own 74 tasks are genuinely complete.
+- Define teardown so temporary integration support is removed after final promotion and accepted deltas from both active changes reach explicit archive closure.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `code-quality-tooling`: Extend CI and Sandbox Tests pull-request base filters to integration so its pull requests receive the six live `protect-main` contexts, keep both workflows' integration pushes untriggered, and keep unfiltered PR Governance separate from required ruleset contexts.
+- `project-memory`: Define the setup, runtime, final-promotion, teardown, and archive timing for a long-lived umbrella change delivered through milestone pull requests.
+- `release-governance`: Narrowly permit merge-commit delivery for verified same-repository main-sync and final-promotion pull requests while retaining single-commit governance everywhere else.
+- `release-workflow`: Make the temporary integration branch non-release across automatic, manual, Release PR, and npm channel selection paths.
+
+## Impact
+
+- Affected repository surfaces: CI and Sandbox Tests pull-request triggers/tests, release regression tests, PR governance policy/tests, Quantex runtime guidance, delivery runbooks, the narrow redesign task `11.6` clarification, and a temporary GitHub ruleset/branch.
+- Affected OpenSpec state: this change remains independent from `redesign-lifecycle-engine`; neither change may be archived merely because a milestone merges.
+- No CLI command, runtime behavior, public API, package metadata, release artifact, npm channel, or product release is added by this change.
+- Within this lifecycle-delivery scope, the only change allowed to reach `main` before final promotion is the process-only bootstrap that enables and verifies this topology; unrelated normal `main` delivery continues under existing governance.

--- a/openspec/changes/support-integration-branch-delivery/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/support-integration-branch-delivery/specs/code-quality-tooling/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: Temporary lifecycle integration pull requests MUST use the main merge gates
+
+While `codex/redesign-lifecycle-integration` exists, the repository SHALL run the same merge-gating definitions for a pull request whose base is exactly that branch as it runs for a pull request to `main`. The temporary integration ruleset MUST require pull requests and these six live `protect-main` contexts: `classify`, `lint`, `test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`, and `sandbox-tests`. CI and Sandbox Tests MUST add the exact integration ref to their `pull_request` base filters and MUST NOT add it to either workflow's `push` filter. PR Governance MUST continue to run for every pull request through its unfiltered trigger, but it MUST NOT be represented as one of the six ruleset contexts.
+
+#### Scenario: Pull request targets the exact integration branch
+
+- **GIVEN** the temporary integration ruleset is active
+- **WHEN** a pull request uses `codex/redesign-lifecycle-integration` as its exact base ref
+- **THEN** CI and Sandbox Tests MUST run through their `pull_request` triggers and produce all six required contexts used by `main`
+- **AND** the ruleset MUST prevent merge until every context succeeds
+
+#### Scenario: PR Governance observes an integration pull request
+
+- **WHEN** any pull request, including an integration-target pull request, is opened or updated
+- **THEN** PR Governance MUST run through its existing unfiltered `pull_request` trigger
+- **AND** the temporary ruleset MUST NOT substitute its context for `sandbox-tests` or any other live required context
+
+#### Scenario: Integration branch receives a push event
+
+- **WHEN** a commit reaches `codex/redesign-lifecycle-integration`
+- **THEN** neither CI nor Sandbox Tests MUST start from an integration-branch `push` trigger
+- **AND** pull-request validation MUST remain the branch's merge-gating surface
+
+#### Scenario: Setup creates temporary protection
+
+- **GIVEN** the process-only bootstrap pull request has merged to `main`
+- **WHEN** maintainers prepare the integration branch for milestone delivery
+- **THEN** they MUST first synchronize the integration ref to the exact post-bootstrap `main` tip and verify it is zero commits ahead and zero commits behind
+- **AND** only then MAY they create the ruleset requiring pull requests and the six live `protect-main` contexts defined by this requirement

--- a/openspec/changes/support-integration-branch-delivery/specs/project-memory/spec.md
+++ b/openspec/changes/support-integration-branch-delivery/specs/project-memory/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Umbrella changes MUST remain active across milestone delivery
+
+Quantex SHALL permit a large OpenSpec umbrella change to be delivered through multiple reviewed milestone pull requests without treating an intermediate merge as archive eligibility. Each milestone merge MUST report its own validation, PR, and merge closure while the umbrella change remains active until every contracted task is genuinely complete and the final delivery topology has closed.
+
+#### Scenario: Lifecycle milestone merges to integration
+
+- **GIVEN** `redesign-lifecycle-engine` is the active lifecycle umbrella change
+- **WHEN** one implementation milestone merges to `codex/redesign-lifecycle-integration`
+- **THEN** the milestone MUST report merge closure without reporting umbrella archive closure
+- **AND** the redesign task counter MUST change only for implementation tasks actually completed
+- **AND** both `redesign-lifecycle-engine` and `support-integration-branch-delivery` MUST remain active
+
+### Requirement: Lifecycle integration delivery MUST include setup, runtime, and teardown
+
+The delivery change SHALL own the complete temporary-branch lifecycle. Setup MUST include the process-only bootstrap on `main`, exact post-bootstrap synchronization, and ruleset creation. Runtime MUST include milestone pull requests and same-repository main synchronization. Teardown MUST include final promotion, integration-specific workflow and policy cleanup, ruleset and branch removal, current-spec synchronization, and archive closure.
+
+#### Scenario: Bootstrap prepares the integration path
+
+- **WHEN** the delivery process is set up
+- **THEN** exactly one process-only bootstrap pull request MAY enter `main` before final promotion
+- **AND** that pull request MUST NOT include lifecycle redesign implementation
+- **AND** integration protection MUST be created only after the branch matches the post-bootstrap `main` tip exactly
+
+#### Scenario: Integration operates between milestones
+
+- **WHEN** lifecycle milestones are delivered before final promotion
+- **THEN** they MUST enter the integration branch through pull requests
+- **AND** later `main` changes MUST enter integration only through the verified same-repository main-sync topology after protection is active
+- **AND** neither active OpenSpec change MAY be archived during this runtime phase
+
+#### Scenario: Final promotion becomes eligible
+
+- **GIVEN** `redesign-lifecycle-engine` began this delivery phase at `8/74`
+- **WHEN** maintainers propose final integration-to-`main` promotion
+- **THEN** the redesign change MUST report exactly `74/74` after its other 73 tasks complete on their existing terms and clarified task `11.6` has real post-promotion follow-up readiness
+- **AND** the task `11.6` clarification MUST preserve its number, checkbox, 74-task denominator, implementation scope, and completion credit while deferring actual current-spec synchronization and archive execution
+- **AND** integration MUST contain the latest `main` tip through a final verified main sync
+- **AND** all required redesign validation MUST pass and no lifecycle milestone pull request may remain open
+
+#### Scenario: Redesign task 11.6 is clarified before promotion
+
+- **WHEN** Phase 0/1 resolves the dependency between the `74/74` promotion gate and post-promotion archive closure
+- **THEN** it MAY clarify task `11.6` to require a prepared owner, command path, ordering, validation, and protected-branch delivery plan for the post-promotion follow-up
+- **AND** it MUST NOT renumber the task, add or remove a checkbox, change the denominator or implementation scope, mark readiness complete before its criteria are met, synchronize current specs, or archive either change before promotion
+
+### Requirement: Archive closure MUST occur after promotion and teardown
+
+Final promotion, product release, teardown, spec synchronization, and OpenSpec archive closure SHALL be reported as separate lifecycle moments. Neither active change MAY be archived before the exact integration-to-`main` promotion has merged, temporary workflow/policy support and repository protection have been removed, and accepted current-spec deltas have been synchronized.
+
+#### Scenario: Final promotion merges to main
+
+- **WHEN** the exact integration-to-`main` pull request merges
+- **THEN** maintainers MUST report promotion merge closure separately from release and archive closure
+- **AND** both OpenSpec changes MUST remain active while post-promotion teardown is pending
+
+#### Scenario: Post-promotion archive follow-up runs
+
+- **GIVEN** promotion is merged, integration-specific workflow and policy support is cleaned up, the temporary ruleset and branch are removed, and accepted deltas are synchronized into current specs
+- **WHEN** the agent-driven archive follow-up runs
+- **THEN** it MUST archive both `redesign-lifecycle-engine` and `support-integration-branch-delivery` through the repo-native protected-branch delivery path
+- **AND** it MUST validate and report the resulting OpenSpec state

--- a/openspec/changes/support-integration-branch-delivery/specs/release-governance/spec.md
+++ b/openspec/changes/support-integration-branch-delivery/specs/release-governance/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: Multi-commit pull requests MUST be limited to verified lifecycle integration topology
+
+PR Governance SHALL continue to require exactly one commit for ordinary pull requests. It MAY accept multiple commits only for either a same-repository pull request from `main` to the exact base `codex/redesign-lifecycle-integration` or a same-repository pull request from that exact integration head to `main`. Both multi-commit exceptional operations MUST be delivered with a merge commit so accepted ancestry is preserved. This change MUST NOT impose a merge method on ordinary single-commit milestone or product pull requests.
+
+#### Scenario: Ordinary milestone contains one commit
+
+- **WHEN** an ordinary milestone pull request contains exactly one commit
+- **THEN** it MUST remain eligible for the repository's existing allowed merge methods
+- **AND** this integration change MUST NOT require a merge commit
+
+#### Scenario: Ordinary pull request contains multiple commits
+
+- **WHEN** a pull request contains multiple commits and does not match either exact lifecycle integration topology
+- **THEN** PR Governance MUST reject it
+- **AND** branch similarity, a lifecycle label, or a process-only diff MUST NOT create an exception
+
+#### Scenario: Same-repository main sync contains multiple commits
+
+- **GIVEN** the base and head repositories are the same Quantex repository
+- **WHEN** a pull request has base ref `codex/redesign-lifecycle-integration`, head ref `main`, and multiple commits
+- **THEN** PR Governance MAY accept the commit-count exception
+- **AND** the pull request MUST pass all required contexts and merge with a merge commit
+
+#### Scenario: Exact final promotion contains multiple commits
+
+- **GIVEN** the base and head repositories are the same Quantex repository
+- **WHEN** a pull request has base ref `main`, head ref `codex/redesign-lifecycle-integration`, and multiple commits
+- **THEN** PR Governance MAY accept the commit-count exception
+- **AND** the pull request MUST pass all required contexts and merge with a merge commit
+
+#### Scenario: Lookalike topology attempts the exception
+
+- **WHEN** a multi-commit pull request originates from a fork, reverses the required refs, uses a lookalike integration name, or changes either exact base or head ref
+- **THEN** PR Governance MUST reject the commit-count exception
+
+#### Scenario: Exceptional merge topology is verified
+
+- **WHEN** a main-sync or final-promotion exception is merged
+- **THEN** the resulting protected-branch commit MUST have two parents corresponding to the refreshed base and head tips approved by the pull request
+- **AND** a squash or rebase result MUST be treated as failed delivery closure for that operation

--- a/openspec/changes/support-integration-branch-delivery/specs/release-workflow/spec.md
+++ b/openspec/changes/support-integration-branch-delivery/specs/release-workflow/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Temporary lifecycle integration MUST remain outside every release path
+
+The Release workflow and release policy SHALL preserve their positive `main`/`beta` release target allowlist while `codex/redesign-lifecycle-integration` exists. The integration branch MUST NOT trigger automatic release reconciliation, appear as a manual release target, receive a Release PR, or produce an npm tag or channel. This change MUST prove that boundary with regression tests and MUST leave production Release workflow, Release PR, policy, and resolver logic unchanged when the tests pass; only a concrete failing regression MAY justify the smallest production correction. Promotion to `main` MAY enter the normal `main` release flow only after the promotion merge exists on `main`.
+
+#### Scenario: Existing positive allowlist rejects integration before resolution
+
+- **GIVEN** focused regression tests exercise automatic, manual, and Release PR entry gates and prove release-target resolution and npm-channel selection remain downstream of those gates
+- **WHEN** the existing `main`/`beta` allowlist rejects `codex/redesign-lifecycle-integration` at every entry point
+- **THEN** the bootstrap MUST keep the production Release workflow and resolver surfaces unchanged
+
+#### Scenario: Regression exposes a release boundary gap
+
+- **WHEN** a focused regression proves that an existing production release path accepts `codex/redesign-lifecycle-integration`
+- **THEN** the bootstrap MAY change only the smallest production surface necessary to restore the positive `main`/`beta` allowlist
+- **AND** the regression MUST pass before delivery
+
+#### Scenario: Successful integration CI completes
+
+- **WHEN** CI succeeds for a pull request or commit associated with `codex/redesign-lifecycle-integration`
+- **THEN** the Release `workflow_run` path MUST NOT reconcile or publish that branch
+
+#### Scenario: Maintainer opens manual release dispatch
+
+- **WHEN** a maintainer selects a target for manual Release workflow recovery
+- **THEN** only `main` and `beta` MUST be accepted target branches
+- **AND** `codex/redesign-lifecycle-integration` MUST NOT be offered or accepted
+
+#### Scenario: Release PR resolution observes integration
+
+- **WHEN** release automation or Release PR validation receives `codex/redesign-lifecycle-integration` as a proposed target or base branch
+- **THEN** it MUST refuse to create, update, validate, or automerge a Release PR for that branch
+
+#### Scenario: Integration is blocked before npm channel derivation
+
+- **WHEN** automatic or manual Release workflow entry evaluates `codex/redesign-lifecycle-integration`
+- **THEN** the positive branch allowlist MUST reject it before release-target resolution runs
+- **AND** npm tag or publishing-channel derivation MUST NOT receive the integration branch
+- **AND** no release artifact may be published for that branch
+
+#### Scenario: Final promotion has merged to main
+
+- **GIVEN** the exact integration-to-`main` promotion has merged
+- **WHEN** normal successful `main` CI completes for the promoted commit
+- **THEN** existing `main` release classification MAY reconcile the product delta
+- **AND** the release MUST be attributed to `main`, not to the removed integration branch

--- a/openspec/changes/support-integration-branch-delivery/tasks.md
+++ b/openspec/changes/support-integration-branch-delivery/tasks.md
@@ -1,0 +1,43 @@
+## 1. Process-Only Bootstrap
+
+- [x] 1.1 Add focused workflow-classification tests proving CI and Sandbox Tests add exact base `codex/redesign-lifecycle-integration` only to `pull_request`, never to `push`, and produce live contexts `classify`, `lint`, all three platform `test` contexts, and `sandbox-tests`; also prove PR Governance retains its unfiltered all-PR trigger without being treated as a required ruleset context.
+- [x] 1.2 Update only the CI and Sandbox Tests `pull_request` base filters needed by the integration tests, keep both workflows' `push` filters on `main`/`beta`, and leave PR Governance without a base filter.
+- [x] 1.3 Add focused release regression tests proving the existing positive `main`/`beta` allowlist rejects integration for Release `workflow_run`, manual target selection, and Release PR targeting/validation before release-target resolution or npm tag/channel derivation can run.
+- [x] 1.4 Keep the production Release workflow, Release PR, policy, and resolver surfaces unchanged when the regression tests pass; only if a test exposes a concrete allowlist gap, make the smallest correction and prove it with that regression.
+- [x] 1.5 Add focused PR-policy tests for the ordinary single-commit rule, both exact same-repository multi-commit topology exceptions, and fork/ref/lookalike near misses; retain actual merge-commit delivery verification in runtime tasks 3.3 and 4.4.
+- [x] 1.6 Update PR Governance payload collection and merge-commit policy logic to satisfy the topology tests without granting any other multi-commit exception.
+- [ ] 1.7 Clarify only `redesign-lifecycle-engine` task `11.6` so it tracks readiness of the explicit post-promotion spec-sync/archive follow-up; preserve its number, checkbox, 74-task denominator, implementation scope, and completion credit, leave it unchecked during the clarification, and do not perform spec sync or archive before promotion.
+- [x] 1.8 Add the setup/runtime/teardown procedure to the canonical delivery runbook and route the central Quantex runtime skill to it without expanding thin agent bootstraps.
+- [x] 1.9 Run the focused workflow/policy tests, `bun run test`, `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run openspec:validate`, and `bun run memory:check` for the complete bootstrap diff.
+- [x] 1.10 Prepare and validate a process-only PR body, verify the diff contains no lifecycle redesign implementation and changes no redesign task number, checkbox count, denominator, implementation scope, or earned completion credit, and deliver the one allowed bootstrap pull request to `main`.
+- [ ] 1.11 Merge the bootstrap through the ordinary single-commit path only after the six live `main` contexts succeed, then record merge closure separately from release and archive closure.
+
+## 2. Integration Setup
+
+- [ ] 2.1 Before protection, synchronize `codex/redesign-lifecycle-integration` to the exact post-bootstrap `main` tip and verify the live remote comparison is zero commits ahead and zero commits behind.
+- [ ] 2.2 Create the temporary integration ruleset requiring pull requests and exact contexts `classify`, `lint`, `test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`, and `sandbox-tests`, and disallow direct updates after initialization.
+- [ ] 2.3 Verify from live repository state that an integration-target pull request receives all six contexts, PR Governance runs separately through its unfiltered trigger, integration push triggers are absent from CI and Sandbox Tests, and no release entry point accepts the branch.
+
+## 3. Milestone Runtime
+
+- [ ] 3.1 Deliver each `redesign-lifecycle-engine` milestone as an ordinary single-commit pull request to the protected integration branch and require all six contexts before merge; retain the existing allowed merge methods for these ordinary pull requests rather than imposing the exceptional merge-commit rule.
+- [ ] 3.2 After each milestone merge, update only redesign tasks actually completed, run the milestone's required validation, and report milestone closure while both OpenSpec changes remain active.
+- [ ] 3.3 Whenever `main` advances, use only a same-repository pull request with base `codex/redesign-lifecycle-integration` and head `main`, merge it with a merge commit after all checks pass, and verify the resulting two-parent topology.
+- [ ] 3.4 Confirm throughout runtime that integration produces no Release workflow run, Release PR, npm tag/channel, package publication, or archive eligibility.
+
+## 4. Final Promotion
+
+- [ ] 4.1 Complete the other 73 `redesign-lifecycle-engine` tasks on their existing terms and satisfy clarified task `11.6` post-promotion follow-up readiness so the unchanged 74-checkbox denominator reports exactly `74/74`; run its final test, build, binary, package, and release-artifact gates, but defer actual current-spec synchronization and archive execution to tasks 5.4 and 5.5.
+- [ ] 4.2 Perform a final verified same-repository main-sync merge, refresh both remote refs, prove the current `main` tip is an ancestor of integration, and confirm no lifecycle milestone pull request remains open.
+- [ ] 4.3 Review the complete integration-to-`main` comparison for only accepted redesign work, validate the PR body, and open the exact same-repository final-promotion pull request.
+- [ ] 4.4 After every required `main` context succeeds, merge final promotion with a merge commit and verify its two parents are the approved refreshed `main` and integration tips.
+- [ ] 4.5 Let normal post-merge `main` release automation classify the promoted product delta and report promotion, release, and still-pending archive closure separately.
+
+## 5. Post-Promotion Teardown
+
+- [ ] 5.1 Add or update focused steady-state tests, then prepare a process-only cleanup that removes the integration pull-request target from CI and Sandbox Tests, temporary multi-commit policy exceptions, and temporary runtime/runbook instructions while retaining release rejection for unknown branches.
+- [ ] 5.2 Run the focused tests, full test suite, lint, format check, typecheck, OpenSpec validation, and memory check; validate the cleanup PR body and merge the cleanup to `main` without treating it as a release.
+- [ ] 5.3 Remove the temporary integration ruleset, delete `codex/redesign-lifecycle-integration`, and verify both are absent from live repository state after recovery use is no longer required.
+- [ ] 5.4 Synchronize the accepted final deltas from `redesign-lifecycle-engine` and `support-integration-branch-delivery` into current specs, retaining only durable conditional and closure rules.
+- [ ] 5.5 Run `bun run openspec:validate` and `bun run memory:check`, then use the repo-native archive-closure flow and validated PR body to archive both active changes through the normal protected-branch PR path.
+- [ ] 5.6 After the archive follow-up merges, verify both changes are under `openspec/changes/archive/`, no active task remains, the working branch is clean, and promotion, release, teardown, and archive closure states are all reported explicitly.

--- a/scripts/pr-merge-commit-policy.ts
+++ b/scripts/pr-merge-commit-policy.ts
@@ -8,17 +8,24 @@ export interface PullRequestCommitMetadata {
 }
 
 export interface PullRequestMergeCommitPolicyInput {
+  baseBranch?: string
   commits: PullRequestCommitMetadata[]
+  headBranch?: string
+  sameRepository?: boolean
   validatedReleasePr?: boolean
 }
+
+type PullRequestTopology = 'final-promotion' | 'main-sync' | 'ordinary'
 
 const prohibitedTrailerPattern = /^co-authored-by:\s*/i
 const riskyAuthorPatterns = [/cursoragent@cursor\.com/i, /^cursor agent$/i, /\[bot\]@users\.noreply\.github\.com$/i]
 const trustedReleaseBotEmailPattern = /^279595574\+quantex-cli-release-bot\[bot\]@users\.noreply\.github\.com$/i
 const trustedReleaseBotNamePattern = /^quantex-cli-release-bot\[bot\]$/i
+const lifecycleIntegrationBranch = 'codex/redesign-lifecycle-integration'
 
 export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeCommitPolicyInput): string[] {
   const commits = input.commits
+  const topology = classifyPullRequestTopology(input)
   const validatedReleasePr = input.validatedReleasePr === true
   const issues: string[] = []
 
@@ -43,7 +50,7 @@ export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeComm
     }
   }
 
-  if (commits.length > 1) {
+  if (commits.length > 1 && topology === 'ordinary') {
     issues.push(
       [
         `Pull request contains ${commits.length} commits; GitHub squash merge can synthesize Co-authored-by trailers from multi-commit contributor metadata.`,
@@ -53,6 +60,7 @@ export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeComm
   }
 
   for (const commit of commits) {
+    if (topology === 'main-sync') continue
     if (validatedReleasePr && isTrustedReleaseBotAuthor(commit)) continue
 
     const authorValues = [commit.authorEmail, commit.authorName].filter(Boolean) as string[]
@@ -72,8 +80,12 @@ export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeComm
 
 if (import.meta.main) {
   const commits = parseCommits(process.argv.slice(2), process.env.PR_COMMITS_JSON)
+  const baseBranch = process.env.PR_BASE_BRANCH
+  const headBranch = process.env.PR_HEAD_BRANCH
+  const sameRepository = parseBooleanFlag(process.env.PR_SAME_REPOSITORY)
   const validatedReleasePr = parseBooleanFlag(process.env.PR_IS_VALIDATED_RELEASE_PR)
-  const issues = validatePullRequestMergeCommitPolicy({ commits, validatedReleasePr })
+  const policyInput = { baseBranch, commits, headBranch, sameRepository, validatedReleasePr }
+  const issues = validatePullRequestMergeCommitPolicy(policyInput)
 
   if (issues.length > 0) {
     console.error('PR merge commit policy check failed:\n')
@@ -81,7 +93,21 @@ if (import.meta.main) {
     process.exit(1)
   }
 
-  console.log('PR merge commit policy check passed.')
+  console.log(`PR merge commit policy check passed (${classifyPullRequestTopology(policyInput)} topology).`)
+}
+
+function classifyPullRequestTopology(input: PullRequestMergeCommitPolicyInput): PullRequestTopology {
+  if (input.sameRepository !== true) return 'ordinary'
+
+  if (input.baseBranch === lifecycleIntegrationBranch && input.headBranch === 'main') {
+    return 'main-sync'
+  }
+
+  if (input.baseBranch === 'main' && input.headBranch === lifecycleIntegrationBranch) {
+    return 'final-promotion'
+  }
+
+  return 'ordinary'
 }
 
 function parseCommits(args: string[], commitsJsonEnv: string | undefined): PullRequestCommitMetadata[] {

--- a/skills/quantex-agent-runtime/SKILL.md
+++ b/skills/quantex-agent-runtime/SKILL.md
@@ -74,6 +74,8 @@ For implementation:
 3. Mark task checkboxes only after the corresponding work is done.
 4. Update specs, ADRs, runbooks, or session docs when implementation changes durable knowledge.
 
+For a long-lived umbrella change using the temporary lifecycle integration topology, follow `docs/runbooks/lifecycle-integration-delivery.md`. A milestone merge is not archive eligibility: update genuine task progress and report merge closure, but keep the umbrella change active until its completion, promotion, spec-sync, and archive conditions are satisfied.
+
 ## Validation Routing
 
 Always run these after modifying files:
@@ -125,7 +127,7 @@ Use explicit closure labels:
 
 Archive closure is agent-driven.
 
-After an OpenSpec-backed implementation PR merges:
+After an OpenSpec-backed implementation PR merges and the change is genuinely complete and archive-eligible:
 
 1. Resume from a clean branch based on the protected target branch.
 2. Sync accepted spec deltas into `openspec/specs/` when they are not already present.
@@ -135,6 +137,8 @@ After an OpenSpec-backed implementation PR merges:
 6. Commit, push, and open the archive PR when protected branches prevent direct archive closure.
 
 Do not rely on repository automation to create archive PRs.
+
+If an implementation PR is only one milestone of an active umbrella change, do not start archive closure. Report that archive closure remains pending by design and continue from the protected integration target described in the lifecycle integration runbook.
 
 ## Script Boundary
 

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 
 const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8')
@@ -6,6 +6,10 @@ const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml',
 const prTemplate = readFileSync('.github/pull_request_template.md', 'utf8')
 const prBodyPolicyScript = readFileSync('scripts/pr-body-policy.ts', 'utf8')
 const prMergeCommitPolicyScript = readFileSync('scripts/pr-merge-commit-policy.ts', 'utf8')
+const collaborationGuide = readFileSync('docs/github-collaboration.md', 'utf8')
+const openspecReadme = readFileSync('openspec/README.md', 'utf8')
+const runtimeSkill = readFileSync('skills/quantex-agent-runtime/SKILL.md', 'utf8')
+const integrationRunbookPath = 'docs/runbooks/lifecycle-integration-delivery.md'
 
 describe('pr governance release intent', () => {
   it('requires a release intent section in PR bodies', () => {
@@ -53,6 +57,29 @@ describe('pr governance release intent', () => {
   it('keeps PR template compatible with agent-driven OpenSpec archive closure', () => {
     expect(prTemplate).toContain('## Closure Check')
     expect(prTemplate).toContain('queued for agent-driven archive closure')
+  })
+
+  it('documents lifecycle integration setup, runtime, promotion, and teardown', () => {
+    expect(existsSync(integrationRunbookPath)).toBe(true)
+    if (!existsSync(integrationRunbookPath)) return
+
+    const runbook = readFileSync(integrationRunbookPath, 'utf8')
+
+    expect(runbook).toContain('codex/redesign-lifecycle-integration')
+    expect(runbook).toContain('main -> integration')
+    expect(runbook).toContain('integration -> main')
+    expect(runbook).toContain('74/74')
+    expect(runbook).toContain('sandbox-tests')
+    expect(runbook).toContain('must not publish')
+    expect(runbook).toContain('Post-promotion teardown')
+  })
+
+  it('keeps umbrella changes active across milestone merges', () => {
+    expect(runtimeSkill).toContain('docs/runbooks/lifecycle-integration-delivery.md')
+    expect(runtimeSkill).toContain('milestone merge is not archive eligibility')
+    expect(openspecReadme).toContain('milestone merge is not archive eligibility')
+    expect(collaborationGuide).toContain('Lifecycle Integration Delivery')
+    expect(prTemplate).toContain('active across milestone merges by design')
   })
 
   it('runs commit trailer governance from CI through a local repository script', () => {

--- a/test/pr-merge-commit-policy.test.ts
+++ b/test/pr-merge-commit-policy.test.ts
@@ -1,5 +1,51 @@
+import { readFileSync } from 'node:fs'
 import { describe, expect, it } from 'vitest'
 import { validatePullRequestMergeCommitPolicy } from '../scripts/pr-merge-commit-policy'
+
+const integrationBranch = 'codex/redesign-lifecycle-integration'
+const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml', 'utf8')
+
+function extractNamedStep(workflow: string, stepName: string): string {
+  const marker = `      - name: ${stepName}\n`
+  const startIndex = workflow.indexOf(marker)
+  if (startIndex === -1) throw new Error(`Missing workflow step: ${stepName}`)
+
+  const remainingWorkflow = workflow.slice(startIndex + marker.length)
+  const nextStepIndex = remainingWorkflow.indexOf('\n      - ')
+  const endIndex = nextStepIndex === -1 ? workflow.length : startIndex + marker.length + nextStepIndex
+
+  return workflow.slice(startIndex, endIndex)
+}
+
+const mainSyncCommits = [
+  {
+    authorEmail: 'cursoragent@cursor.com',
+    authorName: 'Cursor Agent',
+    message: 'fix(ci): preserve accepted main history',
+    sha: 'a1bf9b84bb9d44cd7dfc3eb8c04d717d94a2403a',
+  },
+  {
+    authorEmail: '279595574+quantex-cli-release-bot[bot]@users.noreply.github.com',
+    authorName: 'quantex-cli-release-bot[bot]',
+    message: 'chore: release 0.29.0',
+    sha: 'faccfe099ca1de911087caf6904263ae22283e22',
+  },
+]
+
+const cleanPromotionCommits = [
+  {
+    authorEmail: '540628938@qq.com',
+    authorName: 'drswith',
+    message: 'refactor(core): establish lifecycle engine foundation',
+    sha: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  },
+  {
+    authorEmail: 'drswith@outlook.com',
+    authorName: 'Drswith',
+    message: 'refactor(providers): migrate provider catalog',
+    sha: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  },
+]
 
 describe('pr merge commit policy', () => {
   it('rejects empty commit metadata so the policy cannot fail open', () => {
@@ -44,6 +90,57 @@ describe('pr merge commit policy', () => {
     })
 
     expect(issues).toContainEqual(expect.stringContaining('Pull request contains 2 commits'))
+    expect(issues).toContainEqual(expect.stringContaining('a1bf9b84bb9d'))
+  })
+
+  it('accepts multiple commits only for an exact same-repository main sync', () => {
+    expect(
+      validatePullRequestMergeCommitPolicy({
+        baseBranch: integrationBranch,
+        commits: mainSyncCommits,
+        headBranch: 'main',
+        sameRepository: true,
+      }),
+    ).toEqual([])
+  })
+
+  it('accepts multiple clean commits for the exact same-repository final promotion', () => {
+    expect(
+      validatePullRequestMergeCommitPolicy({
+        baseBranch: 'main',
+        commits: cleanPromotionCommits,
+        headBranch: integrationBranch,
+        sameRepository: true,
+      }),
+    ).toEqual([])
+  })
+
+  it.each([
+    ['fork main sync', integrationBranch, 'main', false],
+    ['fork final promotion', 'main', integrationBranch, false],
+    ['lookalike main sync', `${integrationBranch}-staging`, 'main', true],
+    ['other protected source', integrationBranch, 'beta', true],
+    ['lookalike final promotion', 'main', `${integrationBranch}-staging`, true],
+  ])('rejects multiple commits for %s', (_, baseBranch, headBranch, sameRepository) => {
+    const issues = validatePullRequestMergeCommitPolicy({
+      baseBranch,
+      commits: cleanPromotionCommits,
+      headBranch,
+      sameRepository,
+    })
+
+    expect(issues).toContainEqual(expect.stringContaining('Pull request contains 2 commits'))
+  })
+
+  it('retains risky-author validation for final promotion history', () => {
+    const issues = validatePullRequestMergeCommitPolicy({
+      baseBranch: 'main',
+      commits: mainSyncCommits,
+      headBranch: integrationBranch,
+      sameRepository: true,
+    })
+
+    expect(issues).not.toContainEqual(expect.stringContaining('Pull request contains 2 commits'))
     expect(issues).toContainEqual(expect.stringContaining('a1bf9b84bb9d'))
   })
 
@@ -108,5 +205,36 @@ describe('pr merge commit policy', () => {
     })
 
     expect(issues).toContainEqual(expect.stringContaining('Co-authored-by:'))
+  })
+
+  it('rejects direct co-author trailers even for an exact main sync', () => {
+    const issues = validatePullRequestMergeCommitPolicy({
+      baseBranch: integrationBranch,
+      commits: [
+        {
+          authorEmail: '540628938@qq.com',
+          authorName: 'drswith',
+          message: ['chore(integration): sync main', '', 'Co-authored-by: Cursor Agent <cursoragent@cursor.com>'].join(
+            '\n',
+          ),
+          sha: 'cccccccccccccccccccccccccccccccccccccccc',
+        },
+        cleanPromotionCommits[0]!,
+      ],
+      headBranch: 'main',
+      sameRepository: true,
+    })
+
+    expect(issues).toContainEqual(expect.stringContaining('Co-authored-by:'))
+  })
+
+  it('passes immutable pull-request topology fields to the workflow policy step', () => {
+    const policyStep = extractNamedStep(prGovernanceWorkflow, 'Validate PR merge commit policy')
+
+    expect(policyStep).toContain('PR_BASE_BRANCH: ${{ github.event.pull_request.base.ref }}')
+    expect(policyStep).toContain('PR_HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}')
+    expect(policyStep).toContain(
+      'PR_SAME_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name == github.repository }}',
+    )
   })
 })

--- a/test/workflow-classification.test.ts
+++ b/test/workflow-classification.test.ts
@@ -3,7 +3,49 @@ import { describe, expect, it } from 'vitest'
 
 const ciWorkflow = readFileSync('.github/workflows/ci.yml', 'utf8')
 const prGovernanceWorkflow = readFileSync('.github/workflows/pr-governance.yml', 'utf8')
+const releaseAutomergeWorkflow = readFileSync('.github/workflows/release-pr-automerge.yml', 'utf8')
+const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf8')
 const sandboxWorkflow = readFileSync('.github/workflows/sandbox-tests.yml', 'utf8')
+const integrationBranch = 'codex/redesign-lifecycle-integration'
+
+function extractEventBlock(workflow: string, eventName: string): string {
+  const lines = workflow.split(/\r?\n/)
+  const startIndex = lines.findIndex(line => line === `  ${eventName}:`)
+
+  if (startIndex === -1) throw new Error(`Missing ${eventName} event block.`)
+
+  const nextBoundaryOffset = lines.slice(startIndex + 1).findIndex(line => /^(?:  [\w-]+|[\w-]+):/.test(line))
+  const endIndex = nextBoundaryOffset === -1 ? lines.length : startIndex + 1 + nextBoundaryOffset
+
+  return lines.slice(startIndex, endIndex).join('\n')
+}
+
+function extractYamlList(block: string, key: string): string[] {
+  const lines = block.split(/\r?\n/)
+  const keyIndex = lines.findIndex(line => line.trim() === `${key}:`)
+
+  if (keyIndex === -1) throw new Error(`Missing ${key} list.`)
+
+  const keyIndent = lines[keyIndex]?.search(/\S/) ?? 0
+  const values: string[] = []
+
+  for (const line of lines.slice(keyIndex + 1)) {
+    if (line.trim() === '') continue
+
+    const indent = line.search(/\S/)
+    if (indent <= keyIndent) break
+    if (indent === keyIndent + 2 && line.trim().startsWith('- ')) values.push(line.trim().slice(2))
+  }
+
+  return values
+}
+
+function extractTopLevelJobIds(workflow: string): string[] {
+  const jobsBlock = workflow.split('\njobs:\n')[1]
+  if (!jobsBlock) throw new Error('Missing jobs block.')
+
+  return [...jobsBlock.matchAll(/^  ([\w-]+):\n/gm)].map(match => match[1] as string)
+}
 
 describe('workflow classification integration', () => {
   it('routes CI scope classification through the shared taxonomy script', () => {
@@ -25,5 +67,81 @@ describe('workflow classification integration', () => {
       'QTX_ISOLATION_SCENARIOS=managed,deno-managed,uv-managed,adopt-preinstalled,ambiguous-multi-method,self-binary',
     )
     expect(sandboxWorkflow).not.toContain("'src/self/**'")
+  })
+
+  it.each([
+    ['PR Governance', prGovernanceWorkflow, 'pull_request'],
+    ['Release', releaseWorkflow, 'workflow_dispatch'],
+  ])('isolates the terminal %s %s event from following top-level keys', (_, workflow, eventName) => {
+    expect(extractEventBlock(workflow, eventName)).not.toMatch(/^(?:permissions|jobs):/m)
+  })
+
+  it('targets the integration branch only for CI pull requests', () => {
+    expect(extractYamlList(extractEventBlock(ciWorkflow, 'pull_request'), 'branches')).toEqual([
+      'main',
+      'beta',
+      integrationBranch,
+    ])
+    expect(extractYamlList(extractEventBlock(ciWorkflow, 'push'), 'branches')).toEqual(['main', 'beta'])
+  })
+
+  it('targets the integration branch only for Sandbox Tests pull requests', () => {
+    expect(extractYamlList(extractEventBlock(sandboxWorkflow, 'pull_request'), 'branches')).toEqual([
+      'main',
+      'beta',
+      integrationBranch,
+    ])
+    expect(extractYamlList(extractEventBlock(sandboxWorkflow, 'push'), 'branches')).toEqual(['main', 'beta'])
+  })
+
+  it('preserves the six live integration merge-gate contexts', () => {
+    const ciJobIds = extractTopLevelJobIds(ciWorkflow)
+    const sandboxJobIds = extractTopLevelJobIds(sandboxWorkflow)
+    const governanceJobIds = extractTopLevelJobIds(prGovernanceWorkflow)
+    const platformList = ciWorkflow.match(/^\s+os: \[(?<platforms>[^\]]+)\]$/m)?.groups?.platforms
+
+    if (!platformList) throw new Error('Missing CI test platform matrix.')
+
+    const requiredContexts = [
+      ...ciJobIds.filter(jobId => jobId !== 'test'),
+      ...platformList.split(',').map(platform => `test (${platform.trim()})`),
+      ...sandboxJobIds.filter(jobId => jobId === 'sandbox-tests'),
+    ]
+
+    expect(requiredContexts).toEqual([
+      'classify',
+      'lint',
+      'test (ubuntu-latest)',
+      'test (windows-latest)',
+      'test (macos-latest)',
+      'sandbox-tests',
+    ])
+    expect(governanceJobIds).toContain('validate-body')
+    expect(requiredContexts).not.toContain('validate-body')
+  })
+
+  it('keeps PR Governance on its unfiltered all-pull-request trigger', () => {
+    const pullRequestBlock = extractEventBlock(prGovernanceWorkflow, 'pull_request')
+
+    expect(pullRequestBlock).not.toMatch(/^\s+branches:/m)
+    expect(extractYamlList(pullRequestBlock, 'types')).toEqual(['opened', 'edited', 'reopened', 'synchronize'])
+  })
+
+  it('blocks integration at release event gates before resolver and npm channel selection', () => {
+    const workflowRunBlock = extractEventBlock(releaseWorkflow, 'workflow_run')
+    const workflowDispatchBlock = extractEventBlock(releaseWorkflow, 'workflow_dispatch')
+    const releasePrBlock = extractEventBlock(releaseAutomergeWorkflow, 'pull_request_target')
+
+    expect(extractYamlList(workflowRunBlock, 'branches')).toEqual(['main', 'beta'])
+    expect(extractYamlList(workflowDispatchBlock, 'options')).toEqual(['main', 'beta'])
+    expect(extractYamlList(releasePrBlock, 'branches')).toEqual(['main', 'beta'])
+    expect(workflowRunBlock).not.toContain(integrationBranch)
+    expect(workflowDispatchBlock).not.toContain(integrationBranch)
+    expect(releasePrBlock).not.toContain(integrationBranch)
+    expect(releaseWorkflow).not.toContain(integrationBranch)
+    expect(releaseAutomergeWorkflow).not.toContain(integrationBranch)
+    expect(releaseWorkflow).toContain('- name: Resolve release target')
+    expect(releaseWorkflow).toContain('echo "npm_tag=beta"')
+    expect(releaseWorkflow).toContain('echo "npm_tag=latest"')
   })
 })


### PR DESCRIPTION
## Summary

Enable a temporary, protected lifecycle-redesign integration path without making it a release branch.

- run the existing CI and Sandbox Tests definitions for PRs whose base is exactly `codex/redesign-lifecycle-integration`
- keep integration out of CI/Sandbox push triggers and every Release `main`/`beta` allowlist
- preserve ordinary single-commit governance while allowing only the exact same-repository main-sync and final-promotion multi-commit topologies
- document setup, milestone delivery, final promotion, teardown, and umbrella OpenSpec archive timing

This process-only bootstrap contains no lifecycle-engine implementation. The redesign remains isolated from `main` until the final integration promotion.

## Linked Artifacts

- Issue: not applicable
- ADR: not applicable
- OpenSpec: `support-integration-branch-delivery`
- Discussion: not applicable

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (61 files, 710 tests)
- [x] `bun run openspec:validate` (15 passed, 0 failed)
- [ ] Not run, explained below

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [ ] Not needed
- [x] `docs/runbooks/lifecycle-integration-delivery.md`
- [x] `openspec/changes/support-integration-branch-delivery/`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is active across milestone merges by design; archive closure remains post-promotion.
- [x] Release is not applicable and integration remains excluded from release entry points.

## Notes

Reviewer focus:

- CI and Sandbox add integration only under `pull_request.branches`; their `push.branches` remain `main`/`beta`.
- `.github/workflows/release.yml`, `.github/workflows/release-pr-automerge.yml`, release policy, and resolver production code are unchanged.
- The live integration ruleset will be created only after this PR merges and the still-unprotected integration ref is fast-forwarded to the resulting `main` tip.
- OpenSpec task 1.7 is owned by the Phase 0/1 PR: it will clarify `redesign-lifecycle-engine` task 11.6 after this bootstrap reaches integration and before any subsequent milestone starts.
- `redesign-lifecycle-engine` task numbering, checkbox count, implementation scope, and earned progress are unchanged by this PR.
