### PR TITLE
chore(tooling): tolerate ignored staged fixtures

### DIFF
--- a/docs/superpowers/plans/2026-07-11-lint-staged-ignored-fixtures.md
+++ b/docs/superpowers/plans/2026-07-11-lint-staged-ignored-fixtures.md
@@ -1,0 +1,63 @@
+# Lint-Staged Ignored Fixture Compatibility Plan
+
+> **For agentic workers:** Use `superpowers:test-driven-development` for the configuration regression and `superpowers:verification-before-completion` before commit, push, or PR claims.
+
+**Goal:** Allow a milestone commit containing only formatter-ignored JSON fixtures in its JSON lint-staged group to pass pre-commit without formatting those fixtures or weakening checks for supported files.
+
+**Architecture:** Keep `.oxfmtrc.json` ignore boundaries unchanged. Add oxfmt's pinned `--no-error-on-unmatched-pattern` option to both lint-staged formatter commands so an all-ignored matched set is a successful no-op; supported staged source still runs through oxfmt and TypeScript/JavaScript still runs through oxlint afterward.
+
+**Delivery:** One process/tooling commit and one PR from `codex/fix-lint-staged-ignored-fixtures` to protected `codex/redesign-lifecycle-integration`. This prerequisite contains no lifecycle engine implementation, does not target `main`, and cannot trigger Release.
+
+## Task 1: Extend the active delivery contract
+
+**Modify:**
+
+- `openspec/changes/support-integration-branch-delivery/proposal.md`
+- `openspec/changes/support-integration-branch-delivery/design.md`
+- `openspec/changes/support-integration-branch-delivery/specs/code-quality-tooling/spec.md`
+- `openspec/changes/support-integration-branch-delivery/tasks.md`
+
+Record the observed pre-commit blocker and the exact no-op behavior for an all-ignored matched set. Preserve `.oxfmtrc.json` ignore patterns and require real formatter/linter failures on supported files to remain blocking. Add one implementation task without changing the redesign change's 74-task denominator.
+
+Also record already verified live setup facts: bootstrap PR #442 merged after all required checks, integration was synchronized to the post-bootstrap main SHA with `0 0` drift, and ruleset `protect-lifecycle-integration` is active.
+
+## Task 2: Add the failing configuration regression
+
+**Create:** `test/lint-staged-config.test.ts`
+
+Assert that:
+
+- `test/fixtures` remains ignored by oxfmt;
+- both lint-staged oxfmt commands use `--no-error-on-unmatched-pattern`;
+- the TypeScript/JavaScript task still runs `oxlint --fix` after oxfmt;
+- the JSON/config task does not add a linter or bypass formatter-supported files.
+
+Run the focused test before changing `package.json`; it must fail because both commands currently omit the option.
+
+## Task 3: Make the minimal lint-staged change
+
+**Modify:** `package.json`
+
+Change both formatter commands from `oxfmt --write` to:
+
+```text
+oxfmt --write --no-error-on-unmatched-pattern
+```
+
+Do not change `.oxfmtrc.json`, formatter version, lint-staged globs, hooks, or CI commands. Run the focused test and a direct ignored-only oxfmt smoke using `.release-please-manifest.json`.
+
+## Task 4: Validate and deliver
+
+Run:
+
+```bash
+bun run test -- test/lint-staged-config.test.ts
+bun run lint
+bun run format:check
+bun run typecheck
+bun run test
+bun run openspec:validate
+bun run memory:check
+```
+
+Stage the complete prerequisite diff and create one `chore(tooling)` commit through the normal pre-commit hook. Validate the PR body, push, open a PR to exact integration, wait for the six required contexts plus PR Governance and review, and merge with an ordinary allowed method. Keep both umbrella changes active and report release/archive closure as pending.

--- a/openspec/changes/support-integration-branch-delivery/design.md
+++ b/openspec/changes/support-integration-branch-delivery/design.md
@@ -14,6 +14,7 @@ Stakeholders are maintainers delivering lifecycle milestones, reviewers protecti
 
 - Aggregate lifecycle redesign milestones on a temporary protected branch without making that branch a release line.
 - Apply the same six live `protect-main` required contexts to integration and `main`, while keeping PR Governance as a separate all-PR workflow.
+- Preserve deliberate formatter-ignore boundaries for golden fixtures without letting an all-ignored lint-staged match block a milestone commit.
 - Preserve the repository's single-commit default and allow multi-commit history only for two exact, same-repository synchronization/promotion topologies.
 - Make setup, steady-state operation, final promotion, teardown, spec synchronization, and archive closure one explicit lifecycle.
 - Keep the redesign umbrella change independent and require genuine `74/74` completion before final promotion.
@@ -24,6 +25,7 @@ Stakeholders are maintainers delivering lifecycle milestones, reviewers protecti
 - Publishing from integration, generating integration Release PRs, or deriving an npm tag/channel from integration.
 - Merging any lifecycle redesign implementation into `main` through the bootstrap pull request.
 - Replacing the existing six contexts, weakening `main` protection, or adding integration `push` triggers to CI or Sandbox Tests.
+- Formatting golden fixtures that are deliberately excluded by `.oxfmtrc.json`, skipping hooks, or suppressing formatter/linter failures for supported staged files.
 - Renumbering `redesign-lifecycle-engine` tasks, changing its checkbox count or 74-task denominator, expanding its implementation scope, or awarding completion credit before the clarified criteria are met. Only task `11.6` wording may be clarified to separate post-promotion follow-up readiness from later execution.
 
 ## Decisions
@@ -67,7 +69,15 @@ PR Governance already uses an unfiltered `pull_request` trigger and continues to
 
 A separate integration workflow was rejected because duplicated job names and logic would drift from `main`. Adding integration to either workflow's `push` filter was rejected because it provides no additional merge gate and could be mistaken for a release-adjacent signal.
 
-### 4. Identify the only two multi-commit exceptions from immutable PR topology
+### 4. Treat an all-ignored lint-staged formatter match as a successful no-op
+
+Lifecycle compatibility baselines include golden JSON under `test/fixtures`. The formatter configuration deliberately ignores that directory so formatting cannot silently rewrite hard fixture bytes, while the broad lint-staged JSON glob still selects those paths before oxfmt applies its own ignore rules. Pinned oxfmt exits non-zero when every path passed to one invocation is ignored, which made a valid fixture-only JSON group abort the Phase 0/1 commit even though repository-wide format validation was green.
+
+Both lint-staged oxfmt commands use the pinned `--no-error-on-unmatched-pattern` option. This preserves the existing ignore configuration: an all-ignored matched set formats zero files and succeeds, while any supported staged JavaScript, TypeScript, JSON, or config file still runs through oxfmt and JavaScript/TypeScript still runs through `oxlint --fix`. The option does not bypass the hook or convert real formatter/linter failures on supported files into success.
+
+Removing `test/fixtures` from the formatter ignore list was rejected because hard fixtures should not be mechanically rewritten. Narrowing lint-staged globs around one current fixture path was rejected because future ignored formatter paths could reproduce the same failure. Skipping the hook was rejected because the repository contract requires local pre-commit enforcement.
+
+### 5. Identify the only two multi-commit exceptions from immutable PR topology
 
 Ordinary pull requests continue to contain exactly one commit when evaluated by PR Governance. A multiple-commit pull request is permitted only when all repository identity and ref predicates match one of these shapes:
 
@@ -84,7 +94,7 @@ Before a recurring main-sync merge, the operator refreshes both remote refs and 
 
 Squashing these two operations was rejected because it would destroy ancestry and make later synchronization ambiguous. Rebasing was rejected because it would rewrite already reviewed milestone commits. Branch-name-only detection was rejected because a fork could imitate the ref name.
 
-### 5. Gate final promotion on redesign completion, not milestone count
+### 6. Gate final promotion on redesign completion, not milestone count
 
 Milestone merges into integration close only that milestone's PR and validation state. They do not make either OpenSpec change archive-eligible. `redesign-lifecycle-engine` stays active while its counter advances from `8/74`; this delivery change stays active throughout the branch lifecycle.
 
@@ -104,7 +114,7 @@ The exact integration-to-`main` pull request then uses a merge commit and the no
 
 Archiving at `74/74` before promotion was rejected because implementation/readiness completion is not merge closure. Archiving on a milestone merge was rejected because the umbrella contract spans all milestones.
 
-### 6. Treat teardown and archive closure as post-promotion work
+### 7. Treat teardown and archive closure as post-promotion work
 
 The final promotion is followed by an explicit teardown:
 
@@ -124,6 +134,7 @@ Leaving dormant integration triggers and policy exceptions in place was rejected
 - [A broad multi-commit exemption weakens PR governance] -> Match repository identity plus both exact refs, test near misses, and remove the exemption during teardown.
 - [Integration accidentally becomes releasable] -> Keep a positive `main`/`beta` release allowlist at every entry point and add negative tests proving workflow, manual, and Release PR gates stop integration before resolver and npm-channel paths.
 - [The initial ruleset protects stale workflow content] -> Create protection only after the post-bootstrap exact synchronization is verified `0/0`.
+- [Golden fixtures make pre-commit fail despite being deliberately ignored] -> Keep ignore boundaries intact and let oxfmt's all-ignored matched set succeed without suppressing checks on supported staged files.
 - [Partial redesign reaches `main`] -> Allow only process/bootstrap changes before the `74/74` gate and review the complete final comparison.
 - [Task `11.6` creates a promotion/archive dependency cycle] -> Clarify only its readiness semantics without renumbering, changing the denominator or scope, awarding early credit, or executing post-promotion work before promotion.
 - [Two active changes are archived too early] -> Model milestone merge, final promotion, release, teardown, spec sync, and archive as distinct closure states.
@@ -141,9 +152,10 @@ Leaving dormant integration triggers and policy exceptions in place was rejected
 
 ### Runtime
 
-1. Deliver lifecycle milestones as ordinary single-commit pull requests to integration.
-2. When `main` advances, open the exact same-repository `main -> integration` pull request, pass all six contexts, and merge it with a merge commit.
-3. Continue reporting milestone closure separately while both OpenSpec changes remain active.
+1. Verify lint-staged can accept deliberately formatter-ignored compatibility fixtures without formatting them or bypassing supported-file checks.
+2. Deliver lifecycle milestones as ordinary single-commit pull requests to integration.
+3. When `main` advances, open the exact same-repository `main -> integration` pull request, pass all six contexts, and merge it with a merge commit.
+4. Continue reporting milestone closure separately while both OpenSpec changes remain active.
 
 ### Final promotion and teardown
 

--- a/openspec/changes/support-integration-branch-delivery/proposal.md
+++ b/openspec/changes/support-integration-branch-delivery/proposal.md
@@ -9,6 +9,7 @@ This is a durable delivery-process change, so it requires an independent OpenSpe
 - Establish `codex/redesign-lifecycle-integration` as a temporary, protected aggregation branch initialized from the exact current `origin/main` commit and accepting changes only through pull requests after initialization.
 - Permit one process-only bootstrap pull request to `main` so the existing `main` checks can validate the new CI, governance, release exclusion, runbook, and runtime rules before lifecycle implementation uses the integration branch. The bootstrap pull request MUST NOT contain lifecycle redesign implementation.
 - Give pull requests whose base is exactly the integration branch the six live `protect-main` required contexts: `classify`, `lint`, `test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`, and `sandbox-tests`. CI and Sandbox Tests MUST add the integration ref only to their `pull_request` base filters, never to their `push` filters. PR Governance continues to run for every pull request without a base filter, but it is not one of the six ruleset contexts.
+- Keep formatter-ignored compatibility fixtures usable in milestone commits: lint-staged formatter commands MUST treat a matched set containing no formatter-supported files as a successful no-op without removing ignore boundaries or weakening formatting and linting for supported staged sources.
 - Preserve single-commit pull requests by default while permitting multiple commits only for the verified same-repository `main` to integration synchronization topology and the exact integration to `main` final-promotion topology; both exceptions require merge commits.
 - Prove with regression tests that the existing positive `main`/`beta` release allowlist excludes integration from Release `workflow_run`, manual release targets, Release PR targets, and npm tag or channel derivation. Production release routing changes only if those tests expose a concrete gap.
 - Permit one narrow semantic clarification to `redesign-lifecycle-engine` task `11.6`: keep its number, checkbox, 74-task denominator, implementation scope, and completion credit unchanged while defining the task as readiness for the post-promotion spec-sync/archive follow-up. The clarification itself MUST NOT check the task early. The other 73 tasks plus later completed follow-up readiness may produce `74/74`; actual spec synchronization and archive execution remain post-promotion work.
@@ -23,14 +24,14 @@ None.
 
 ### Modified Capabilities
 
-- `code-quality-tooling`: Extend CI and Sandbox Tests pull-request base filters to integration so its pull requests receive the six live `protect-main` contexts, keep both workflows' integration pushes untriggered, and keep unfiltered PR Governance separate from required ruleset contexts.
+- `code-quality-tooling`: Extend CI and Sandbox Tests pull-request base filters to integration so its pull requests receive the six live `protect-main` contexts, keep both workflows' integration pushes untriggered, keep unfiltered PR Governance separate from required ruleset contexts, and let formatter-ignored milestone fixtures remain a successful lint-staged no-op.
 - `project-memory`: Define the setup, runtime, final-promotion, teardown, and archive timing for a long-lived umbrella change delivered through milestone pull requests.
 - `release-governance`: Narrowly permit merge-commit delivery for verified same-repository main-sync and final-promotion pull requests while retaining single-commit governance everywhere else.
 - `release-workflow`: Make the temporary integration branch non-release across automatic, manual, Release PR, and npm channel selection paths.
 
 ## Impact
 
-- Affected repository surfaces: CI and Sandbox Tests pull-request triggers/tests, release regression tests, PR governance policy/tests, Quantex runtime guidance, delivery runbooks, the narrow redesign task `11.6` clarification, and a temporary GitHub ruleset/branch.
+- Affected repository surfaces: CI and Sandbox Tests pull-request triggers/tests, release regression tests, PR governance policy/tests, lint-staged formatter configuration/tests, Quantex runtime guidance, delivery runbooks, the narrow redesign task `11.6` clarification, and a temporary GitHub ruleset/branch.
 - Affected OpenSpec state: this change remains independent from `redesign-lifecycle-engine`; neither change may be archived merely because a milestone merges.
-- No CLI command, runtime behavior, public API, package metadata, release artifact, npm channel, or product release is added by this change.
+- No CLI command, runtime behavior, public API, published package identity, runtime dependency, release artifact, npm channel, or product release is added by this change.
 - Within this lifecycle-delivery scope, the only change allowed to reach `main` before final promotion is the process-only bootstrap that enables and verifies this topology; unrelated normal `main` delivery continues under existing governance.

--- a/openspec/changes/support-integration-branch-delivery/specs/code-quality-tooling/spec.md
+++ b/openspec/changes/support-integration-branch-delivery/specs/code-quality-tooling/spec.md
@@ -29,3 +29,22 @@ While `codex/redesign-lifecycle-integration` exists, the repository SHALL run th
 - **WHEN** maintainers prepare the integration branch for milestone delivery
 - **THEN** they MUST first synchronize the integration ref to the exact post-bootstrap `main` tip and verify it is zero commits ahead and zero commits behind
 - **AND** only then MAY they create the ruleset requiring pull requests and the six live `protect-main` contexts defined by this requirement
+
+### Requirement: Formatter-ignored milestone fixtures MUST NOT block pre-commit
+
+While lifecycle milestones add hard compatibility fixtures under paths deliberately excluded by the repository formatter configuration, lint-staged SHALL treat an oxfmt invocation whose entire matched set is formatter-ignored as a successful no-op. The repository MUST retain those ignore boundaries, MUST continue formatting supported staged files, and MUST continue running `oxlint --fix` after oxfmt for staged JavaScript and TypeScript. Real formatter or linter failures on supported files MUST remain commit-blocking.
+
+#### Scenario: A milestone stages only ignored JSON fixtures in the JSON formatter group
+
+- **GIVEN** every JSON path selected for one lint-staged oxfmt invocation is excluded by `.oxfmtrc.json`
+- **WHEN** the pre-commit hook runs
+- **THEN** oxfmt MUST format zero files without failing solely because no supported target remains
+- **AND** the ignored fixture bytes MUST remain unchanged
+
+#### Scenario: A milestone also stages formatter-supported source
+
+- **GIVEN** lint-staged selects formatter-supported source in addition to any ignored fixtures
+- **WHEN** the pre-commit hook runs
+- **THEN** supported files MUST still run through oxfmt
+- **AND** staged JavaScript and TypeScript MUST still run through `oxlint --fix` after formatting
+- **AND** any real formatter or linter failure MUST still abort the commit

--- a/openspec/changes/support-integration-branch-delivery/tasks.md
+++ b/openspec/changes/support-integration-branch-delivery/tasks.md
@@ -10,13 +10,14 @@
 - [x] 1.8 Add the setup/runtime/teardown procedure to the canonical delivery runbook and route the central Quantex runtime skill to it without expanding thin agent bootstraps.
 - [x] 1.9 Run the focused workflow/policy tests, `bun run test`, `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run openspec:validate`, and `bun run memory:check` for the complete bootstrap diff.
 - [x] 1.10 Prepare and validate a process-only PR body, verify the diff contains no lifecycle redesign implementation and changes no redesign task number, checkbox count, denominator, implementation scope, or earned completion credit, and deliver the one allowed bootstrap pull request to `main`.
-- [ ] 1.11 Merge the bootstrap through the ordinary single-commit path only after the six live `main` contexts succeed, then record merge closure separately from release and archive closure.
+- [x] 1.11 Merge the bootstrap through the ordinary single-commit path only after the six live `main` contexts succeed, then record merge closure separately from release and archive closure.
 
 ## 2. Integration Setup
 
-- [ ] 2.1 Before protection, synchronize `codex/redesign-lifecycle-integration` to the exact post-bootstrap `main` tip and verify the live remote comparison is zero commits ahead and zero commits behind.
-- [ ] 2.2 Create the temporary integration ruleset requiring pull requests and exact contexts `classify`, `lint`, `test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`, and `sandbox-tests`, and disallow direct updates after initialization.
+- [x] 2.1 Before protection, synchronize `codex/redesign-lifecycle-integration` to the exact post-bootstrap `main` tip and verify the live remote comparison is zero commits ahead and zero commits behind.
+- [x] 2.2 Create the temporary integration ruleset requiring pull requests and exact contexts `classify`, `lint`, `test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`, and `sandbox-tests`, and disallow direct updates after initialization.
 - [ ] 2.3 Verify from live repository state that an integration-target pull request receives all six contexts, PR Governance runs separately through its unfiltered trigger, integration push triggers are absent from CI and Sandbox Tests, and no release entry point accepts the branch.
+- [x] 2.4 Add a focused lint-staged regression and configure both oxfmt tasks so a matched set containing only formatter-ignored lifecycle fixtures is a successful no-op while supported staged files, `oxlint --fix`, and real failure propagation remain enforced.
 
 ## 3. Milestone Runtime
 

--- a/package.json
+++ b/package.json
@@ -109,11 +109,11 @@
   },
   "lint-staged": {
     "*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}": [
-      "oxfmt --write",
+      "oxfmt --write --no-error-on-unmatched-pattern",
       "oxlint --fix"
     ],
     "*.{json,jsonc,json5,html,css,scss,less}": [
-      "oxfmt --write"
+      "oxfmt --write --no-error-on-unmatched-pattern"
     ]
   },
   "engines": {

--- a/test/lint-staged-config.test.ts
+++ b/test/lint-staged-config.test.ts
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it } from 'vitest'
+
+const sourceGlob = '*.{js,mjs,cjs,jsx,ts,mts,cts,tsx}'
+const configGlob = '*.{json,jsonc,json5,html,css,scss,less}'
+const tolerantFormatCommand = 'oxfmt --write --no-error-on-unmatched-pattern'
+
+describe('lint-staged formatter configuration', () => {
+  it('treats formatter-ignored fixture groups as a no-op without weakening supported source checks', async () => {
+    const packageJson = await readJson<{
+      'lint-staged': Record<string, string[]>
+    }>('package.json')
+    const formatConfig = await readJson<{
+      ignorePatterns: string[]
+    }>('.oxfmtrc.json')
+
+    expect(formatConfig.ignorePatterns).toContain('test/fixtures')
+    expect(packageJson['lint-staged'][sourceGlob]).toEqual([tolerantFormatCommand, 'oxlint --fix'])
+    expect(packageJson['lint-staged'][configGlob]).toEqual([tolerantFormatCommand])
+  })
+})
+
+async function readJson<T>(path: string): Promise<T> {
+  return JSON.parse(await readFile(new URL(`../${path}`, import.meta.url), 'utf8')) as T
+}


### PR DESCRIPTION
## Summary

Unblock lifecycle milestone commits that contain formatter-ignored golden JSON fixtures while preserving every supported-file pre-commit check.

- keep `test/fixtures` excluded from oxfmt so golden bytes are not rewritten
- make an all-ignored lint-staged oxfmt invocation a successful no-op with the pinned `--no-error-on-unmatched-pattern` option
- retain oxfmt for supported staged files and `oxlint --fix` after formatting for JavaScript/TypeScript
- record the regression, delivery rationale, and verified bootstrap/integration setup state in the active delivery change

This prerequisite contains no lifecycle-engine implementation and targets only the protected integration branch.

## Linked Artifacts

- Issue: not applicable
- ADR: not applicable
- OpenSpec: `support-integration-branch-delivery`
- Discussion: not applicable

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (62 files, 711 tests)
- [x] `bun run openspec:validate` (15 passed, 0 failed)
- [ ] Not run, explained below

Additional focused evidence: `test/lint-staged-config.test.ts` failed before the config change and passed afterward; an ignored-only oxfmt smoke formatted zero files, exited successfully, and preserved the input hash. The final commit passed the normal pre-commit hook without bypass flags.

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [ ] Not needed
- [x] `docs/superpowers/plans/2026-07-11-lint-staged-ignored-fixtures.md`
- [x] `openspec/changes/support-integration-branch-delivery/`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change remains active across milestone merges by design; archive closure remains post-promotion.
- [x] Release is not applicable and integration remains excluded from release entry points.

## Notes

Reviewer focus:

- `.oxfmtrc.json`, formatter versions, lint-staged globs, hook commands, and CI are unchanged.
- `--no-error-on-unmatched-pattern` only changes the no-supported-target exit path; it does not format ignored fixtures or suppress failures on supported files.
- This is an ordinary one-commit integration PR. It does not use either multi-commit topology exception.
- `redesign-lifecycle-engine` remains absent from this diff; its progress stays `8/74` on the pending Phase 0/1 branch.
