### PR TITLE
refactor: migrate lifecycle observations and read-only commands

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,23 +1,16 @@
-# Provider/Catalog Milestone Progress
+# Observation and Read-Only Milestone Progress
 
-Base: `origin/codex/redesign-lifecycle-integration@af78c65e6f47e9c9804eb5844db82dd96628e631`
+Base: `origin/codex/redesign-lifecycle-integration@7b1dcf5b0caf8750f073a5252b4798548a9a1296`
 
 | Task | State | Checkpoint | Evidence |
 | --- | --- | --- | --- |
-| 1. Typed provider contracts and registry | complete | `feat(providers): add typed provider registry` | Red→green; 6 focused tests; 749 full tests; independent review passed |
-| 2. Provider conformance harness | complete | `test(providers): add adapter conformance suite` | 8 reusable cases; production unsupported boundary; independent review passed |
-| 3. npm/Bun adapters | complete | `refactor(providers): migrate npm and bun adapters` | Typed adapters + boolean compatibility facade; 153 focused / 790 full tests |
-| 4. Homebrew/winget adapters | complete | `refactor(providers): migrate brew and winget adapters` | Typed adapters + formula/cask/id compatibility; 106 focused / 811 full tests |
-| 5. Cargo/Deno adapters | complete | `refactor(providers): migrate cargo and deno adapters` | Typed adapters + arguments/binary-name compatibility; 121 focused / 832 full tests |
-| 6. pip/uv/mise adapters | complete | `refactor(providers): migrate pip uv and mise adapters` | Typed adapters + uv args and uv/mise presence/version; 144 focused / 860 full tests |
-| 7a. Script/binary explicit effects | complete | `refactor(providers): model script and binary effects` | Typed first-party adapters + shell/argv effects; 70 focused / 865 full tests |
-| 7b. Registry-derived capabilities | complete | `refactor(providers): derive capabilities from registry` | Single first-party registry + derived compatibility/update order; 100 focused / 868 full tests |
-| 8. Normalized catalog candidate schema | complete | `refactor(catalog): add provider-bound candidate schema` | Strict staged source schema + v1 projection; 118 focused / 872 full tests |
-| 9a. npm/Bun/mise catalog entries | complete | `refactor(catalog): normalize npm bun and mise candidates` | 24 source files + v1 package/method projection; 202 focused / 874 full tests |
-| 9b. Cargo/Deno/pip/uv catalog entries | complete | `refactor(catalog): normalize rust and python candidates` | 5 source files + args/probes/legacy package-name projection; 204 focused / 876 full tests |
-| 9c. Homebrew/winget catalog entries | complete | `refactor(catalog): normalize system package candidates` | 14 source files + formula/cask/id projection; 202 focused / 878 full tests |
-| 9d. Script/binary catalog entries | complete | `refactor(catalog): normalize install effect candidates` | Explicit source/effects + complete typed edge coverage; 186 focused / 881 full tests |
-| 10. Generated support data/docs | complete | `docs(catalog): generate provider support matrix` | Deterministic JSON/Markdown + stale-output validation; 111 focused / 883 full tests |
-| 11. Milestone validation/review/delivery | complete | PR [#450](https://github.com/Drswith/quantex-cli/pull/450) | One commit; full gates/build passed; independent review found no blocker/important |
+| 1. Live lifecycle observer | complete | `2a7218d` + `68704c5` | 44 focused tests; controller gate passed; independent re-review approved |
+| 2. Deterministic observation planning | complete | `00f12a7` + `bcf9ad9` | 88 focused tests; controller gate passed; independent re-review approved |
+| 3. Read-only application and v1 projection | complete | `7500245` + `879c29f` | 47 focused tests; controller gate passed; independent re-review approved |
+| 4. list/info migration | complete | `7aa8645` + `c864132` | 27 focused tests; controller gate passed; independent re-review approved |
+| 5. inspect/resolve migration | complete | `f7e059f` + `be27468` | 37 focused tests; controller gate passed; independent re-review approved |
+| 6. capabilities/doctor migration | complete | `a3d815d` + `2323960` | 58 controller tests; independent re-review approved |
+| 7. Real-environment and OpenSpec closure | complete after sixth fix wave | prior checkpoints + `f6fa654` + `4066817` | Invocation interruption wins request transport rejection before headers |
+| 8. Review and integration PR | whole-branch review approved | pending | No Critical, Important, or Minor findings; normalization in progress |
 
 Recovery rule: resume the first row that is not `complete`; inspect its brief/report and `git status` before running commands.

--- a/.superpowers/sdd/task-1-brief.md
+++ b/.superpowers/sdd/task-1-brief.md
@@ -1,29 +1,43 @@
-# Task 1 Brief: Typed Provider Contracts And Registry
+### Task 1: Build the live agent lifecycle observer (OpenSpec 5.1)
 
-## Objective
+**Files:**
+- Create: `src/lifecycle/agent-observation.ts`
+- Create: `test/lifecycle/agent-observation.test.ts`
+- Modify: `src/lifecycle/model.ts`
+- Modify: `src/lifecycle/index.ts`
+- Modify: `src/lifecycle/provider-evidence.ts`
 
-Implement the smallest compile-time provider boundary that fully expresses OpenSpec task `4.1` without rerouting legacy command behavior.
+**Interfaces:**
+- Consumes: `AgentDefinition`, `InstalledAgentState`, `LifecycleReceipt`, `ProviderRegistry`, `resolveStateProviderBinding`, `resolveReceiptProviderBinding`, `observeLifecycleProvider`.
+- Produces: `observeAgentLifecycle(agent, ports): Promise<AgentLifecycleObservationResult>` where the result contains the domain `LifecycleObservation`, exact provider binding/capabilities when resolvable, executable/version facts, installed-state provenance, receipt, and normalized catalog methods.
 
-## Required behavior
+- [ ] **Step 1: Write table-driven failing observation tests**
 
-- Stable first-party provider IDs are unique and exhaustively typed.
-- Registry lookup/list APIs are read-only and offer no dynamic registration mutation.
-- An adapter exposes typed availability and observation operations plus optional typed install, update, uninstall, latest-version, batch-update, and verification operations.
-- Capabilities are derived solely from operation presence.
-- Outcomes distinguish success, unsupported, unavailable, failed, cancelled, timed out, and indeterminate states.
-- Provider failures can preserve argv, exit status, retryability, and safe remediation/evidence.
-- Operation context carries `AbortSignal` and optional timeout without importing CLI state.
+  Cover: absent/no evidence, live untracked executable, verified tracked state+receipt, legacy tracked state without receipt, conclusive ghost, state/receipt provider conflict, provider-present/PATH-absent conflict, provider-absent/PATH-present conflict, unsupported binding, and indeterminate provider outcome. For agents without state or receipt, explicitly cover one candidate provider present, multiple candidate providers present, and candidate probe failure while PATH is present. Assert provider id, target id/kind, capabilities, drift kind, version/path, and that no state mutator is called.
 
-## Compatibility boundary
+- [ ] **Step 2: Verify the tests fail for the missing observer**
 
-- Do not change `AgentDefinition`, catalog JSON, public root exports, command handlers, or current installer behavior in this task.
-- Do not replace `INSTALLER_CAPABILITIES` yet; that happens only after all adapters exist.
-- Do not mark OpenSpec `4.1` complete until tests and the exact contract categories above pass.
+  Run: `bun run test -- test/lifecycle/agent-observation.test.ts`
 
-## TDD loop
+  Expected: FAIL because `observeAgentLifecycle` is not defined.
 
-1. Create `test/providers/registry.test.ts` importing modules that do not yet exist.
-2. Run the focused test and record the expected module/contract failure.
-3. Add minimal provider types and a compile-time registry implementation.
-4. Re-run focused tests, lint, format check, and typecheck.
-5. Write `task-1-report.md`, update progress, update OpenSpec only if literally complete, and create the checkpoint commit.
+- [ ] **Step 3: Implement minimal injected observation ports**
+
+  Define ports for clock, executable/path/version inspection, installed-state/receipt reads, provider registry, and provider observation. Use exact state/receipt bindings; compare provider id, target id, target kind, and executable identity. When no persisted binding exists, observe every catalog candidate: exactly one live candidate may establish provider ownership, multiple live candidates classify as `conflicting-source`, and any unresolved candidate probe that prevents a conclusive decision classifies as `indeterminate`. PATH presence alone never establishes provider ownership. Preserve typed provider outcomes rather than branching on messages.
+
+- [ ] **Step 4: Make drift classification explicit and exhaustive**
+
+  Use only `none`, `untracked`, `recorded-absent`, `conflicting-source`, and `indeterminate`. A present executable is not proof of provider ownership; a receipt is provenance, not live proof.
+
+- [ ] **Step 5: Run the focused gate and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/lifecycle/agent-observation.test.ts test/lifecycle/provider-evidence.test.ts test/state.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `feat(lifecycle): observe live agent evidence`

--- a/.superpowers/sdd/task-1-report.md
+++ b/.superpowers/sdd/task-1-report.md
@@ -1,32 +1,65 @@
-# Task 1 Report: Typed Provider Contracts And Registry
+# Task 1 Report: Live Agent Lifecycle Observer
 
 ## Result
 
-OpenSpec task `4.1` is complete. The new internal provider boundary defines a closed first-party ID set, typed availability/observation/mutation/version/verification operations, typed outcomes and evidence, optional-operation-derived capabilities, and an immutable compile-time registry API. No command or legacy installer routing changed.
+Implemented OpenSpec `redesign-lifecycle-engine` task `5.1` only. The new read-only observer combines PATH/version facts, installed-state provenance, lifecycle receipts, exact provider evidence, registry-derived capabilities, and normalized catalog bindings into `LifecycleObservation` without importing or invoking a state mutator.
 
-## TDD evidence
+## RED evidence
 
-- Red: `bun run test -- test/providers/registry.test.ts` failed because `src/providers` did not exist.
-- Green: the initial registry suite passed 5 tests.
-- Review red: `bun run typecheck` proved verification was incorrectly required and failure evidence was missing.
-- Review green: verification became optional, failure evidence was added, all outcome variants were asserted, and the first-party key/ID relation gained a compile-time negative test.
-- Final focused result: 1 file / 6 tests passed.
+- Command: `bun run test -- test/lifecycle/agent-observation.test.ts`
+- Expected failure: exit `1`; Vitest reported `Cannot find module '../../src/lifecycle/agent-observation'` at the observer import because the observer module/API did not exist.
+- Test-load correction: after production implementation began, the table fixture exposed a test-only TDZ (`Cannot access 'receipt' before initialization`). The constants were moved above the table without changing production code, then the behavior matrix ran normally.
+- Review RED cycles:
+  - 3 failures reproduced missing conflict handling for multiple live candidates with PATH absent, an unresolvable persisted receipt binding, and recorded executable-path drift.
+  - 1 failure reproduced acceptance of provider evidence for a different target identity.
+- Important review-fix RED cycles were rerun against isolated checkpoint `2a7218d` with only the new tests applied:
+  - `-t "keeps conclusive multiple-live conflict ahead of another candidate failure"` failed because the observer returned `indeterminate` instead of the already-conclusive `present` / `conflicting-source` result.
+  - `-t "normalizes a persisted provider adapter rejection to indeterminate"` failed with an escaped `Error: bun adapter rejected`.
+  - `-t "normalizes a catalog candidate adapter rejection to indeterminate"` failed with the same escaped adapter rejection on the no-state candidate path.
+  - `-t "fails closed for an unresolved"` failed for both brew and winget because each unresolved candidate was silently filtered and the observer returned `present` instead of `indeterminate`.
 
-## Compatibility evidence
+## GREEN and regression evidence
 
-- `bun run test -- test/providers/registry.test.ts test/package-manager/index.test.ts test/agents.test.ts`: 3 files / 172 tests passed.
-- `bun run test`: 67 files / 749 tests passed before the review-only contract tightening; the final focused and static checks passed after tightening.
-- `bun run lint`: 0 warnings / 0 errors.
-- `bun run format:check`: passed.
-- `bun run typecheck`: passed.
+- Observer matrix: `bun run test -- test/lifecycle/agent-observation.test.ts` -> 1 file, 17 tests passed.
+- Final focused gate: `bun run test -- test/lifecycle/agent-observation.test.ts test/lifecycle/provider-evidence.test.ts test/state.test.ts` -> 3 files, 38 tests passed.
+- Review-fix GREEN: observer matrix -> 1 file, 22 tests passed.
+- Review-fix final focused gate: `bun run test -- test/lifecycle/agent-observation.test.ts test/lifecycle/provider-evidence.test.ts test/state.test.ts` -> 3 files, 44 tests passed.
+- Equivalent catalog candidates are explicitly covered: duplicate bindings deduplicate to one binding and do not create a false unresolved-candidate signal.
+- `bun run format:check` -> passed.
+- `bun run lint` -> 0 warnings, 0 errors.
+- `bun run typecheck` -> passed.
 
-## Independent review
+## Modified files
 
-The first review found four important contract gaps: mandatory verification, missing failure evidence, missing outcome-variant coverage, and a first-party map whose keys were not tied to literal adapter IDs. Each was reproduced or encoded as a failing type/test assertion and fixed individually. Follow-up review closed all four findings and found no blocker or remaining important issue.
+- `src/lifecycle/agent-observation.ts` (new)
+- `test/lifecycle/agent-observation.test.ts` (new)
+- `src/lifecycle/model.ts`
+- `src/lifecycle/index.ts`
+- `src/lifecycle/provider-evidence.ts`
+- `test/lifecycle/provider-evidence.test.ts`
 
-## Scope retained
+## Checkpoint commit
 
-- No existing adapter has been migrated yet.
-- No duplicated capability table or update bucket has been removed yet.
-- No catalog/schema/public export/state/CLI behavior changed.
-- OpenSpec `4.2` and later tasks remain incomplete.
+- `2a7218d7122ad7936e5f73b117598bbfcfd40273` — `feat(lifecycle): observe live agent evidence`
+- Review-fix delivery uses a new commit, `fix(lifecycle): fail closed on incomplete provider evidence`; it does not amend the checkpoint.
+
+## Self-review
+
+- Scope is limited to Task 1 / OpenSpec 5.1; no planner, command migration, OpenSpec checkbox, or Task 2+ file was changed.
+- Persisted state and receipts are provenance only; invalid bindings fail closed and never fall back to invented provider ownership.
+- Exact provider ID, target ID/kind, executable name/path, PATH presence, and typed provider outcomes participate in drift classification.
+- With no persisted binding, every platform catalog candidate is observed: one live candidate can establish untracked ownership, multiple live candidates conflict, and any unresolved probe is indeterminate.
+- Conclusive target mismatch and multi-provider conflict take precedence over other failed candidate probes; only unresolved evidence that prevents a conclusion becomes `indeterminate`.
+- Provider adapter rejection is caught at the observer boundary and normalized into a typed `failed` provider outcome plus domain `indeterminate` observation on both persisted-binding and no-state candidate paths.
+- Unresolvable managed candidates remain explicit evidence and fail closed without confusing legitimate duplicate bindings with missing normalization.
+- The ports expose reads only. The test supplies a throwing `mutateState` sentinel and proves it is never called in every table row.
+- Drift kinds remain exhaustive: `none`, `untracked`, `recorded-absent`, `conflicting-source`, and `indeterminate`.
+
+## Concerns and closure
+
+- CodeGraph was not initialized in this worktree, so structural exploration used narrow source reads instead; no index initialization was performed.
+- The checkpoint commit intentionally contains the five implementation/test files. This report and the shared SDD progress file were updated after commit so the report could contain the actual immutable commit SHA.
+- The review-fix commit includes the controller-maintained `.superpowers/sdd` brief, progress, and report updates so coordination evidence is preserved with the fix.
+- OpenSpec remains active at 30/74 by instruction; task checkbox unchanged. No push, PR, release, merge, or archive action was requested for this checkpoint.
+- Independent re-review approved Task 1 with no Critical or Important findings. The controller reran the 44-test focused gate plus format, lint, and typecheck successfully.
+- The controller checked first-party provider observation paths: they perform local executable/package presence and installed-version probes; latest-version network resolution is a separate operation and is not invoked by this observer.

--- a/.superpowers/sdd/task-2-brief.md
+++ b/.superpowers/sdd/task-2-brief.md
@@ -1,28 +1,38 @@
-# Task 2 Brief: Reusable Provider Conformance Harness
+### Task 2: Complete deterministic planning over observation states (OpenSpec 5.2)
 
-## Objective
+**Files:**
+- Modify: `src/lifecycle/mutation-planner.ts`
+- Modify: `src/lifecycle/model.ts`
+- Modify: `test/lifecycle/mutation-planner.test.ts`
+- Create: `test/lifecycle/observation-planning.test.ts`
 
-Create one reusable Vitest contract that later provider adapter tests can invoke with injected deterministic cases. This task establishes the harness and proves it against a fixture adapter; it does not claim real-provider conformance yet.
+**Interfaces:**
+- Consumes: `LifecycleObservation`, requested `LifecycleIntent`, exact provider binding, and registry-derived capabilities.
+- Produces: deterministic `LifecycleMutationPlanningResult` with decisions for satisfied, install, adopt, preserve-unmanaged, clear-ghost, uninstall, unsupported, and blocked.
 
-## Required cases
+- [ ] **Step 1: Add failing planner matrix tests**
 
-- Unsupported optional operation is absent from derived capabilities and maps to a typed `unsupported` outcome.
-- Failure preserves reason, command, exit code, retryability, remediation, and evidence.
-- An already-aborted operation returns `cancelled`, not generic failure.
-- Provider timeout returns `timed-out` with the effective timeout.
-- Observation distinguishes typed present and absent results; present evidence includes version/provider detail.
-- Provider unavailability remains distinct from command failure.
-- Successful verification is satisfied and carries non-empty provider-specific evidence.
+  Use one row for every required state: already-satisfied, absent, tracked, untracked, ghost, conflicting, unsupported, and indeterminate. Repeat each row to prove stable plan ids, step ordering, effects, and postconditions.
 
-## Boundary
+- [ ] **Step 2: Verify unsupported and contradictory rows fail**
 
-- Keep the reusable harness in `test/providers/conformance.ts`.
-- Use a fresh subject per test so cancellation or mutable fixtures cannot leak between adapters.
-- Do not mark OpenSpec `4.2` complete until every real first-party adapter is migrated and invokes this harness; this checkpoint only makes later group completion mechanically enforceable.
+  Run: `bun run test -- test/lifecycle/mutation-planner.test.ts test/lifecycle/observation-planning.test.ts`
 
-## TDD loop
+  Expected: FAIL until capability-aware decisions exist.
 
-1. Add a fixture test importing the not-yet-created conformance helper and confirm module failure.
-2. Implement the smallest reusable helper that asserts the required cases.
-3. Run focused tests and static checks.
-4. Request a narrow independent review, write the task report, and create a checkpoint commit while leaving `4.2` unchecked.
+- [ ] **Step 3: Extend the pure planner only**
+
+  Add no filesystem, process, provider, console, output-envelope, or Commander imports. An absent required provider capability returns `unsupported`; conflicting/indeterminate observations return `blocked`; read-only callers may consume the plan without executing it.
+
+- [ ] **Step 4: Run focused tests and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/lifecycle/mutation-planner.test.ts test/lifecycle/observation-planning.test.ts test/lifecycle/shadow-planning.test.ts test/commands/ensure.test.ts test/commands/install.test.ts test/commands/uninstall.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `refactor(lifecycle): plan from live observations`

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,23 +1,75 @@
-# Task 2 Report: Reusable Provider Conformance Harness
+# Task 2 Report: Deterministic Observation Planning
 
 ## Result
 
-Added a reusable, fresh-subject provider conformance harness covering unsupported optional operations, exact typed failure diagnostics, live-versus-aborted cancellation behavior, effective timeout propagation, provider unavailability, present/absent/indeterminate observation, and exact verification evidence.
+Implemented OpenSpec `redesign-lifecycle-engine` task `5.2` only. The pure lifecycle planner now consumes an exact provider/target binding with a registry-derived capability snapshot and deterministically produces `satisfied`, `install`, `adopt`, `preserve-unmanaged`, `clear-ghost`, `uninstall`, `unsupported`, or `blocked` without executing the plan.
 
-`src/providers/invoke.ts` is the production boundary that converts absent optional target or batch operations into typed `unsupported` outcomes. Its overloads keep target requests separate from `update-many` batch requests.
+The provider planning context is optional only for compatibility with the already-migrated Phase 6 ensure/install/uninstall paths. Supplying the context enables fail-closed capability checks; an explicit empty capability list means the registry has confirmed that no mutation operation is supported.
 
-## TDD and review evidence
+## RED evidence
 
-- Red: the fixture suite initially failed because `test/providers/conformance.ts` did not exist.
-- Initial green: fixture conformance passed 7 cases.
-- First review rejected false-positive callbacks that could fabricate cancellation, timeout, unsupported, and evidence results.
-- The harness now owns live/aborted/timeout contexts, uses control calls, and compares exact diagnostics/evidence. Indeterminate observation became an eighth case.
-- Second review rejected test-only unsupported synthesis; focused tests failed until the production invocation boundary and both target/batch overloads existed.
-- Final focused result: 2 files / 15 tests passed; independent follow-up review found no blocker or important issue.
+- Initial command: `bun run test -- test/lifecycle/mutation-planner.test.ts test/lifecycle/observation-planning.test.ts`
+- Expected result: exit `1`; 2 of 20 tests failed because an absent target with an explicit empty capability snapshot still selected `install` and emitted a `bun-install` effect instead of selecting `unsupported` with no steps.
+- Uninstall capability RED: `bun run test -- test/lifecycle/mutation-planner.test.ts -t 'tracked uninstall lacks'` exited `1`; the planner selected `uninstall` and emitted a `bun-uninstall` effect even though the provider snapshot exposed only `observe`.
+- Exact-binding RED: `bun run test -- test/lifecycle/mutation-planner.test.ts -t 'different observed provider target'` exited `1`; the planner combined a Bun capability snapshot with an npm observation and emitted an npm uninstall step instead of blocking the contradictory inputs.
 
-## Scope retained
+## GREEN and regression evidence
 
-- The harness is proven against a deterministic fixture only.
-- Real first-party adapters have not yet invoked it.
-- OpenSpec `4.2` remains unchecked until all nine managed provider adapters are migrated and conformant.
-- No legacy command, catalog, state, or output behavior changed.
+- Initial GREEN: planner focused tests passed, 2 files and 20 tests.
+- Uninstall capability GREEN: targeted test passed, followed by 2 planner files and 21 tests passing.
+- Exact-binding GREEN: targeted test passed, followed by 2 planner files and 22 tests passing.
+- Pre-report focused gate: 6 files and 83 tests passed before the two self-review cases were added.
+- Final focused gate: 6 files and 85 tests passed.
+- Final `bun run format:check`, `bun run lint`, and `bun run typecheck` all passed; `git diff --check` also passed.
+
+## Modified files
+
+- `src/lifecycle/model.ts`
+- `src/lifecycle/mutation-planner.ts`
+- `test/lifecycle/mutation-planner.test.ts`
+- `test/lifecycle/observation-planning.test.ts` (new)
+- `.superpowers/sdd/task-2-report.md` (new)
+- `.superpowers/sdd/progress.md`
+- `.superpowers/sdd/task-2-brief.md` (approved Task 2 brief already present at task start)
+
+## Deterministic matrix
+
+The repeated table covers already-satisfied, absent, tracked, untracked with exact provider evidence, ghost, conflicting, unsupported, indeterminate, and untracked without provider evidence. Every row compares two complete results and asserts the plan ID, ordered steps, effects, and postconditions.
+
+## Self-review
+
+- The planner imports only lifecycle model types. It has no filesystem, process, provider adapter, console, output-envelope, or Commander dependency.
+- Conflicting and indeterminate observations return `blocked` with no steps.
+- A provider planning context that disagrees with observed provider ID, target ID, or target kind returns `blocked` rather than borrowing capabilities from another binding.
+- Missing install or uninstall capability returns `unsupported` with no effects or postconditions.
+- Provider mutation effects and package postconditions use one resolved provider/target pair, preventing mixed-provider plans.
+- Existing Phase 6 callers continue to use their legacy provider ID/target fields and retain the previous mutation decisions when no capability snapshot is supplied.
+- No command migration, plan execution, provider call, filesystem/process access, or OpenSpec checkbox change is included.
+
+## Checkpoint
+
+- Planned commit: `refactor(lifecycle): plan from live observations`
+- Review state: implementation complete; independent review pending.
+- OpenSpec state: `redesign-lifecycle-engine` remains active; task `5.2` checkbox intentionally unchanged.
+
+## Important review fix: exact target kinds
+
+Review found that `LifecyclePlanningProvider.targetKind` was optional and runtime comparison only considered kind when both observation and planning snapshot supplied it. A complete `brew/cask/demo` observation could therefore borrow an uninstall capability from a malformed `brew/demo` snapshot with no target kind.
+
+### Review-fix RED evidence
+
+- Command: `bun run test -- test/lifecycle/mutation-planner.test.ts -t 'target kind|legacy provider fields'`
+- Expected result: exit `1`; the missing-kind runtime case selected `uninstall` and emitted a `brew-uninstall` effect instead of returning `blocked`. The explicit kind-mismatch and legacy compatibility rows already passed.
+- Command: `bun run typecheck`
+- Expected result: exit `2`; TypeScript reported an unused `@ts-expect-error`, proving that a new planning snapshot without `targetKind` was still accepted by the type.
+
+### Review-fix GREEN evidence
+
+- `LifecycleProviderTargetKind` is now derived from the present observation's canonical `providerTargetKind` field, and `LifecyclePlanningProvider.targetKind` is required.
+- Runtime comparison now blocks whenever an observation declares a kind that differs from the snapshot, including malformed JS/cast input whose kind is missing.
+- Targeted command: 1 file, 3 tests passed; 13 unrelated tests skipped.
+- `bun run typecheck` passed, proving the missing-kind fixture is now rejected at compile time while the intentional `@ts-expect-error` is consumed.
+- Legacy `providerId` / `providerTargetId` fields remain an independent compatibility path and do not require a planning target kind.
+- Planned fix commit: `fix(lifecycle): require exact planning target kinds` (new commit; no amend).
+- Independent re-review approved Task 2 with no Critical, Important, or Minor findings.
+- The controller reran the full 6-file / 88-test focused gate. Its first run exposed two transient `install.test.ts` timing/order failures; the complete install file and both individual cases passed immediately in isolation, and the full 6-file gate then passed 88/88 with format, lint, and typecheck green. No planner-linked causal path or reproducible product regression was found.

--- a/.superpowers/sdd/task-3-brief.md
+++ b/.superpowers/sdd/task-3-brief.md
@@ -1,31 +1,39 @@
-# Task 3 Brief: Migrate npm And Bun Adapters
+### Task 3: Add the read-only application and v1 projection boundary
 
-## Objective
+**Files:**
+- Create: `src/services/lifecycle-observations.ts`
+- Create: `src/compatibility/agent-inspection.ts`
+- Create: `test/services/lifecycle-observations.test.ts`
+- Create: `test/compatibility/agent-inspection.test.ts`
+- Modify: `src/services/agents.ts`
 
-Implement typed npm and Bun provider adapters, run both through the reusable conformance harness, and route the maintained `ManagedInstaller` npm/Bun entries through a boolean compatibility projection without changing current CLI or root-export behavior.
+**Interfaces:**
+- Consumes: agent registry, live observer, current catalog method formatting inputs, and existing `AgentInspection` semantics.
+- Produces: `resolveAgentObservation(name)` and `observeRegisteredAgents()` plus `projectObservationToV1Inspection(result): AgentInspection`.
 
-## Architecture
+The existing `inspectRegisteredAgents` and `resolveAgentInspection` exports remain on the legacy implementation for mutation and execution consumers. Add an import/route boundary test that fails if this milestone rewires ensure/install/run/update or removes those exports; only the six read-only commands consume the new service.
 
-- Add a shared internal registry-package adapter factory only where npm/Bun behavior is genuinely identical; keep provider-specific command construction/default dependencies in separate `src/providers/adapters/npm.ts` and `bun.ts` modules.
-- Dependencies are injectable for deterministic conformance tests. Default dependencies call the existing `src/package-manager/npm.ts`, `bun.ts`, `utils/detect`, and npm-registry version resolver through namespace/property access so existing Vitest spies remain effective.
-- Typed operations preflight an aborted signal and distinguish cancellation/timeout/failure. A timeout race may stop waiting on a legacy boolean dependency, but this milestone must not claim process-tree cancellation or route a new timeout into existing CLI behavior.
-- Provider requests carry typed npm/Bun options for update strategy, dist tag, and registry. Do not encode these options in untyped metadata.
-- Observation maps `present`, `absent`, and `unknown` into typed present/absent/indeterminate outcomes and preserves provider/version evidence. Verification derives satisfied/unsatisfied/indeterminate from a fresh observation.
-- Mutation success/failure carries exact command/provider evidence; false legacy results become typed failures without fabricating an exit code.
-- `ManagedInstaller` remains a maintained compatibility type/root export. Its npm/Bun entries project typed outcomes back to existing booleans and preserve direct installed-version/presence probes so current call counts and meanings do not drift.
-- Do not migrate the other seven managed providers, remove the capability table, normalize catalog data, or route command handlers directly to typed outcomes in this task.
+- [ ] **Step 1: Add failing service tests for aliases, ordering, and unknown agents**
 
-## Required tests
+  Assert canonical registry order, alias resolution, one observation per agent, no provider/state mutation, and unchanged legacy service exports for non-read-only callers.
 
-1. Add failing `test/providers/npm.test.ts` and `bun.test.ts` before adapter modules exist.
-2. Invoke `describeProviderConformance` for each real adapter factory with injected deterministic dependencies. The reusable unsupported case may be omitted for a full-capability adapter because production target/batch unsupported mapping is already tested centrally.
-3. Prove npm/Bun install, update, update-many, uninstall, observation, latest-version resolution, and verification preserve provider identity/evidence.
-4. Prove `latest-major` and `respect-semver`, dist tag, and normalized registry inputs reach the existing provider-specific dependencies unchanged.
-5. Prove a never-settling dependency returns the exact requested timeout and an already-aborted signal never invokes the dependency.
-6. Run existing npm/Bun low-level tests to preserve npm argv, registry normalization, Bun trust/rollback, Windows scoped-package parsing, presence, and version parsing.
-7. Run existing package-manager/index and update tests to prove the compatibility facade remains boolean and strategy-aware.
+- [ ] **Step 2: Add failing compatibility projection tests**
 
-## Completion
+  Lock current meanings of `inPath`, `binaryPath`, `resolvedBinaryPath`, `installedVersion`, `latestVersion`, `lifecycle`, `sourceLabel`, and `updateLabel` across tracked, untracked, ghost, conflicting, and indeterminate internal observations.
 
-- Update OpenSpec `4.3` only after both default adapters are wired through the compatibility facade, both conformance suites pass, all focused legacy tests pass, and independent review has no blocker/important finding.
-- Write `task-3-report.md`, update progress, and create checkpoint `refactor(providers): migrate npm and bun adapters`.
+- [ ] **Step 3: Implement the application service and one-way compatibility adapter**
+
+  Domain/application code must not import output envelopes or presenters. The compatibility adapter may reuse current label helpers but must omit new drift/capability fields from v1 objects.
+
+- [ ] **Step 4: Run focused tests and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/services/lifecycle-observations.test.ts test/compatibility/agent-inspection.test.ts test/commands/list.test.ts test/commands/info.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `feat(observation): add read-only application boundary`

--- a/.superpowers/sdd/task-3-report.md
+++ b/.superpowers/sdd/task-3-report.md
@@ -1,39 +1,56 @@
-# Task 3 Report: Migrate npm And Bun Adapters
+# Task 3 Report: Read-Only Application and v1 Projection Boundary
 
 ## Result
 
-OpenSpec `4.3` is complete. npm and Bun now have typed provider adapters with injectable dependencies, typed availability/observation/latest-version/mutation/verification outcomes, exact provider and command evidence, safe failure reasons, pre-aborted cancellation, and bounded timeout results.
+Implemented the Task 3 application boundary without migrating any command. `resolveAgentObservation(name)` and
+`observeRegisteredAgents()` resolve the canonical registry, run the live observer exactly once per agent, preserve
+registry ordering, and combine the observation with current ordered install methods and the values required by the
+v1 `AgentInspection` compatibility shape.
 
-The maintained `ManagedInstaller` root-export contract remains boolean. Its npm/Bun entries now call the typed adapters and project success back to `true`; installed-version and presence probes remain direct compatibility projections so existing probe behavior and call counts stay stable.
+The one-way `projectObservationToV1Inspection()` adapter preserves the historical meanings of PATH presence,
+binary/resolved paths, installed/latest versions, lifecycle, source label, and update label. It does not expose drift,
+receipts, provider targets, or capabilities.
 
-## Compatibility preserved
+## RED and GREEN evidence
 
-- npm and Bun `latest-major` / `respect-semver` strategies.
-- Explicit versus default dist tags, including explicit `latest` command evidence.
-- Registry URL normalization and registry-aware install/update/latest-version resolution.
-- npm argv behavior and Bun trust, rollback, scoped-package parsing, presence, and version behavior through the unchanged low-level modules.
-- Batch target identity, install arguments, direct provider probes, current command handlers, state, output, and root exports.
+- Initial RED: both focused suites failed to load because `src/services/lifecycle-observations.ts` and
+  `src/compatibility/agent-inspection.ts` did not exist.
+- Compatibility RED: the service initially did not share installed state with executable inspection, so a tracked
+  package-manager version could not preserve legacy precedence. The focused test failed with an undefined version.
+- GREEN: the two new suites pass 14 tests, including aliases, unknown agents, canonical ordering, one observation per
+  agent, one installed-state read, legacy route boundaries, read-only imports, and six projection states.
+- Final focused command gate: 4 files and 23 tests passed.
+- `bun run format:check`, `bun run lint`, and `bun run typecheck` passed.
 
-## TDD and interruption evidence
+## Compatibility and scope
 
-- Initial red: both provider tests failed because `src/providers/adapters/npm.ts` and `bun.ts` did not exist.
-- The delegated implementation turn later stopped on an account usage limit. Its uncommitted tests and adapter files remained in the worktree; recovery resumed from `.superpowers/sdd/progress.md` without repeating completed Tasks 1/2.
-- Compatibility red: three tests proved `ManagedInstaller` still bypassed typed adapters before the facade was changed.
-- Additional red/green loops covered TypeScript outcome narrowing, lint-safe timeout racing, explicit `latest` evidence, and preservation of safe dependency rejection reasons.
+- `inspectRegisteredAgents` and `resolveAgentInspection` remain unchanged legacy implementations.
+- `ensure`, `install`, `run`, `update`, and update planning remain routed through `src/services/agents.ts`.
+- No list/info/inspect/resolve/capabilities/doctor command was modified; OpenSpec 5.3-5.6 migration has not started.
+- Application and domain code import no output envelope, presenter, Commander, state mutator, or lifecycle lock.
+- The service reuses one installed-state read for live observation and managed-version probing, avoiding inconsistent
+  evidence within one agent observation.
 
-## Validation
+## Checkpoint and review state
 
-- Focused provider/legacy/update suite: 7 files / 153 tests passed.
-- Full suite: 71 files / 790 tests passed.
-- `bun run lint`: 0 warnings / 0 errors.
-- `bun run format:check`: passed.
-- `bun run typecheck`: passed.
-- `bun run openspec:validate`: 16/16 passed.
-- `bun run memory:check`: passed.
+- Checkpoint: `feat(observation): add read-only application boundary` (this commit).
+- State: implementation complete; independent review pending.
+- OpenSpec: `redesign-lifecycle-engine` remains active and no checkbox was changed.
 
-## Scope retained
+## Important review fix: raw PATH evidence
 
-- The other seven managed providers remain on the legacy registry.
-- The duplicated capability table and hard-coded update groups remain until OpenSpec `4.8`.
-- OpenSpec `4.2` remains unchecked until every real first-party provider uses the conformance harness.
-- Catalog normalization and command/state lifecycle migration remain untouched.
+Review found that the v1 compatibility adapter projected the observer's merged executable evidence. When PATH was
+absent but a tracked provider reported the executable present, the lifecycle observation correctly became
+`present` / `conflicting-source`, but v1 incorrectly reported `inPath: true` and exposed provider-derived path and
+version values.
+
+- RED: the projection reproduced all four drifted v1 fields; the observer lacked explicit raw PATH evidence; the
+  service resolved the provider path instead of the original PATH probe path.
+- GREEN: `AgentLifecycleObservationResult.pathExecutable` now preserves the raw executable probe while the existing
+  merged `executable` and lifecycle observation remain unchanged. The service resolves only the raw path, and the v1
+  adapter derives `inPath`, `binaryPath`, `resolvedBinaryPath`, and `installedVersion` only from raw PATH evidence.
+- Review-fix focused gate: 5 files and 47 tests passed; format, lint, and typecheck passed.
+- Scope remains Task 3 only: no command route, legacy service, output key, or OpenSpec checkbox changed.
+- Planned review-fix commit: `fix(observation): preserve v1 path inspection semantics` (new commit; no amend).
+- Independent re-review approved Task 3 with no Critical, Important, or Minor findings.
+- The controller reran the 5-file / 47-test focused gate plus format, lint, and typecheck successfully.

--- a/.superpowers/sdd/task-4-brief.md
+++ b/.superpowers/sdd/task-4-brief.md
@@ -1,22 +1,33 @@
-# Task 4 Brief: Migrate Homebrew And winget Adapters
+### Task 4: Migrate list and info without v1 drift (OpenSpec 5.3)
 
-## Objective
+**Files:**
+- Modify: `src/commands/list.ts`
+- Modify: `src/commands/info.ts`
+- Modify: `test/commands/list.test.ts`
+- Modify: `test/commands/info.test.ts`
+- Modify: `test/compatibility/v1-baseline.test.ts`
 
-Implement typed Homebrew and winget adapters, preserve formula/cask/package-ID semantics, run both through the shared conformance harness, and route their maintained `ManagedInstaller` entries through typed-to-boolean compatibility projections.
+**Interfaces:**
+- Consumes: `observeRegisteredAgents`, `resolveAgentObservation`, and the v1 inspection projection.
+- Produces: unchanged `list` and `info` `CommandResult` data and human presentation.
 
-## Boundary
+- [ ] **Step 1: Add route-boundary tests**
 
-- Reuse the existing cancellation/timeout/typed-failure machinery through a narrow shared legacy-operation helper; do not duplicate another promise race.
-- Homebrew targets normalize to `formula` unless explicitly `cask`; winget targets normalize to `id`.
-- Preserve exact command forms: `brew <action> [--cask] <name>` and `winget <action> --id <id> -e`.
-- Existing low-level boolean modules remain unchanged and are default adapter dependencies accessed through module namespaces so spies remain effective.
-- Package presence is injectable for conformance. Until a later observation implementation supplies a real probe, default Homebrew/winget observation is typed `indeterminate`, not fabricated absence or presence.
-- Do not migrate Cargo/Deno, capabilities, update buckets, catalog data, state, or command handlers.
+  Mock the new observation service, make legacy inspection calls fail if invoked, and assert existing success/error envelopes, ordering, source/update labels, versions, and install-method rendering.
 
-## Completion
+- [ ] **Step 2: Route list/info through the new boundary**
 
-- Start with failing provider tests for missing adapter modules.
-- Verify formula/cask/id commands, batch identity, typed outcomes, cancellation, timeout, and boolean compatibility routing.
-- Run focused legacy/update tests and the full repository gates.
-- Mark OpenSpec `4.4` only after both adapters and facade entries pass; keep `4.2` unchecked.
-- Write the report and checkpoint `refactor(providers): migrate brew and winget adapters`.
+  Keep the existing result interfaces and presenters unchanged. Do not expose drift, receipt, provider target, or capability arrays in v1 output.
+
+- [ ] **Step 3: Run command and compatibility gates**
+
+  Run:
+
+  ```bash
+  bun run test -- test/commands/list.test.ts test/commands/info.test.ts test/compatibility/v1-baseline.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `refactor(readonly): migrate list and info observations`

--- a/.superpowers/sdd/task-4-report.md
+++ b/.superpowers/sdd/task-4-report.md
@@ -1,28 +1,27 @@
-# Task 4 Report: Migrate Homebrew And winget Adapters
+# Task 4 Report: Migrate List And Info Observations
 
 ## Result
 
-OpenSpec `4.4` is complete. Homebrew and winget now expose typed availability, observation, mutation, verification, cancellation, timeout, failure, and evidence behavior. Homebrew preserves formula versus cask identity; winget preserves exact package IDs.
+`list` and `info` now consume `observeRegisteredAgents` and `resolveAgentObservation`, respectively, then pass observations through the existing one-way v1 inspection projection. Their `CommandResult` data and human presenters remain unchanged.
 
-The maintained `ManagedInstaller` entries route through the typed adapters and project typed success back to booleans. Default dependencies still call the existing low-level Homebrew/winget modules through namespace properties.
+The migration does not expose lifecycle drift, receipts, provider targets, or capability arrays. `inspect`, `resolve`, `capabilities`, `doctor`, mutation/execution commands, and legacy service exports remain on their prior routes.
 
 ## TDD evidence
 
-- Red: the system-provider suite failed because the Homebrew/winget adapter modules did not exist.
-- Red: compatibility tests proved both `ManagedInstaller` entries still bypassed the typed adapters.
-- Green: both adapters pass the shared conformance harness and provider-specific formula/cask/id command assertions.
-- The existing cancellation/timeout race was extracted without behavior change into one shared legacy-operation helper rather than duplicated.
+- Red: three command route-boundary tests and one v1 compatibility test failed because `list` and `info` still invoked legacy inspection; the legacy spies intentionally rejected every call.
+- Green: the same tests pass with the commands routed through lifecycle observations and the existing v1 projection.
+- Route tests lock registry ordering, success/error envelopes, source/update labels, versions, JSON omission behavior, and install-method rendering.
+- Review probe: the prior partial assertions still passed after deliberately adding `drift` to `info.data.agent`; the replacement exact fixture failed on that field before the probe was removed.
+- Strict compatibility fixtures now lock complete JSON results and NDJSON result events, including `info.data.agent`, `info.data.inspection`, envelope, target, warnings, and metadata.
 
 ## Validation
 
-- Focused provider/compatibility/update suite: 4 files / 106 tests passed.
-- Full suite: 72 files / 811 tests passed.
-- lint: 0 warnings / 0 errors.
-- format check, typecheck, OpenSpec 16/16, and memory check passed.
+- Brief-focused command and compatibility gate: 3 files / 13 tests passed.
+- Lifecycle observation service and v1 projection gate: 2 files / 14 tests passed.
+- Format check, lint, and typecheck passed.
 
-## Scope retained
+## State
 
-- Default Homebrew/winget presence remains typed `indeterminate` until a real observation probe is introduced; no presence is fabricated.
-- Cargo/Deno and later providers remain unmigrated.
-- OpenSpec `4.2` remains unchecked until every first-party provider runs the conformance suite.
-- Capability-table, update-bucket, catalog, command, and state migration remain untouched.
+- Independent re-review approved Task 4 with no Critical, Important, or Minor findings.
+- The controller reran the combined 5-file / 27-test command, compatibility, service, and projection gate plus format, lint, and typecheck successfully.
+- OpenSpec `5.3` remains unchecked for controller-owned review and integration closure.

--- a/.superpowers/sdd/task-5-brief.md
+++ b/.superpowers/sdd/task-5-brief.md
@@ -1,19 +1,33 @@
-# Task 5 Brief: Migrate Cargo And Deno Adapters
+### Task 5: Migrate inspect and resolve without v1 drift (OpenSpec 5.4)
 
-## Objective
+**Files:**
+- Modify: `src/commands/inspect.ts`
+- Modify: `src/commands/resolve.ts`
+- Modify: `test/commands/inspect.test.ts`
+- Modify: `test/commands/resolve.test.ts`
+- Modify: `test/compatibility/v1-baseline.test.ts`
 
-Migrate Cargo and Deno to typed adapters while preserving Cargo argument ordering/forced reinstall and Deno global-install arguments/executable-name uninstall semantics. Route both maintained `ManagedInstaller` entries through typed compatibility projections.
+**Interfaces:**
+- Consumes: resolved agent observation and v1 projection.
+- Produces: unchanged inspect capabilities/inspection fields and resolve success/guidance/error contracts.
 
-## Boundary
+- [ ] **Step 1: Add failing route and compatibility tests**
 
-- Reuse the typed system-package adapter and shared legacy-operation helper.
-- Cargo target arguments follow the crate name; update inserts `--force` before configured arguments.
-- Deno install arguments precede the package reference; update adds `--force`; uninstall uses `binaryName` when bound.
-- Default presence remains indeterminate rather than fabricated.
-- Do not touch pip/uv/mise, capabilities, catalog, commands, or state.
+  Cover installed managed, installed untracked, absent, ghost, conflicting/indeterminate, alias, unknown, and install-guidance cases. Lock `AGENT_NOT_FOUND`, `AGENT_NOT_INSTALLED`, docs refs, suggested ensure command, launch argv, source label, install source, and capabilities.
 
-## Completion
+- [ ] **Step 2: Route inspect/resolve through observation**
 
-- Add failing provider and compatibility tests first.
-- Run Cargo/Deno conformance, existing low-level tests, package-manager/update compatibility, and full gates.
-- Mark only OpenSpec `4.5`, keep `4.2` unchecked, report, and checkpoint commit.
+  A ghost or inconclusive internal state must not be reported installed solely from persisted state. Preserve existing install guidance and strict structured fields.
+
+- [ ] **Step 3: Run focused and protocol gates**
+
+  Run:
+
+  ```bash
+  bun run test -- test/commands/inspect.test.ts test/commands/resolve.test.ts test/compatibility/v1-baseline.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `refactor(readonly): migrate inspect and resolve observations`

--- a/.superpowers/sdd/task-5-report.md
+++ b/.superpowers/sdd/task-5-report.md
@@ -1,28 +1,31 @@
-# Task 5 Report: Migrate Cargo And Deno Adapters
+# Task 5 Report: Migrate Inspect And Resolve Observations
 
 ## Result
 
-OpenSpec `4.5` is complete. Cargo and Deno now expose the typed provider contract through the shared system-package adapter. Cargo preserves configured argument ordering and forced reinstall updates; Deno preserves global install argument ordering and executable-name uninstall identity.
+`inspect` and `resolve` now consume `resolveAgentObservation` and project the resolved observation through the existing one-way v1 inspection boundary. Their human, JSON, and NDJSON result contracts remain unchanged.
 
-The maintained `ManagedInstaller` entries route through the typed adapters and continue projecting typed success to booleans. Their default dependencies preserve the existing low-level call shapes, including absent optional arguments and Deno batch `binaryName` values.
+Live PATH evidence remains authoritative for installed status. Absent, ghost, conflicting, and indeterminate observations are not reported as installed solely because persisted state or a receipt exists. Managed and untracked installations retain their prior source labels, install sources, lifecycle values, versions, and launch argv.
 
 ## TDD evidence
 
-- Red: the provider suite failed until Cargo and Deno typed adapters existed.
-- Red: existing package-manager tests detected empty arrays replacing optional arguments and missing Deno batch executable names.
-- Green: both adapters pass the shared conformance harness and provider-specific command/evidence assertions.
-- Compatibility tests prove Cargo arguments and Deno executable names cross the maintained facade without loss.
+- Red: route and compatibility tests failed while `inspect` and `resolve` still invoked the legacy inspection service; rejecting legacy-service spies made the old route observable.
+- Green: both commands now resolve observations and use `projectObservationToV1Inspection` before producing v1 data.
+- Command tests cover managed, untracked, absent, ghost, conflicting, indeterminate, alias, unknown-agent, and install-guidance cases.
+- Strict JSON and NDJSON fixtures lock `AGENT_NOT_FOUND`, `AGENT_NOT_INSTALLED`, docs references, suggested ensure commands, launch argv, source labels, install sources, and the existing inspect capability object.
+- Negative assertions prevent drift, receipts, provider targets, provider capability arrays, and other internal observation evidence from leaking into v1 output.
+- Exact human-output fixtures lock installed and unknown `inspect` output plus installed, not-installed guidance, and unknown `resolve` output, including Capabilities, Update Mode, Path, Launch, Install Type, ensure guidance, and unknown-agent text.
+- Exact JSON and NDJSON failure fixtures cover both commands' `AGENT_NOT_FOUND` results/events and `resolve`'s `AGENT_NOT_INSTALLED` guidance event, including metadata, warnings, targets, and the NDJSON result wrapper.
+- Review probes proved the human fixture catches call-sequence drift and the structured fixture rejects unexpected failure-envelope fields; the probes were removed after RED verification.
 
 ## Validation
 
-- Focused provider/package-manager/update suite: 6 files / 121 tests passed.
-- Full suite: 73 files / 832 tests passed.
-- lint: 0 warnings / 0 errors.
-- format check, typecheck, OpenSpec 16/16, and memory check passed.
+- Brief-focused command and compatibility gate: 3 files / 23 tests passed.
+- Lifecycle observation service and v1 projection gate: 2 files / 14 tests passed.
+- Format check, lint, and typecheck passed.
 
-## Scope retained
+## State
 
-- Cargo and Deno presence remains typed `indeterminate` until real observation probes are introduced.
-- pip, uv, mise, script, and standalone-binary providers remain unmigrated.
-- OpenSpec `4.2` remains unchecked until every first-party provider runs the conformance suite.
-- Capability derivation, catalog normalization, commands, and state migration remain untouched.
+- Independent re-review approved Task 5 with no Critical, Important, or Minor findings.
+- The controller reran the combined 5-file / 37-test command, compatibility, service, and projection gate plus format, lint, and typecheck successfully.
+- OpenSpec `5.4` remains unchecked for controller-owned review and integration closure.
+- `list`, `info`, `capabilities`, `doctor`, mutation/execution commands, and legacy service exports were not changed.

--- a/.superpowers/sdd/task-6-brief.md
+++ b/.superpowers/sdd/task-6-brief.md
@@ -1,19 +1,38 @@
-# Task 6 Brief: Migrate pip, uv, And mise Adapters
+### Task 6: Derive capabilities and doctor diagnostics from registries (OpenSpec 5.5–5.6)
 
-## Objective
+**Files:**
+- Create: `src/services/provider-observations.ts`
+- Create: `test/services/provider-observations.test.ts`
+- Modify: `src/commands/capabilities.ts`
+- Modify: `src/commands/doctor.ts`
+- Modify: `test/commands/capabilities.test.ts`
+- Modify: `test/commands/doctor.test.ts`
 
-Migrate pip, uv, and mise to typed adapters while preserving provider-specific command shapes, uv install arguments, and uv/mise presence and installed-version behavior. Route all three maintained `ManagedInstaller` entries through typed compatibility projections.
+**Interfaces:**
+- Consumes: `firstPartyProviderRegistry.list()`, `getCapabilities(id)`, provider `availability`, agent observations, and existing explicitly network-aware self inspection.
+- Produces: a typed provider availability/capability snapshot projected into the unchanged nine v1 installer fields and current doctor issue model.
 
-## Boundary
+- [ ] **Step 1: Add provider snapshot tests**
 
-- Extend the shared system-package adapter only with optional installed-version observation and explicit operation diagnostics.
-- pip keeps its existing command resolution and has no fabricated presence/version probe.
-- uv keeps `tool install`, `tool upgrade`, package arguments, and parsed tool-list presence/version behavior.
-- mise keeps global use/unuse, forced update, and parsed installed-tool presence/version behavior.
-- Do not touch script/binary providers, derived capabilities, catalog, commands, or state.
+  Prove each registry adapter is queried once, capabilities come from implemented operations, cancellation/timeout/unavailable outcomes stay typed, and script/binary providers are not added to the strict v1 `installers` projection.
 
-## Completion
+- [ ] **Step 2: Add command route tests**
 
-- Add failing provider and compatibility tests first.
-- Run conformance, existing low-level tests, package-manager/update compatibility, and full gates.
-- Mark only OpenSpec `4.6`, keep `4.2` unchecked, report, and checkpoint commit.
+  Make direct `isBunAvailable`/`isNpmAvailable`/etc. calls fail if used. Assert unchanged platform reasons, feature fields, self-upgrade projection, doctor installer booleans, issue codes, blocking flags, remediation commands, and explicitly network-aware self checks.
+
+- [ ] **Step 3: Route capabilities and doctor through shared snapshots**
+
+  Preserve exact v1 fields. Do not infer provider capabilities from duplicated command tables. Doctor agent issues consume live drift classifications but continue to emit only established issue/result fields.
+
+- [ ] **Step 4: Run focused gates and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/services/provider-observations.test.ts test/commands/capabilities.test.ts test/commands/doctor.test.ts test/providers/conformance.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `refactor(readonly): derive capabilities and diagnostics`

--- a/.superpowers/sdd/task-6-report.md
+++ b/.superpowers/sdd/task-6-report.md
@@ -1,28 +1,46 @@
-# Task 6 Report: Migrate pip, uv, And mise Adapters
+# Task 6 Report: Derive Capabilities And Doctor Diagnostics
 
 ## Result
 
-OpenSpec `4.6` is complete. pip, uv, and mise now expose typed availability, observation, mutation, verification, cancellation, timeout, failure, and evidence behavior. uv preserves tool arguments; uv and mise project parsed installed versions into typed observations.
+`capabilities` and `doctor` now consume one shared provider snapshot derived from
+`firstPartyProviderRegistry.list()`, `getCapabilities(id)`, and each adapter's typed `availability` operation.
+The strict v1 installer projection remains exactly the existing nine managed providers; script and binary adapters
+remain available to the internal registry without appearing in the v1 `installers` object.
 
-The maintained `ManagedInstaller` entries route mutations through typed adapters and project typed success back to booleans. Existing uv/mise presence and installed-version methods remain direct compatibility projections, while default adapter dependencies retain the existing low-level module call shapes.
+`doctor` now consumes live lifecycle observations and uses observation drift for agent diagnostics. The v1 agent,
+installer, self-upgrade, issue, blocking, remediation, platform-reason, feature, JSON, and human projections remain
+unchanged. Explicitly network-aware `inspectSelf()` checks remain scoped to these commands; no other command gained a
+network effect.
 
-## TDD evidence
+After review, the v1 feature projection also consumes a command capability snapshot derived from the authoritative
+command-contract registry flags and effects. The projection preserves every existing v1 feature field and value while
+removing the command module's duplicated support booleans.
 
-- Red: the provider suite failed until pip, uv, and mise typed adapters existed.
-- Red: compatibility tests proved their maintained installer entries still bypassed typed adapters.
-- Green: all three adapters pass the shared conformance harness, including typed version observations for uv and mise.
-- The shared system-package adapter now uses explicit operation identities in diagnostics instead of inferring them from provider-specific command positions.
+## TDD Evidence
+
+- Red: provider snapshot tests failed on the unimplemented snapshot and projection behavior.
+- Red: command route tests rejected every direct `is*Available` call; both legacy command routes failed.
+- Green: each registered adapter availability operation is invoked once, capabilities are obtained from the registry,
+  and cancelled, timed-out, and unavailable outcomes retain their typed form.
+- Green: command tests lock the nine strict installer keys, platform reasons, feature fields, self-upgrade projection,
+  installer booleans, established issue codes, blocking flags, remediation commands, and live-drift routing.
+- Negative projections prove script/binary providers and internal observation fields do not leak into v1 output.
+- Review RED removed `--yes`/`--refresh` and upgrade mutation/network effects from a registry fixture; the previous
+  hard-coded command projection incorrectly remained true.
+- Review GREEN derives feature support from registry flags/effects and uses a real timed-out provider observation to
+  prove indeterminate live drift does not fabricate an untracked-agent issue or alter established self remediation.
 
 ## Validation
 
-- Focused provider/package-manager/update suite: 6 files / 144 tests passed.
-- Full suite: 74 files / 860 tests passed.
-- lint: 0 warnings / 0 errors.
-- format check, typecheck, OpenSpec 16/16, and memory check passed.
+- Brief-focused gate: 4 files / 30 tests passed.
+- Observation and v1 protocol gate: 4 files / 36 tests passed.
+- Full suite: 95 files / 1034 tests passed.
+- Format check, lint, and typecheck passed.
 
-## Scope retained
+## State
 
-- pip presence remains typed `indeterminate`; no package-state probe is fabricated.
-- Script and standalone-binary candidates remain unmigrated.
-- OpenSpec `4.2` remains unchecked until every first-party provider runs the conformance suite.
-- Capability derivation, catalog normalization, commands, and state migration remain untouched.
+- Independent re-review approved Task 6 with no Critical, Important, or Minor findings.
+- The controller reran the combined 8-file / 58-test provider, command, observation, compatibility, inspect, and resolve gate plus format, lint, and typecheck successfully.
+- OpenSpec `5.5` and `5.6` remain unchecked for controller-owned review and integration closure.
+- Other read-only commands, mutation/execution paths, legacy routes, provider adapters, state, and self-upgrade behavior
+  were not changed.

--- a/.superpowers/sdd/task-7-brief.md
+++ b/.superpowers/sdd/task-7-brief.md
@@ -1,20 +1,47 @@
-# Task 7 Brief: Represent Script And Binary Effects
+### Task 7: Real-environment comparison and milestone closure (OpenSpec 5.7)
 
-## Objective
+**Files:**
+- Create: `scripts/read-only-lifecycle-smoke.ts`
+- Create: `test/read-only-lifecycle-smoke.test.ts`
+- Modify: `package.json`
+- Modify: `openspec/changes/redesign-lifecycle-engine/tasks.md`
 
-Represent script and standalone-binary installation as compile-time first-party providers whose targets carry an explicit shell-script or executable effect. Route maintained unmanaged installation through typed outcomes without changing existing catalog commands or platform coverage.
+**Interfaces:**
+- Consumes: the six migrated commands through the real CLI in a temporary HOME and the existing compatibility fixtures.
+- Produces: deterministic local/container smoke evidence without mutating agent/provider state.
 
-## Boundary
+- [x] **Step 1: Add a smoke harness test**
 
-- Add no dynamic provider loading and no new public CLI surface.
-- Existing string commands project to explicit `shell-script` effects at the compatibility boundary.
-- Direct argv execution is modeled as an `executable` effect without passing through a shell.
-- Script/binary providers install only; update and uninstall remain unsupported.
-- Capability-table and update-bucket derivation remain Task 8.
+  Run `list`, `info`, `inspect`, `resolve`, `capabilities`, and `doctor` in human and JSON modes against absent, tracked, untracked, and ghost fixtures. Assert parseable structured stdout, expected stable fields/error codes, no state-file byte changes, and no install/update/uninstall process invocation.
 
-## Completion
+- [x] **Step 2: Run the harness locally and in Bun container**
 
-- Add failing effect/provider/compatibility tests first.
-- Preserve legacy shell invocation on Windows and Unix.
-- Run focused package-manager/provider tests and full gates.
-- Mark only OpenSpec `4.7`, report, and checkpoint commit.
+  Run:
+
+  ```bash
+  bun run test:readonly-smoke
+  docker run --rm -v "$PWD:/mnt/quantex-cli:ro" oven/bun:1.3.11 sh -lc 'mkdir /tmp/quantex-work && cd /mnt/quantex-cli && tar --exclude=.git --exclude=node_modules --exclude=dist -cf - . | tar -xf - -C /tmp/quantex-work && cd /tmp/quantex-work && bun install --frozen-lockfile && bun run test:readonly-smoke'
+  ```
+
+  Expected: both environments pass; host-dependent availability/version values are normalized rather than golden-locked.
+
+- [x] **Step 3: Run the complete milestone gate**
+
+  Run:
+
+  ```bash
+  bun run format
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  bun run test
+  bun run openspec:validate
+  bun run memory:check
+  bun run build
+  ```
+
+- [x] **Step 4: Mark only OpenSpec 5.1–5.7 complete**
+
+  Confirm `bun run openspec:list` reports 37/74. Keep `redesign-lifecycle-engine` active and do not sync current specs or archive.
+
+  Commit: `test(readonly): verify observation migration`

--- a/.superpowers/sdd/task-7-report.md
+++ b/.superpowers/sdd/task-7-report.md
@@ -1,27 +1,36 @@
-# Task 7 Report: Represent Script And Binary Effects
+# Task 7 Report: Verify Read-Only Observation Migration
 
 ## Result
 
-OpenSpec `4.7` is complete. Script and standalone-binary candidates now have closed first-party provider identities and typed targets can carry either an explicit shell-script effect or a direct executable argv effect. No dynamic registration or loading surface was added.
+The real CLI smoke harness runs `list`, `info`, `inspect`, `resolve`, `capabilities`, and `doctor` in human and JSON modes across absent, tracked, untracked, and ghost Codex fixtures. Each fixture uses an isolated temporary HOME, controlled PATH sentinels, and a seeded version cache.
 
-The maintained unmanaged install path projects existing string commands into shell-script effects and projects typed success back to the existing boolean workflow. Unix continues to use `sh -c`; Windows continues to use `powershell.exe -Command`. Direct executable effects bypass the shell.
+The 48-invocation matrix verifies parseable JSON v1 envelopes, fixture-specific stable command fields and `AGENT_NOT_INSTALLED` guidance, meaningful human markers, unchanged state-file bytes after every command, and guarded read-only process execution. Host-dependent paths, versions, and availability values are normalized rather than golden-locked. The same canonical normalized summary is compared locally and in the Bun container.
 
-## TDD evidence
+## Debugging evidence
 
-- Red: effect tests failed until the install-effect adapter and typed effect model existed.
-- Green: tests prove platform-specific shell projection, direct argv execution, typed missing-effect failure, and absence of update/uninstall operations.
-- Package-manager compatibility proves legacy script installation retains its command and installed-state identity.
+- Initial focused RED: `absent/human/list` changed `state.json` bytes because source execution reconciled the unrelated self-install source and migrated the legacy fixture to schema v2.
+- Fix: the temporary HOME still consumes the existing v1 compatibility fixtures, but projects them to current state with the already-detected `source` self install source before starting the agent lifecycle smoke boundary.
+- Initial Docker RED: Bun 1.3.11 plus Vitest produced an undefined `z` while the smoke module imported the full agent catalog only to seed version-cache keys. Direct Bun 1.3.11 Zod imports worked.
+- Fix: cache setup reads the generated catalog support input instead. The child CLI still loads and executes the real production catalog and command paths.
 
 ## Validation
 
-- Focused provider/registry/package-manager suite: 3 files / 70 tests passed.
-- Full suite: 75 files / 865 tests passed.
-- lint: 0 warnings / 0 errors.
-- format check, typecheck, OpenSpec 16/16, and memory check passed.
+- Host focused smoke: 3 files / 24 tests passed; 48 real CLI invocations.
+- Host direct harness: 48 real CLI invocations passed.
+- `oven/bun:1.3.11` smoke: 3 files / 24 tests passed after frozen install in the read-only source-copy topology.
+- Full suite: 98 files / 1058 tests passed.
+- Format check passed; lint reported 0 warnings and 0 errors; typecheck passed.
+- OpenSpec validation passed 16/16; project memory check passed; build passed.
 
-## Scope retained
+## Review fixes
 
-- Existing catalog JSON remains unchanged; normalized candidate migration occurs in later catalog tasks.
-- Script/binary observation remains typed `indeterminate` until candidates declare probes.
-- Script/binary update and uninstall remain unsupported.
-- Capability-table and update-bucket derivation remain OpenSpec `4.8`.
+- Compatibility RED: three tests failed because no deterministic baseline, normalized summary, or fixture-swap rejection existed. GREEN locks list/info/inspect/resolve lifecycle, source, update, error, and guidance fields; capabilities/doctor stable markers; command-specific human markers; and fixture state/executable identity. Swapping tracked/untracked or absent/ghost now fails baseline comparison.
+- Mutation-guard RED: fourteen deliberate mutation/effect probes lacked `READ_ONLY_MUTATION_BLOCKED`, while two observation probes could not run without the preload. A later self-review RED proved a probe-shaped package name could bypass the Bun rule. GREEN uses a real Bun preload to intercept child CLI `Bun.spawn`/`spawnSync`, allows only exact declared observation probes, records every allowed spawn, and rejects provider mutations, mise `use`/`unuse`, shell/script execution, and unknown executable effects. Seventeen guard tests pass.
+- Timeout RED: two tests failed because no bounded child-wait API existed. GREEN proves normal close resolution and hung-child SIGTERM -> grace -> SIGKILL rejection; real CLI commands use the same 30-second timeout and one-second hard-kill grace.
+
+## State
+
+- OpenSpec `5.1` through `5.7` are complete; `redesign-lifecycle-engine` is active at 37/74.
+- Independent re-review approved Task 7 with no Critical, Important, or Minor findings.
+- The controller reran the 3-file / 24-test real-CLI smoke gate plus format, lint, typecheck, OpenSpec 16/16, and memory checks successfully; OpenSpec remains active at 37/74.
+- Task 8, current-spec synchronization, archive closure, push, PR, and release work remain intentionally out of scope.

--- a/.superpowers/sdd/task-8-brief.md
+++ b/.superpowers/sdd/task-8-brief.md
@@ -1,21 +1,49 @@
-# Task 8 Brief: Derive Capabilities And Update Buckets
+### Task 8: Review, normalize, push, and PR to integration
 
-## Objective
+**Files:**
+- Create ignored PR body: `.tmp/observation-readonly-pr-body.md`
 
-Create the single compile-time first-party adapter registry and derive legacy installer capabilities plus update bucket ordering from registered operations. Preserve all public capability results and update presentation order.
+**Interfaces:**
+- Consumes: reviewed milestone tree and latest remote integration head.
+- Produces: one-commit PR `codex/redesign-observation-readonly` → `codex/redesign-lifecycle-integration`.
 
-## Boundary
+- [ ] **Step 1: Request independent review**
 
-- No dynamic provider registration or loading.
-- `getInstallerCapabilities` and related compatibility helpers retain their names and semantics.
-- A provider is managed only when its registered adapter implements update and uninstall.
-- npm/Bun latest-version lookup remains derived from `resolveLatestVersion`.
-- Planning and service update buckets consume the same derived managed-provider order.
-- Do not touch catalog candidate schema or entries.
+  Review observation correctness, provider/receipt conflict handling, pure planner behavior, read-only/no-lock/no-write guarantees, v1 projection compatibility, network effects, and real-environment evidence. Resolve every blocker/important finding with TDD.
 
-## Completion
+- [ ] **Step 2: Re-fetch and rebase if integration advanced**
 
-- Add failing first-party registry/capability/order tests first.
-- Remove the duplicated capability table and both hard-coded update enumerations.
-- Run focused planning/service/provider tests and full gates.
-- Mark only OpenSpec `4.8`, report, and checkpoint commit.
+  Compare `merge-base` with `origin/codex/redesign-lifecycle-integration`. Rebase onto latest integration if needed and rerun the full gate.
+
+- [ ] **Step 3: Preserve checkpoints and normalize**
+
+  Retain granular history on `codex/redesign-observation-readonly-checkpoints`, then normalize the delivery branch to one commit:
+
+  ```text
+  refactor: migrate lifecycle observations and read-only commands
+  ```
+
+  Verify the pre/post normalization tree ids match.
+
+- [ ] **Step 4: Validate and create the PR**
+
+  Build the body from `.github/pull_request_template.md`, run:
+
+  ```bash
+  bun run pr:body:check -- --body-file .tmp/observation-readonly-pr-body.md --title "refactor: migrate lifecycle observations and read-only commands"
+  ```
+
+  Push and create a ready PR with base `codex/redesign-lifecycle-integration`.
+
+- [ ] **Step 5: Verify remote closure**
+
+  Require CI, Sandbox Tests when classified, OpenSpec, memory, and governance checks to pass. Confirm no Release workflow/npm publication. After review, rebase-merge with expected-head protection; use squash only if rebase is unavailable/unsafe. Verify the merged integration tree equals the reviewed tree and keep OpenSpec active.
+
+## Self-Review
+
+- Spec coverage: Tasks 1–7 map exactly to OpenSpec 5.1–5.7; Task 8 owns the required milestone delivery closure.
+- Scope: no update/idempotency, execution, self-upgrade, schema-v2 output, dynamic providers, workflow orchestration, release, or archive work is included.
+- Compatibility: every command migration retains its existing result interface/presenter and uses an explicit v1 projection.
+- Failure safety: provider/receipt conflicts and unavailable probes remain internal drift/indeterminate evidence; read-only commands never repair state.
+- Type consistency: `AgentLifecycleObservationResult`, `resolveAgentObservation`, `observeRegisteredAgents`, `projectObservationToV1Inspection`, and provider snapshot interfaces are defined before command consumers.
+- Placeholder scan: no unresolved placeholder markers remain.

--- a/.superpowers/sdd/task-8-report.md
+++ b/.superpowers/sdd/task-8-report.md
@@ -1,27 +1,105 @@
-# Task 8 Report: Derive Capabilities And Update Buckets
+# Task 8 Report: Review, Normalize, And Deliver Observation Milestone
 
-## Result
+## Current state
 
-OpenSpec `4.8` is complete. One compile-time first-party adapter registry now contains every managed, script, and binary provider. The maintained installer capability API derives install, target-version lookup, update, uninstall, and lifecycle results from the adapter operations in that registry.
+Six review fix waves are complete. Delivery normalization, push, and PR creation remain paused pending another whole-branch re-review.
 
-Planning and service-layer update buckets consume the same derived managed-provider sequence. The historical bun, npm, brew, cargo, deno, mise, pip, uv, winget ordering remains unchanged.
+## Fix evidence
 
-## TDD evidence
-
-- Red: first-party tests failed until the concrete compile-time registry and managed-order projection existed.
-- Green: tests compare every compatibility capability with actual registered operations and lock the maintained update order.
-- Full compatibility testing caught an accidental new root-package export; the internal helper was removed from the public facade instead of changing the v1 fixture.
+1. Read-only self inspection now detects install source without reconciling or persisting it. Capabilities, doctor, and passive human notices use that path; passive notices retain current output and self target resolution without writing update-notice state. The real CLI smoke no longer pre-fills self source, covers legacy/current/missing self fields plus latest-greater-than-current human output, and compares the complete config-directory file set and bytes after every command.
+2. Lifecycle observations now create cancellation and timeout state per invocation. Registry and system provider availability, package presence, and installed-version probes consume the same context. npm, Bun, mise, and uv observation spawns use bounded process-tree termination; providers whose presence probe is a fixed in-process unknown have no child to cancel. A real CLI `--timeout 100ms` case locks the established `TIMEOUT` envelope and exit code, while the production process runner test proves a hanging fake npm process plus grandchild are both terminated after the same 100ms provider deadline.
 
 ## Validation
 
-- Focused provider/update/package-manager suite: 5 files / 100 tests passed.
-- Full suite: 76 files / 868 tests passed.
-- lint: 0 warnings / 0 errors.
-- format check, typecheck, OpenSpec 16/16, and memory check passed.
+- Focused observation/provider/command/package-manager gate: 16 files / 168 tests passed, followed by the expanded lifecycle gate.
+- Read-only smoke: 4 files / 26 tests passed locally.
+- Bun 1.3.11 container: 4 files / 26 tests passed after frozen install.
+- Full suite: 99 files / 1061 tests passed.
+- Format check, lint (0 warnings / 0 errors), typecheck, OpenSpec 16/16, project memory, and build passed.
 
-## Scope retained
+## Second-wave review findings
 
-- The v1 root-package runtime export list is unchanged.
-- The catalog schema and entries remain in their compatibility shape.
-- OpenSpec `4.2` remains unchecked pending the final first-party conformance closure.
-- Candidate normalization and generated support documentation remain later provider/catalog tasks.
+1. `capabilities` and `doctor` provider snapshots do not register live CLI cancellation handlers, so hanging probes may survive SIGINT/SIGTERM when no timeout is configured.
+2. Context-aware process timeouts can be swallowed by availability and package-probe helpers, degrading typed `timed-out`/`cancelled` outcomes to `unavailable` or `indeterminate`.
+3. The latest-greater-than-current passive notice path lacks a positive compatibility assertion proving that human notice output remains while notice state stays unchanged.
+
+## Second-wave fix evidence
+
+1. A shared CLI operation context now supplies invocation-scoped signal and timeout, registers and unregisters one cancellation handler, tracks live work, and joins cleanup before cancellation completes. Lifecycle observations, capabilities, and doctor all use it. Real CLI SIGINT and SIGTERM tests run capabilities without a timeout, require the established exit `11` / `CANCELLED` envelope, and prove the hanging provider parent and grandchild are gone before exit.
+2. Context-aware process interruption now crosses helper boundaries as typed `timed-out` or `cancelled` evidence. Contextual adapters wait for process-tree cleanup instead of racing it; legacy no-context boolean/unknown behavior is unchanged. First-party conformance covers timeout and cancellation for all nine managed provider availability probes plus npm, Bun, mise, and uv package-presence and installed-version probes, including clean process trees.
+3. Passive human notices now have positive exact-output coverage for latest greater than current while asserting no update-notice setter call. The real CLI baseline requires the exact `99.0.0` notice marker and retains complete config-directory file/byte equality after every command.
+
+## Second-wave validation
+
+- Focused cancellation, provider, command, and package-manager gate: 17 files / 162 tests passed.
+- Expanded read-only smoke: 5 files / 28 tests passed locally.
+- Bun 1.3.11 container: 5 files / 28 tests passed after frozen install.
+- Full suite: 102 files / 1070 tests passed.
+- Format check, lint (0 warnings / 0 errors), typecheck, OpenSpec 16/16, project memory, and build passed.
+
+## Third-wave fix evidence
+
+- Third whole-branch review confirmed the typed provider interruption and passive-notice findings are closed, but found that cancellation still joined the entire application promise without a bound. A mixed cache-miss or hanging agent-version task could therefore delay `CANCELLED` even when provider child cleanup succeeded.
+- The third fix wave separated application cancellation from explicitly registered resource cleanup. Cancellation races the application promptly, gives registered resources a bounded graceful window, then invokes bounded force cleanup. Process observations and self network fetches consume the shared context; Windows tree cleanup is locked to `taskkill.exe /PID <pid> /T /F`.
+- A real no-timeout `doctor` regression combines a self cache miss with hanging provider and agent-version parent/grandchild trees. SIGINT and SIGTERM retain exit `11` and the established `CANCELLED` envelope, finish within the 3-second contract, and leave all four PIDs stopped. Unit coverage also proves never-settling application work cannot block cancellation and never-settling cleanup advances to force cleanup.
+
+## Third-wave validation
+
+- Full suite: 102 files / 1074 tests passed.
+- Expanded read-only smoke: 5 files / 28 tests passed locally and in the Bun 1.3.11 container after frozen install.
+- Format check, lint (0 warnings / 0 errors), typecheck, OpenSpec 16/16, project memory, and build passed.
+- OpenSpec `5.7` is complete again; observation/read-only migration is 7/7 and the full change is 37/74.
+
+## Fourth-wave fix evidence
+
+- Fourth whole-branch review confirmed process cleanup and bounded application cancellation are closed, but found that fetch cancellation ended at response headers. A slow or never-ending response body could outlive cancellation and later write version cache state.
+- Network attempts now retain the external invocation signal and per-attempt timeout through request, response-body consumption, and JSON validation. The response reader is an explicit shared cleanup resource; cancellation aborts the request, explicitly cancels the reader with a bounded settle, preserves typed `cancelled` / `timed-out` evidence, and unregisters listeners and cleanup after the complete response lifecycle.
+- Version and self-release cache paths recheck cancellation before cache mutation, persistence, fallback freshness, and network freshness. Self binary-release planning preserves typed interruption instead of degrading it to a network-resolution result.
+- A real local server returns headers and a partial JSON prefix but never ends the body. Shared-invocation version cancellation, direct self-release cancellation, and a 100ms per-attempt timeout all finish in roughly 110-140ms, close the server stream, and preserve the complete config/cache directory listing and bytes. Existing normal-body, retry, and cache regressions remain green.
+
+## Fourth-wave validation
+
+- Focused network, version, self, runtime, command-runtime, and mixed process-signal gate: 8 files / 93 tests passed.
+- Expanded read-only smoke: 5 files / 28 tests passed locally.
+- Bun 1.3.11 container with slow-body coverage: 6 files / 32 tests passed after frozen install.
+- Full suite: 103 files / 1078 tests passed.
+- Format check, lint (0 warnings / 0 errors), typecheck, OpenSpec 16/16, project memory, and build passed.
+- OpenSpec `5.7` is complete again; observation/read-only migration is 7/7 and the full change is 37/74.
+
+## Fifth-wave fix evidence
+
+- Fifth whole-branch review confirmed slow-body cancellation and cache safety, but found that an internal network-attempt timeout was incorrectly promoted to command-level typed `TIMEOUT` without an invocation deadline.
+- Internal `networkTimeoutMs` exhaustion now uses a private network-attempt error, retains the established retry budget, cancels the active response body with the same bounded cleanup, and returns the legacy unavailable/stale result after retries are exhausted. Only an external invocation signal produces typed `ProcessInterruptionError`; explicit CLI deadlines retain the established `TIMEOUT` envelope.
+- Version lookup without invocation context returns `undefined` or an unchanged stale cache entry. Binary self planning maps internal exhaustion to `resolutionError.network`. External version and self cancellation remain typed and close the server stream without cache changes.
+- No-timeout `list`, `info`, `capabilities`, and `doctor` retain successful v1 projections with latest-version data unavailable. The six read-only command suites and explicit timeout regressions remain green, as do normal body, retry, HTTP status, cache-hit, and cache-write cases.
+
+## Fifth-wave validation
+
+- Focused network, version, self, command-runtime, six-command, and explicit-timeout gate: 15 files / 133 tests passed.
+- Expanded read-only smoke: 5 files / 28 tests passed locally.
+- Bun 1.3.11 container network lifecycle plus real CLI smoke: 6 files / 35 tests passed after frozen install.
+- Full suite: 104 files / 1082 tests passed.
+- Format check, lint (0 warnings / 0 errors), typecheck, OpenSpec 16/16, project memory, and build passed.
+- OpenSpec `5.7` is complete again; observation/read-only migration is 7/7 and the full change is 37/74.
+
+## Sixth-wave fix evidence
+
+- Sixth whole-branch review confirmed internal timeout fallbacks, but found a request-before-headers race where transport `AbortError` could beat the already-recorded typed invocation timeout and be swallowed as an ordinary network failure.
+- Fetch-attempt arbitration now checks recorded local interruption after any transport rejection, awaits the bounded response cleanup, and then throws the authoritative interruption. Typed invocation cancellation or timeout can upgrade an internal attempt timeout; unrelated transport failures retain legacy retry/fallback behavior.
+- Direct headerless transport tests prove a 20ms invocation deadline remains typed `timed-out`, external abort remains typed `cancelled`, and an internal headerless timeout remains legacy `undefined`. Existing headers, body, validation, self, stale-cache, retry, status, cache-hit, and cache-write coverage remains green and cache-safe.
+- A real CLI preload keeps fetch pending before headers and rejects immediately when aborted. `capabilities --timeout 100ms` retains exit `10` and the established `TIMEOUT` envelope, emits no late success, and leaves the complete config-directory listing and bytes unchanged.
+
+## Sixth-wave validation
+
+- Focused network, version, self, command-runtime, real CLI, and explicit-timeout gate: 10 files / 101 tests passed.
+- Expanded read-only smoke: 5 files / 28 tests passed locally.
+- Bun 1.3.11 container network lifecycle, headerless real CLI, and smoke: 7 files / 39 tests passed after frozen install.
+- Full suite: 105 files / 1086 tests passed.
+- Format check, lint (0 warnings / 0 errors), typecheck, OpenSpec 16/16, project memory, and build passed.
+- OpenSpec `5.7` is complete again; observation/read-only migration is 7/7 and the full change is 37/74.
+
+## Recovery state
+
+- Final whole-branch re-review of `7b1dcf5..4066817` found no Critical, Important, or Minor issues and returned `Ready to merge: Yes`.
+- Preserve all current checkpoints and fix commits before delivery normalization.
+- Next: fetch the latest integration head, retain the checkpoint branch, normalize to one tree-identical commit, rerun the full delivery gate, and create the integration PR.

--- a/docs/superpowers/plans/2026-07-12-observation-readonly-milestone.md
+++ b/docs/superpowers/plans/2026-07-12-observation-readonly-milestone.md
@@ -1,0 +1,351 @@
+# Observation and Read-Only Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete OpenSpec `redesign-lifecycle-engine` tasks 5.1–5.7 by introducing one live lifecycle observation boundary and routing all read-only agent/provider commands through it without changing v1 output contracts.
+
+**Architecture:** Add an application-level observer that combines catalog candidates, installed-state provenance, lifecycle receipts, executable/version evidence, exact provider observations, and registry-derived capabilities into the existing lifecycle domain model. Keep command result interfaces and human presenters as the v1 compatibility shell; commands consume an explicit compatibility projection rather than rebuilding lifecycle truth independently. The observer performs reads only, the planner remains pure, and provider availability is derived from the compile-time registry.
+
+**Tech Stack:** Bun 1.3.x, strict TypeScript, Vitest, OpenSpec, existing provider/state/inspection/output modules, oxlint, and oxfmt.
+
+## Global Constraints
+
+- Scope is OpenSpec 5.1–5.7 only; update/idempotency, agent execution, self-upgrade, command-registry completion, legacy removal, release, and archive closure remain deferred.
+- Preserve all v1 JSON/NDJSON field names, requiredness, error codes, exit mapping, stdout/stderr behavior, install guidance, package/binary names, and maintained root exports.
+- Do not add lifecycle/drift/provider metadata to strict v1 projections; keep richer evidence internal until a negotiated protocol version exists.
+- Read-only commands perform no state, receipt, provider, or lifecycle-lock mutation.
+- Keep the legacy `inspectRegisteredAgents` and `resolveAgentInspection` exports and semantics intact for ensure/install/run/update and other mutation/execution callers; only `list`, `info`, `inspect`, `resolve`, `capabilities`, and `doctor` may route through the new observation service in this milestone.
+- Provider failure or contradictory evidence fails closed as `indeterminate` or `conflicting-source`; persisted state never overrides the live environment.
+- `doctor` may retain its explicitly declared network checks; this milestone must not add fresh network effects to other commands.
+- Work in `/Users/drs/.codex/worktrees/quantex-observation-readonly` on `codex/redesign-observation-readonly`, based on latest `codex/redesign-lifecycle-integration`.
+- Keep recoverable checkpoint commits. Before PR delivery, retain checkpoint refs, normalize to one reviewed commit, and target `codex/redesign-lifecycle-integration`; rebase merge preferred, squash fallback, no merge commit or auto-merge.
+
+---
+
+### Task 1: Build the live agent lifecycle observer (OpenSpec 5.1)
+
+**Files:**
+- Create: `src/lifecycle/agent-observation.ts`
+- Create: `test/lifecycle/agent-observation.test.ts`
+- Modify: `src/lifecycle/model.ts`
+- Modify: `src/lifecycle/index.ts`
+- Modify: `src/lifecycle/provider-evidence.ts`
+
+**Interfaces:**
+- Consumes: `AgentDefinition`, `InstalledAgentState`, `LifecycleReceipt`, `ProviderRegistry`, `resolveStateProviderBinding`, `resolveReceiptProviderBinding`, `observeLifecycleProvider`.
+- Produces: `observeAgentLifecycle(agent, ports): Promise<AgentLifecycleObservationResult>` where the result contains the domain `LifecycleObservation`, exact provider binding/capabilities when resolvable, executable/version facts, installed-state provenance, receipt, and normalized catalog methods.
+
+- [ ] **Step 1: Write table-driven failing observation tests**
+
+  Cover: absent/no evidence, live untracked executable, verified tracked state+receipt, legacy tracked state without receipt, conclusive ghost, state/receipt provider conflict, provider-present/PATH-absent conflict, provider-absent/PATH-present conflict, unsupported binding, and indeterminate provider outcome. For agents without state or receipt, explicitly cover one candidate provider present, multiple candidate providers present, and candidate probe failure while PATH is present. Assert provider id, target id/kind, capabilities, drift kind, version/path, and that no state mutator is called.
+
+- [ ] **Step 2: Verify the tests fail for the missing observer**
+
+  Run: `bun run test -- test/lifecycle/agent-observation.test.ts`
+
+  Expected: FAIL because `observeAgentLifecycle` is not defined.
+
+- [ ] **Step 3: Implement minimal injected observation ports**
+
+  Define ports for clock, executable/path/version inspection, installed-state/receipt reads, provider registry, and provider observation. Use exact state/receipt bindings; compare provider id, target id, target kind, and executable identity. When no persisted binding exists, observe every catalog candidate: exactly one live candidate may establish provider ownership, multiple live candidates classify as `conflicting-source`, and any unresolved candidate probe that prevents a conclusive decision classifies as `indeterminate`. PATH presence alone never establishes provider ownership. Preserve typed provider outcomes rather than branching on messages.
+
+- [ ] **Step 4: Make drift classification explicit and exhaustive**
+
+  Use only `none`, `untracked`, `recorded-absent`, `conflicting-source`, and `indeterminate`. A present executable is not proof of provider ownership; a receipt is provenance, not live proof.
+
+- [ ] **Step 5: Run the focused gate and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/lifecycle/agent-observation.test.ts test/lifecycle/provider-evidence.test.ts test/state.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `feat(lifecycle): observe live agent evidence`
+
+### Task 2: Complete deterministic planning over observation states (OpenSpec 5.2)
+
+**Files:**
+- Modify: `src/lifecycle/mutation-planner.ts`
+- Modify: `src/lifecycle/model.ts`
+- Modify: `test/lifecycle/mutation-planner.test.ts`
+- Create: `test/lifecycle/observation-planning.test.ts`
+
+**Interfaces:**
+- Consumes: `LifecycleObservation`, requested `LifecycleIntent`, exact provider binding, and registry-derived capabilities.
+- Produces: deterministic `LifecycleMutationPlanningResult` with decisions for satisfied, install, adopt, preserve-unmanaged, clear-ghost, uninstall, unsupported, and blocked.
+
+- [ ] **Step 1: Add failing planner matrix tests**
+
+  Use one row for every required state: already-satisfied, absent, tracked, untracked, ghost, conflicting, unsupported, and indeterminate. Repeat each row to prove stable plan ids, step ordering, effects, and postconditions.
+
+- [ ] **Step 2: Verify unsupported and contradictory rows fail**
+
+  Run: `bun run test -- test/lifecycle/mutation-planner.test.ts test/lifecycle/observation-planning.test.ts`
+
+  Expected: FAIL until capability-aware decisions exist.
+
+- [ ] **Step 3: Extend the pure planner only**
+
+  Add no filesystem, process, provider, console, output-envelope, or Commander imports. An absent required provider capability returns `unsupported`; conflicting/indeterminate observations return `blocked`; read-only callers may consume the plan without executing it.
+
+- [ ] **Step 4: Run focused tests and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/lifecycle/mutation-planner.test.ts test/lifecycle/observation-planning.test.ts test/lifecycle/shadow-planning.test.ts test/commands/ensure.test.ts test/commands/install.test.ts test/commands/uninstall.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `refactor(lifecycle): plan from live observations`
+
+### Task 3: Add the read-only application and v1 projection boundary
+
+**Files:**
+- Create: `src/services/lifecycle-observations.ts`
+- Create: `src/compatibility/agent-inspection.ts`
+- Create: `test/services/lifecycle-observations.test.ts`
+- Create: `test/compatibility/agent-inspection.test.ts`
+- Modify: `src/services/agents.ts`
+
+**Interfaces:**
+- Consumes: agent registry, live observer, current catalog method formatting inputs, and existing `AgentInspection` semantics.
+- Produces: `resolveAgentObservation(name)` and `observeRegisteredAgents()` plus `projectObservationToV1Inspection(result): AgentInspection`.
+
+The existing `inspectRegisteredAgents` and `resolveAgentInspection` exports remain on the legacy implementation for mutation and execution consumers. Add an import/route boundary test that fails if this milestone rewires ensure/install/run/update or removes those exports; only the six read-only commands consume the new service.
+
+- [ ] **Step 1: Add failing service tests for aliases, ordering, and unknown agents**
+
+  Assert canonical registry order, alias resolution, one observation per agent, no provider/state mutation, and unchanged legacy service exports for non-read-only callers.
+
+- [ ] **Step 2: Add failing compatibility projection tests**
+
+  Lock current meanings of `inPath`, `binaryPath`, `resolvedBinaryPath`, `installedVersion`, `latestVersion`, `lifecycle`, `sourceLabel`, and `updateLabel` across tracked, untracked, ghost, conflicting, and indeterminate internal observations.
+
+- [ ] **Step 3: Implement the application service and one-way compatibility adapter**
+
+  Domain/application code must not import output envelopes or presenters. The compatibility adapter may reuse current label helpers but must omit new drift/capability fields from v1 objects.
+
+- [ ] **Step 4: Run focused tests and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/services/lifecycle-observations.test.ts test/compatibility/agent-inspection.test.ts test/commands/list.test.ts test/commands/info.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `feat(observation): add read-only application boundary`
+
+### Task 4: Migrate list and info without v1 drift (OpenSpec 5.3)
+
+**Files:**
+- Modify: `src/commands/list.ts`
+- Modify: `src/commands/info.ts`
+- Modify: `test/commands/list.test.ts`
+- Modify: `test/commands/info.test.ts`
+- Modify: `test/compatibility/v1-baseline.test.ts`
+
+**Interfaces:**
+- Consumes: `observeRegisteredAgents`, `resolveAgentObservation`, and the v1 inspection projection.
+- Produces: unchanged `list` and `info` `CommandResult` data and human presentation.
+
+- [ ] **Step 1: Add route-boundary tests**
+
+  Mock the new observation service, make legacy inspection calls fail if invoked, and assert existing success/error envelopes, ordering, source/update labels, versions, and install-method rendering.
+
+- [ ] **Step 2: Route list/info through the new boundary**
+
+  Keep the existing result interfaces and presenters unchanged. Do not expose drift, receipt, provider target, or capability arrays in v1 output.
+
+- [ ] **Step 3: Run command and compatibility gates**
+
+  Run:
+
+  ```bash
+  bun run test -- test/commands/list.test.ts test/commands/info.test.ts test/compatibility/v1-baseline.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `refactor(readonly): migrate list and info observations`
+
+### Task 5: Migrate inspect and resolve without v1 drift (OpenSpec 5.4)
+
+**Files:**
+- Modify: `src/commands/inspect.ts`
+- Modify: `src/commands/resolve.ts`
+- Modify: `test/commands/inspect.test.ts`
+- Modify: `test/commands/resolve.test.ts`
+- Modify: `test/compatibility/v1-baseline.test.ts`
+
+**Interfaces:**
+- Consumes: resolved agent observation and v1 projection.
+- Produces: unchanged inspect capabilities/inspection fields and resolve success/guidance/error contracts.
+
+- [ ] **Step 1: Add failing route and compatibility tests**
+
+  Cover installed managed, installed untracked, absent, ghost, conflicting/indeterminate, alias, unknown, and install-guidance cases. Lock `AGENT_NOT_FOUND`, `AGENT_NOT_INSTALLED`, docs refs, suggested ensure command, launch argv, source label, install source, and capabilities.
+
+- [ ] **Step 2: Route inspect/resolve through observation**
+
+  A ghost or inconclusive internal state must not be reported installed solely from persisted state. Preserve existing install guidance and strict structured fields.
+
+- [ ] **Step 3: Run focused and protocol gates**
+
+  Run:
+
+  ```bash
+  bun run test -- test/commands/inspect.test.ts test/commands/resolve.test.ts test/compatibility/v1-baseline.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `refactor(readonly): migrate inspect and resolve observations`
+
+### Task 6: Derive capabilities and doctor diagnostics from registries (OpenSpec 5.5–5.6)
+
+**Files:**
+- Create: `src/services/provider-observations.ts`
+- Create: `test/services/provider-observations.test.ts`
+- Modify: `src/commands/capabilities.ts`
+- Modify: `src/commands/doctor.ts`
+- Modify: `test/commands/capabilities.test.ts`
+- Modify: `test/commands/doctor.test.ts`
+
+**Interfaces:**
+- Consumes: `firstPartyProviderRegistry.list()`, `getCapabilities(id)`, provider `availability`, agent observations, and existing explicitly network-aware self inspection.
+- Produces: a typed provider availability/capability snapshot projected into the unchanged nine v1 installer fields and current doctor issue model.
+
+- [ ] **Step 1: Add provider snapshot tests**
+
+  Prove each registry adapter is queried once, capabilities come from implemented operations, cancellation/timeout/unavailable outcomes stay typed, and script/binary providers are not added to the strict v1 `installers` projection.
+
+- [ ] **Step 2: Add command route tests**
+
+  Make direct `isBunAvailable`/`isNpmAvailable`/etc. calls fail if used. Assert unchanged platform reasons, feature fields, self-upgrade projection, doctor installer booleans, issue codes, blocking flags, remediation commands, and explicitly network-aware self checks.
+
+- [ ] **Step 3: Route capabilities and doctor through shared snapshots**
+
+  Preserve exact v1 fields. Do not infer provider capabilities from duplicated command tables. Doctor agent issues consume live drift classifications but continue to emit only established issue/result fields.
+
+- [ ] **Step 4: Run focused gates and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/services/provider-observations.test.ts test/commands/capabilities.test.ts test/commands/doctor.test.ts test/providers/conformance.test.ts
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  ```
+
+  Commit: `refactor(readonly): derive capabilities and diagnostics`
+
+### Task 7: Real-environment comparison and milestone closure (OpenSpec 5.7)
+
+**Files:**
+- Create: `scripts/read-only-lifecycle-smoke.ts`
+- Create: `test/read-only-lifecycle-smoke.test.ts`
+- Modify: `package.json`
+- Modify: `openspec/changes/redesign-lifecycle-engine/tasks.md`
+
+**Interfaces:**
+- Consumes: the six migrated commands through the real CLI in a temporary HOME and the existing compatibility fixtures.
+- Produces: deterministic local/container smoke evidence without mutating agent/provider state.
+
+- [ ] **Step 1: Add a smoke harness test**
+
+  Run `list`, `info`, `inspect`, `resolve`, `capabilities`, and `doctor` in human and JSON modes against absent, tracked, untracked, and ghost fixtures. Assert parseable structured stdout, expected stable fields/error codes, no state-file byte changes, and no install/update/uninstall process invocation.
+
+- [ ] **Step 2: Run the harness locally and in Bun container**
+
+  Run:
+
+  ```bash
+  bun run test:readonly-smoke
+  docker run --rm -v "$PWD:/mnt/quantex-cli:ro" oven/bun:1.3.11 sh -lc 'mkdir /tmp/quantex-work && cd /mnt/quantex-cli && tar --exclude=.git --exclude=node_modules --exclude=dist -cf - . | tar -xf - -C /tmp/quantex-work && cd /tmp/quantex-work && bun install --frozen-lockfile && bun run test:readonly-smoke'
+  ```
+
+  Expected: both environments pass; host-dependent availability/version values are normalized rather than golden-locked.
+
+- [ ] **Step 3: Run the complete milestone gate**
+
+  Run:
+
+  ```bash
+  bun run format
+  bun run format:check
+  bun run lint
+  bun run typecheck
+  bun run test
+  bun run openspec:validate
+  bun run memory:check
+  bun run build
+  ```
+
+- [ ] **Step 4: Mark only OpenSpec 5.1–5.7 complete**
+
+  Confirm `bun run openspec:list` reports 37/74. Keep `redesign-lifecycle-engine` active and do not sync current specs or archive.
+
+  Commit: `test(readonly): verify observation migration`
+
+### Task 8: Review, normalize, push, and PR to integration
+
+**Files:**
+- Create ignored PR body: `.tmp/observation-readonly-pr-body.md`
+
+**Interfaces:**
+- Consumes: reviewed milestone tree and latest remote integration head.
+- Produces: one-commit PR `codex/redesign-observation-readonly` → `codex/redesign-lifecycle-integration`.
+
+- [ ] **Step 1: Request independent review**
+
+  Review observation correctness, provider/receipt conflict handling, pure planner behavior, read-only/no-lock/no-write guarantees, v1 projection compatibility, network effects, and real-environment evidence. Resolve every blocker/important finding with TDD.
+
+- [ ] **Step 2: Re-fetch and rebase if integration advanced**
+
+  Compare `merge-base` with `origin/codex/redesign-lifecycle-integration`. Rebase onto latest integration if needed and rerun the full gate.
+
+- [ ] **Step 3: Preserve checkpoints and normalize**
+
+  Retain granular history on `codex/redesign-observation-readonly-checkpoints`, then normalize the delivery branch to one commit:
+
+  ```text
+  refactor: migrate lifecycle observations and read-only commands
+  ```
+
+  Verify the pre/post normalization tree ids match.
+
+- [ ] **Step 4: Validate and create the PR**
+
+  Build the body from `.github/pull_request_template.md`, run:
+
+  ```bash
+  bun run pr:body:check -- --body-file .tmp/observation-readonly-pr-body.md --title "refactor: migrate lifecycle observations and read-only commands"
+  ```
+
+  Push and create a ready PR with base `codex/redesign-lifecycle-integration`.
+
+- [ ] **Step 5: Verify remote closure**
+
+  Require CI, Sandbox Tests when classified, OpenSpec, memory, and governance checks to pass. Confirm no Release workflow/npm publication. After review, rebase-merge with expected-head protection; use squash only if rebase is unavailable/unsafe. Verify the merged integration tree equals the reviewed tree and keep OpenSpec active.
+
+## Self-Review
+
+- Spec coverage: Tasks 1–7 map exactly to OpenSpec 5.1–5.7; Task 8 owns the required milestone delivery closure.
+- Scope: no update/idempotency, execution, self-upgrade, schema-v2 output, dynamic providers, workflow orchestration, release, or archive work is included.
+- Compatibility: every command migration retains its existing result interface/presenter and uses an explicit v1 projection.
+- Failure safety: provider/receipt conflicts and unavailable probes remain internal drift/indeterminate evidence; read-only commands never repair state.
+- Type consistency: `AgentLifecycleObservationResult`, `resolveAgentObservation`, `observeRegisteredAgents`, `projectObservationToV1Inspection`, and provider snapshot interfaces are defined before command consumers.
+- Placeholder scan: no unresolved placeholder markers remain.

--- a/openspec/changes/redesign-lifecycle-engine/tasks.md
+++ b/openspec/changes/redesign-lifecycle-engine/tasks.md
@@ -44,13 +44,13 @@
 
 ## 5. Observation and Read-Only Migration
 
-- [ ] 5.1 Implement live observation that combines executable, provider, version, receipt, and capability evidence into explicit consistency/drift classifications.
-- [ ] 5.2 Implement pure lifecycle planning for already-satisfied, absent, tracked, untracked, ghost, conflicting, unsupported, and indeterminate observations.
-- [ ] 5.3 Migrate `list` and `info` to the new catalog/application boundary and verify v1 compatibility fixtures.
-- [ ] 5.4 Migrate `inspect` and `resolve` to live observations and preserve install guidance and structured fields.
-- [ ] 5.5 Migrate `capabilities` to registry-derived provider and command capabilities without adding fields to strict v1 projections.
-- [ ] 5.6 Migrate `doctor` to observation-based diagnostics while keeping explicitly declared network checks and remediation semantics.
-- [ ] 5.7 Run read-only commands against real local and container environments and compare results with the compatibility baseline.
+- [x] 5.1 Implement live observation that combines executable, provider, version, receipt, and capability evidence into explicit consistency/drift classifications.
+- [x] 5.2 Implement pure lifecycle planning for already-satisfied, absent, tracked, untracked, ghost, conflicting, unsupported, and indeterminate observations.
+- [x] 5.3 Migrate `list` and `info` to the new catalog/application boundary and verify v1 compatibility fixtures.
+- [x] 5.4 Migrate `inspect` and `resolve` to live observations and preserve install guidance and structured fields.
+- [x] 5.5 Migrate `capabilities` to registry-derived provider and command capabilities without adding fields to strict v1 projections.
+- [x] 5.6 Migrate `doctor` to observation-based diagnostics while keeping explicitly declared network checks and remediation semantics.
+- [x] 5.7 Run read-only commands against real local and container environments and compare results with the compatibility baseline.
 
 ## 6. Versioned State and Core Mutations
 

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "release:smoke": "bun run scripts/verify-release-smoke.ts",
     "test": "vitest run",
     "test:container": "bun run scripts/test-container.ts",
+    "test:readonly-smoke": "vitest run test/read-only-lifecycle-smoke.test.ts test/read-only-lifecycle-timeout.test.ts test/read-only-lifecycle-provider-timeout.test.ts test/read-only-lifecycle-provider-signal.test.ts test/read-only-spawn-guard.test.ts",
     "test:sandbox": "bun run scripts/test-sandbox.ts",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/scripts/read-only-lifecycle-smoke.ts
+++ b/scripts/read-only-lifecycle-smoke.ts
@@ -1,0 +1,798 @@
+import type { CommandResult } from '../src/output/types'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { parseStateDocument } from '../src/state/schema'
+import { assertReadOnlyCommand } from './read-only-spawn-guard'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const CLI_PATH = join(ROOT, 'src', 'cli.ts')
+const GUARD_PATH = join(ROOT, 'scripts', 'read-only-spawn-guard.ts')
+const BUN_PATH = resolveExecutableFromPath('bun')
+const CATALOG_SUPPORT_PATH = join(ROOT, 'src', 'agents', 'generated', 'catalog-support.json')
+const FIXTURE_ROOT = join(ROOT, 'test', 'fixtures', 'compatibility', 'v1', 'state')
+const COMMANDS = ['list', 'info', 'inspect', 'resolve', 'capabilities', 'doctor'] as const
+const FIXTURES = ['absent', 'tracked', 'untracked', 'ghost'] as const
+const MODES = ['human', 'json'] as const
+const AGENT_COMMANDS = new Set(['info', 'inspect', 'resolve'])
+const COMMAND_TIMEOUT_MS = 30_000
+const COMMAND_TIMEOUT_GRACE_MS = 1_000
+const PASSIVE_NOTICE_MARKER =
+  'Quantex CLI 99.0.0 is available (current 0.29.0). Run `quantex doctor` for source-specific update steps.'
+
+type SmokeCommand = (typeof COMMANDS)[number]
+type SmokeFixture = (typeof FIXTURES)[number]
+type SmokeMode = (typeof MODES)[number]
+
+interface CommandOutput {
+  exitCode: number
+  stderr: string
+  stdout: string
+}
+
+interface ChildExitLike {
+  kill(signal: NodeJS.Signals): boolean
+  once(event: 'close', listener: (code: number | null) => void): unknown
+  once(event: 'error', listener: (error: Error) => void): unknown
+  removeListener(event: 'close', listener: (code: number | null) => void): unknown
+  removeListener(event: 'error', listener: (error: Error) => void): unknown
+}
+
+export interface ReadOnlyLifecycleSmokeSummary {
+  commands: SmokeCommand[]
+  fixtures: SmokeFixture[]
+  invocations: number
+  modes: SmokeMode[]
+  normalizedEvidence: ReadOnlyLifecycleEvidence
+}
+
+interface NormalizedCommandEvidence {
+  human: string[]
+  json: unknown
+}
+
+type ReadOnlyLifecycleEvidence = Record<
+  SmokeFixture,
+  {
+    commands: Record<SmokeCommand, NormalizedCommandEvidence>
+    fixture: {
+      executablePresent: boolean
+      recordedInstallType: string | null
+    }
+  }
+>
+
+const INSTALLER_KEYS = ['brew', 'bun', 'cargo', 'deno', 'mise', 'npm', 'pip', 'uv', 'winget'] as const
+const FEATURE_KEYS = [
+  'assumeYes',
+  'cacheBypass',
+  'cacheRefresh',
+  'channels',
+  'colorModes',
+  'dryRun',
+  'execInstallPolicies',
+  'freshnessMetadata',
+  'idempotencyKey',
+  'logLevels',
+  'quietLogs',
+  'selfUpgrade',
+  'timeout',
+] as const
+
+export const READ_ONLY_LIFECYCLE_BASELINE: ReadOnlyLifecycleEvidence = {
+  absent: fixtureBaseline(null, false, {
+    info: observationBaseline(false, 'unmanaged'),
+    inspect: observationBaseline(false, 'unmanaged', undefined, 'command update'),
+    list: observationBaseline(false, 'unmanaged', 'detected in PATH', 'command update'),
+    resolve: resolveBaseline(false),
+  }),
+  ghost: fixtureBaseline('npm', false, {
+    info: observationBaseline(false, 'managed'),
+    inspect: observationBaseline(false, 'managed', undefined, 'managed update'),
+    list: observationBaseline(false, 'managed', 'managed via npm (@openai/codex)', 'managed update'),
+    resolve: resolveBaseline(false),
+  }),
+  tracked: fixtureBaseline('bun', true, {
+    info: observationBaseline(true, 'managed', 'managed via bun (@openai/codex)'),
+    inspect: observationBaseline(true, 'managed', 'managed via bun (@openai/codex)', 'managed update'),
+    list: observationBaseline(true, 'managed', 'managed via bun (@openai/codex)', 'managed update'),
+    resolve: resolveBaseline(true, 'managed', 'managed via bun (@openai/codex)', 'bun'),
+  }),
+  untracked: fixtureBaseline(null, true, {
+    info: observationBaseline(true, 'unmanaged', 'detected in PATH'),
+    inspect: observationBaseline(true, 'unmanaged', 'detected in PATH', 'command update'),
+    list: observationBaseline(true, 'unmanaged', 'detected in PATH', 'command update'),
+    resolve: resolveBaseline(true, 'unmanaged', 'detected in PATH', 'detected-in-path'),
+  }),
+}
+
+export async function runReadOnlyLifecycleSmoke(): Promise<ReadOnlyLifecycleSmokeSummary> {
+  let invocations = 0
+  const normalizedEvidence = {} as ReadOnlyLifecycleEvidence
+
+  for (const fixture of FIXTURES) {
+    const sandbox = await createSandbox(fixture)
+    const commands = {} as Record<SmokeCommand, NormalizedCommandEvidence>
+
+    try {
+      const configBefore = await snapshotDirectory(sandbox.configDir)
+
+      for (const mode of MODES) {
+        for (const command of COMMANDS) {
+          const output = await runCli(command, fixture, mode, sandbox)
+          const evidence = assertCommandOutput(command, fixture, mode, output)
+          commands[command] ??= { human: [], json: undefined }
+          if (mode === 'human') commands[command].human = evidence as string[]
+          else commands[command].json = evidence
+          assertDirectorySnapshot(
+            await snapshotDirectory(sandbox.configDir),
+            configBefore,
+            `${fixture}/${mode}/${command}`,
+          )
+          invocations += 1
+        }
+      }
+
+      await assertGuardedInvocations(sandbox.guardLogPath)
+      normalizedEvidence[fixture] = {
+        commands,
+        fixture: sandbox.fixtureEvidence,
+      }
+    } finally {
+      await rm(sandbox.root, { force: true, recursive: true })
+    }
+  }
+
+  assertReadOnlyLifecycleBaseline(normalizedEvidence)
+
+  return {
+    commands: [...COMMANDS],
+    fixtures: [...FIXTURES],
+    invocations,
+    modes: [...MODES],
+    normalizedEvidence,
+  }
+}
+
+interface Sandbox {
+  env: Record<string, string>
+  configDir: string
+  fixtureEvidence: {
+    executablePresent: boolean
+    recordedInstallType: string | null
+  }
+  guardLogPath: string
+  processLogPath: string
+  root: string
+  statePath: string
+}
+
+async function createSandbox(fixture: SmokeFixture): Promise<Sandbox> {
+  const root = await mkdtemp(join(tmpdir(), `quantex-readonly-${fixture}-`))
+  const home = join(root, 'home')
+  const configDir = join(home, '.quantex')
+  const binDir = join(root, 'bin')
+  const processLogPath = join(root, 'process.log')
+  const guardLogPath = join(root, 'guard.log')
+  const statePath = join(configDir, 'state.json')
+
+  await mkdir(configDir, { recursive: true })
+  await mkdir(binDir, { recursive: true })
+  await writeFile(processLogPath, '')
+  await writeFile(guardLogPath, '')
+  await writeFile(statePath, await prepareStateFixture(fixture))
+  await seedVersionCache(configDir)
+  await installProcessSentinels(binDir, processLogPath, fixture === 'tracked' || fixture === 'untracked')
+  const state = JSON.parse(await readFile(statePath, 'utf8')) as {
+    installedAgents?: { codex?: { installType?: unknown } }
+  }
+
+  return {
+    env: {
+      HOME: home,
+      LANG: 'C',
+      LC_ALL: 'C',
+      NO_COLOR: '1',
+      PATH: `${binDir}:/usr/bin:/bin`,
+      QUANTEX_READ_ONLY_GUARD: '1',
+      QUANTEX_READ_ONLY_GUARD_LOG: guardLogPath,
+      USERPROFILE: home,
+    },
+    configDir,
+    fixtureEvidence: {
+      executablePresent: existsSync(join(binDir, 'codex')),
+      recordedInstallType:
+        typeof state.installedAgents?.codex?.installType === 'string' ? state.installedAgents.codex.installType : null,
+    },
+    guardLogPath,
+    processLogPath,
+    root,
+    statePath,
+  }
+}
+
+async function prepareStateFixture(fixture: SmokeFixture): Promise<string> {
+  const legacyFixture = JSON.parse(await readFile(resolveStateFixture(fixture), 'utf8')) as unknown
+  if (fixture === 'absent' || fixture === 'tracked') return `${JSON.stringify(legacyFixture, null, 2)}\n`
+
+  const document = parseStateDocument(legacyFixture).document
+  return `${JSON.stringify(
+    fixture === 'untracked'
+      ? { ...document, self: {} }
+      : { ...document, self: { ...document.self, installSource: 'source' } },
+    null,
+    2,
+  )}\n`
+}
+
+function resolveStateFixture(fixture: SmokeFixture): string {
+  if (fixture === 'tracked') return join(FIXTURE_ROOT, 'valid.json')
+  if (fixture === 'ghost') return join(FIXTURE_ROOT, 'ghost.json')
+  return join(FIXTURE_ROOT, 'untracked.json')
+}
+
+async function seedVersionCache(configDir: string): Promise<void> {
+  const packages = new Set<string>(['quantex-cli'])
+  const catalogSupport = JSON.parse(await readFile(CATALOG_SUPPORT_PATH, 'utf8')) as unknown
+
+  if (isRecord(catalogSupport) && Array.isArray(catalogSupport.agents)) {
+    for (const agent of catalogSupport.agents) {
+      if (!isRecord(agent) || !isRecord(agent.platforms)) continue
+      for (const candidates of Object.values(agent.platforms)) {
+        if (!Array.isArray(candidates)) continue
+        for (const candidate of candidates) {
+          if (isRecord(candidate) && typeof candidate.targetId === 'string') {
+            packages.add(candidate.targetId)
+          }
+        }
+      }
+    }
+  }
+
+  const expiresAt = Date.now() + 24 * 60 * 60 * 1000
+  const fetchedAt = Date.now()
+  const entries = Object.fromEntries(
+    [...packages].flatMap(packageName =>
+      ['latest', 'beta'].map(tag => [
+        `npm:https://registry.npmjs.org:${packageName}:${tag}`,
+        {
+          body: JSON.stringify({ version: packageName === 'quantex-cli' ? '99.0.0' : '0.0.0-smoke' }),
+          expiresAt,
+          fetchedAt,
+        },
+      ]),
+    ),
+  )
+
+  const cachePath = join(configDir, 'cache', 'versions.json')
+  await mkdir(dirname(cachePath), { recursive: true })
+  await writeFile(cachePath, `${JSON.stringify({ entries }, null, 2)}\n`)
+}
+
+async function snapshotDirectory(root: string): Promise<Map<string, Buffer>> {
+  const snapshot = new Map<string, Buffer>()
+
+  async function visit(directory: string, prefix: string): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true })
+    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+      const relativePath = prefix ? join(prefix, entry.name) : entry.name
+      const absolutePath = join(directory, entry.name)
+      if (entry.isDirectory()) await visit(absolutePath, relativePath)
+      else snapshot.set(relativePath, await readFile(absolutePath))
+    }
+  }
+
+  await visit(root, '')
+  return snapshot
+}
+
+function assertDirectorySnapshot(actual: Map<string, Buffer>, expected: Map<string, Buffer>, label: string): void {
+  const actualFiles = [...actual.keys()]
+  const expectedFiles = [...expected.keys()]
+  assert(
+    JSON.stringify(actualFiles) === JSON.stringify(expectedFiles),
+    `${label}: config directory entries changed (${expectedFiles.join(', ')} -> ${actualFiles.join(', ')}).`,
+  )
+  for (const path of expectedFiles) {
+    assertBytesEqual(actual.get(path)!, expected.get(path)!, `${label}/${path}`)
+  }
+}
+
+async function installProcessSentinels(binDir: string, logPath: string, codexPresent: boolean): Promise<void> {
+  const observedCommands = [
+    'brew',
+    'bun',
+    'cargo',
+    'deno',
+    'mise',
+    'npm',
+    'pip',
+    'pip3',
+    'python',
+    'python3',
+    'uv',
+    'winget',
+  ]
+
+  for (const command of observedCommands) {
+    await writeExecutable(
+      join(binDir, command),
+      `#!/bin/sh\nprintf '%s\\n' '${command} '"$@" >> '${logPath}'\nif [ "$1" = "--version" ]; then\n  ${command === 'bun' ? "printf '%s\\n' '1.3.11'; exit 0" : 'exit 127'}\nfi\nexit 127\n`,
+    )
+  }
+
+  await writeExecutable(
+    join(binDir, 'which'),
+    `#!/bin/sh\nprintf '%s\\n' 'which '"$@" >> '${logPath}'\ncase "$1" in\n  */*) [ -x "$1" ] && { printf '%s\\n' "$1"; exit 0; } ;;\nesac\nold_ifs=$IFS\nIFS=:\nfor directory in $PATH; do\n  if [ -x "$directory/$1" ]; then\n    printf '%s\\n' "$directory/$1"\n    IFS=$old_ifs\n    exit 0\n  fi\ndone\nIFS=$old_ifs\nexit 1\n`,
+  )
+
+  if (codexPresent) {
+    await writeExecutable(
+      join(binDir, 'codex'),
+      `#!/bin/sh\nprintf '%s\\n' 'codex '"$@" >> '${logPath}'\nif [ "$1" = "--version" ]; then\n  printf '%s\\n' 'codex 1.2.3'\n  exit 0\nfi\nexit 127\n`,
+    )
+  }
+}
+
+async function writeExecutable(path: string, contents: string): Promise<void> {
+  await writeFile(path, contents)
+  await chmod(path, 0o755)
+}
+
+async function runCli(
+  command: SmokeCommand,
+  fixture: SmokeFixture,
+  mode: SmokeMode,
+  sandbox: Sandbox,
+): Promise<CommandOutput> {
+  const args = [
+    BUN_PATH,
+    '--preload',
+    GUARD_PATH,
+    CLI_PATH,
+    '--output',
+    mode,
+    '--non-interactive',
+    '--color',
+    'never',
+    '--run-id',
+    `readonly-${fixture}-${mode}-${command}`,
+    command,
+    ...(AGENT_COMMANDS.has(command) ? ['codex'] : []),
+  ]
+  const child = spawn(args[0]!, args.slice(1), {
+    cwd: ROOT,
+    env: sandbox.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  const stdoutChunks: Buffer[] = []
+  const stderrChunks: Buffer[] = []
+  child.stdout.on('data', chunk => stdoutChunks.push(Buffer.from(chunk)))
+  child.stderr.on('data', chunk => stderrChunks.push(Buffer.from(chunk)))
+  const exitCode = await waitForChildExit(child, {
+    commandLabel: `${fixture}/${mode}/${command}`,
+    graceMs: COMMAND_TIMEOUT_GRACE_MS,
+    timeoutMs: COMMAND_TIMEOUT_MS,
+  })
+
+  return {
+    exitCode,
+    stderr: Buffer.concat(stderrChunks).toString('utf8'),
+    stdout: Buffer.concat(stdoutChunks).toString('utf8'),
+  }
+}
+
+export function waitForChildExit(
+  child: ChildExitLike,
+  options: { commandLabel: string; graceMs: number; timeoutMs: number },
+): Promise<number> {
+  return new Promise<number>((resolve, reject) => {
+    let graceTimer: ReturnType<typeof setTimeout> | undefined
+    let timedOut = false
+    const timeoutError = () => new Error(`${options.commandLabel} timed out after ${options.timeoutMs}ms.`)
+    const finish = (result: { error: Error } | { exitCode: number }) => {
+      clearTimeout(timeoutTimer)
+      if (graceTimer) clearTimeout(graceTimer)
+      child.removeListener('close', onClose)
+      child.removeListener('error', onError)
+      if ('error' in result) reject(result.error)
+      else resolve(result.exitCode)
+    }
+    const onClose = (code: number | null) => {
+      if (timedOut) finish({ error: timeoutError() })
+      else finish({ exitCode: code ?? 1 })
+    }
+    const onError = (error: Error) => finish({ error: timedOut ? timeoutError() : error })
+    const timeoutTimer = setTimeout(() => {
+      timedOut = true
+      try {
+        child.kill('SIGTERM')
+      } catch {
+        // Continue to the bounded hard-kill fallback.
+      }
+      graceTimer = setTimeout(() => {
+        try {
+          child.kill('SIGKILL')
+        } catch {
+          // Reject even when the platform cannot deliver SIGKILL.
+        }
+        finish({ error: timeoutError() })
+      }, options.graceMs)
+    }, options.timeoutMs)
+
+    child.once('error', onError)
+    child.once('close', onClose)
+  })
+}
+
+function resolveExecutableFromPath(command: string): string {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    const candidate = join(directory, command)
+    if (existsSync(candidate)) return candidate
+  }
+
+  throw new Error(`Unable to resolve ${command} from the smoke harness PATH.`)
+}
+
+function assertCommandOutput(
+  command: SmokeCommand,
+  fixture: SmokeFixture,
+  mode: SmokeMode,
+  output: CommandOutput,
+): string[] | unknown {
+  const shouldResolve = fixture === 'tracked' || fixture === 'untracked'
+  const expectedExitCode = command === 'resolve' && !shouldResolve ? 4 : 0
+
+  assert(output.exitCode === expectedExitCode, failure(command, fixture, mode, output, 'unexpected exit code'))
+  assert(output.stderr.trim() === '', failure(command, fixture, mode, output, 'stderr must stay empty'))
+
+  if (mode === 'human') {
+    assert(output.stdout.trim().length > 0, failure(command, fixture, mode, output, 'human stdout is empty'))
+    return normalizeHumanEvidence(command, fixture, output.stdout)
+  }
+
+  let result: CommandResult<Record<string, unknown>>
+  try {
+    result = JSON.parse(output.stdout) as CommandResult<Record<string, unknown>>
+  } catch (error) {
+    throw new Error(failure(command, fixture, mode, output, `structured stdout is not JSON: ${String(error)}`), {
+      cause: error,
+    })
+  }
+
+  assert(result.action === command, `Expected action=${command} for ${fixture}, received ${result.action}.`)
+  assert(result.meta.mode === 'json', `Expected JSON mode for ${fixture}/${command}.`)
+  assert(result.meta.schemaVersion === '1', `Expected schemaVersion=1 for ${fixture}/${command}.`)
+  assert(result.meta.runId === `readonly-${fixture}-${mode}-${command}`, `Unexpected runId for ${fixture}/${command}.`)
+  assert(typeof result.meta.timestamp === 'string', `Missing timestamp for ${fixture}/${command}.`)
+  assert(typeof result.meta.version === 'string', `Missing CLI version for ${fixture}/${command}.`)
+  assert(Array.isArray(result.warnings), `Warnings must be an array for ${fixture}/${command}.`)
+  assert(result.target !== undefined, `Missing target for ${fixture}/${command}.`)
+
+  if (command === 'resolve' && !shouldResolve) {
+    assert(result.ok === false, `Expected resolve failure for ${fixture}.`)
+    assert(result.error?.code === 'AGENT_NOT_INSTALLED', `Expected AGENT_NOT_INSTALLED for ${fixture}.`)
+  } else {
+    assert(result.ok === true, `Expected ${command} success for ${fixture}.`)
+    assert(result.error === null, `Expected null error for ${fixture}/${command}.`)
+  }
+
+  assertStableCommandFields(command, fixture, result.data)
+  return normalizeJsonEvidence(command, result)
+}
+
+function normalizeJsonEvidence(command: SmokeCommand, result: CommandResult<Record<string, unknown>>): unknown {
+  const data = result.data
+  assert(isRecord(data), `Missing normalized data for ${command}.`)
+
+  if (command === 'list') {
+    const agents = data.agents
+    assert(Array.isArray(agents), 'Missing list agents while normalizing evidence.')
+    const codex = agents.find(agent => isRecord(agent) && agent.name === 'codex')
+    assert(isRecord(codex), 'Missing Codex list row while normalizing evidence.')
+    return pickObservation(codex, true)
+  }
+
+  if (command === 'info' || command === 'inspect') {
+    assert(isRecord(data.inspection), `Missing ${command} inspection while normalizing evidence.`)
+    return pickObservation(data.inspection, command === 'inspect')
+  }
+
+  if (command === 'resolve') {
+    assert(isRecord(data.resolution), 'Missing resolve resolution while normalizing evidence.')
+    const guidance = isRecord(data.resolution.installGuidance) ? data.resolution.installGuidance : undefined
+    return {
+      errorCode: result.error?.code ?? null,
+      guidance: guidance
+        ? {
+            docsRef: guidance.docsRef,
+            suggestedAction: guidance.suggestedAction,
+            suggestedEnsureCommand: guidance.suggestedEnsureCommand,
+          }
+        : null,
+      installed: data.resolution.installed,
+      installSource: data.resolution.installSource,
+      lifecycle: data.resolution.lifecycle,
+      sourceLabel: data.resolution.sourceLabel,
+    }
+  }
+
+  if (command === 'capabilities') {
+    assert(
+      isRecord(data.features) && isRecord(data.installers),
+      'Missing capabilities shape while normalizing evidence.',
+    )
+    const installers = data.installers
+    return {
+      agentMarker: Array.isArray(data.agents) && data.agents.includes('codex'),
+      featureKeys: Object.keys(data.features).sort(),
+      installerAvailability: Object.fromEntries(
+        INSTALLER_KEYS.map(key => [key, isRecord(installers[key]) ? '<availability>' : '<missing>']),
+      ),
+      installerKeys: Object.keys(data.installers).sort(),
+      outputModes: data.outputModes,
+    }
+  }
+
+  assert(Array.isArray(data.agents) && Array.isArray(data.issues), 'Missing doctor shape while normalizing evidence.')
+  assert(isRecord(data.installers) && isRecord(data.self), 'Missing doctor markers while normalizing evidence.')
+  const codex = data.agents.find(agent => isRecord(agent) && agent.displayName === 'Codex CLI')
+  return {
+    agent: isRecord(codex)
+      ? {
+          lifecycle: codex.lifecycle,
+          sourceLabel: codex.sourceLabel,
+        }
+      : null,
+    installerKeys: Object.keys(data.installers).sort(),
+    issueCodes: data.issues
+      .flatMap(issue => (isRecord(issue) && typeof issue.code === 'string' ? [issue.code] : []))
+      .sort(),
+    selfKeys: Object.keys(data.self).sort(),
+  }
+}
+
+function pickObservation(value: Record<string, any>, includeUpdateLabel: boolean): unknown {
+  return {
+    installed: value.installed,
+    lifecycle: value.lifecycle,
+    sourceLabel: value.sourceLabel ?? null,
+    ...(includeUpdateLabel ? { updateLabel: value.updateLabel } : {}),
+  }
+}
+
+function normalizeHumanEvidence(command: SmokeCommand, fixture: SmokeFixture, stdout: string): string[] {
+  const normalized = stdout.replace(/\s+/g, ' ').trim()
+  const markers = READ_ONLY_LIFECYCLE_BASELINE[fixture].commands[command].human
+  for (const marker of markers) {
+    assert(normalized.includes(marker), `${fixture}/human/${command}: missing compatibility marker "${marker}".`)
+  }
+  return [...markers]
+}
+
+function assertStableCommandFields(command: SmokeCommand, fixture: SmokeFixture, data: unknown): void {
+  assert(isRecord(data), `Missing structured data for ${fixture}/${command}.`)
+
+  if (command === 'list') {
+    assert(Array.isArray(data.agents), `list.agents must be an array for ${fixture}.`)
+    assert(
+      data.agents.some(agent => isRecord(agent) && agent.name === 'codex'),
+      `list must include codex for ${fixture}.`,
+    )
+  } else if (command === 'info' || command === 'inspect') {
+    assert(isRecord(data.agent) && data.agent.name === 'codex', `${command}.agent.name must be codex for ${fixture}.`)
+    assert(isRecord(data.inspection), `${command}.inspection is missing for ${fixture}.`)
+    assert(
+      typeof data.inspection.installed === 'boolean',
+      `${command}.inspection.installed is unstable for ${fixture}.`,
+    )
+  } else if (command === 'resolve') {
+    assert(isRecord(data.agent) && data.agent.name === 'codex', `resolve.agent.name must be codex for ${fixture}.`)
+    assert(isRecord(data.resolution), `resolve.resolution is missing for ${fixture}.`)
+    assert(typeof data.resolution.installed === 'boolean', `resolve.resolution.installed is unstable for ${fixture}.`)
+  } else if (command === 'capabilities') {
+    assert(Array.isArray(data.agents), `capabilities.agents must be an array for ${fixture}.`)
+    assert(isRecord(data.installers), `capabilities.installers is missing for ${fixture}.`)
+    for (const installer of Object.values(data.installers)) {
+      assert(isRecord(installer) && typeof installer.available === 'boolean', 'Installer availability must be boolean.')
+    }
+  } else {
+    assert(Array.isArray(data.agents), `doctor.agents must be an array for ${fixture}.`)
+    assert(Array.isArray(data.issues), `doctor.issues must be an array for ${fixture}.`)
+    assert(isRecord(data.installers), `doctor.installers is missing for ${fixture}.`)
+    assert(isRecord(data.self), `doctor.self is missing for ${fixture}.`)
+  }
+}
+
+export function assertReadOnlyLifecycleBaseline(value: unknown): void {
+  if (stableJson(value) !== stableJson(READ_ONLY_LIFECYCLE_BASELINE)) {
+    throw new Error(
+      `Read-only lifecycle evidence does not match the deterministic compatibility baseline.\nActual: ${JSON.stringify(value, null, 2)}\nExpected: ${JSON.stringify(READ_ONLY_LIFECYCLE_BASELINE, null, 2)}`,
+    )
+  }
+}
+
+export function formatReadOnlyLifecycleSummary(normalizedEvidence: unknown): string {
+  return stableJson({
+    kind: 'read-only-lifecycle-smoke',
+    normalizedEvidence,
+  })
+}
+
+function fixtureBaseline(
+  recordedInstallType: string | null,
+  executablePresent: boolean,
+  observations: Record<'info' | 'inspect' | 'list' | 'resolve', unknown>,
+): ReadOnlyLifecycleEvidence[SmokeFixture] {
+  const installed = executablePresent
+  const source = recordedInstallType
+    ? `managed via ${recordedInstallType} (@openai/codex)`
+    : installed
+      ? 'detected in PATH'
+      : undefined
+  const installedHuman = installed ? ['Installed: Yes'] : ['Installed: No']
+  const inspectHuman = [
+    ...installedHuman,
+    recordedInstallType ? 'Update Mode: managed update' : 'Update Mode: command update',
+  ]
+  if (installed && source) {
+    installedHuman.push(`Source: ${source}`)
+    inspectHuman.push(`Source: ${source}`)
+  }
+
+  const resolveHuman = installed
+    ? [`Source: ${source}`, `Lifecycle: ${recordedInstallType ? 'managed' : 'unmanaged'}`]
+    : ['Codex CLI is not installed.', 'Try: quantex ensure codex']
+  const doctorHuman = ['Quantex CLI Environment Check', 'Managed Installers:', 'Installed Agents:', 'Issues:']
+  if (installed) doctorHuman.push(`[${recordedInstallType ? 'managed' : 'unmanaged'}; ${source}]`)
+  else doctorHuman.push('No agents installed')
+
+  return {
+    commands: {
+      capabilities: {
+        human: ['Quantex Capabilities', 'Installers:', 'Features:', 'codex', PASSIVE_NOTICE_MARKER],
+        json: {
+          agentMarker: true,
+          featureKeys: [...FEATURE_KEYS].sort(),
+          installerAvailability: Object.fromEntries(INSTALLER_KEYS.map(key => [key, '<availability>'])),
+          installerKeys: [...INSTALLER_KEYS].sort(),
+          outputModes: ['human', 'json', 'ndjson'],
+        },
+      },
+      doctor: {
+        human: doctorHuman,
+        json: {
+          agent: installed
+            ? {
+                lifecycle: recordedInstallType ? 'managed' : 'unmanaged',
+                sourceLabel: source,
+              }
+            : null,
+          installerKeys: [...INSTALLER_KEYS].sort(),
+          issueCodes: ['SELF_AUTO_UPDATE_UNAVAILABLE'],
+          selfKeys: ['canAutoUpdate', 'currentVersion', 'installSource', 'latestVersion', 'outdated'],
+        },
+      },
+      info: { human: ['Codex CLI', ...installedHuman, PASSIVE_NOTICE_MARKER], json: observations.info },
+      inspect: { human: ['Codex CLI', ...inspectHuman, PASSIVE_NOTICE_MARKER], json: observations.inspect },
+      list: {
+        human: [
+          'AI Agents:',
+          'Codex CLI',
+          installed ? 'Codex CLI installed' : 'Codex CLI not installed',
+          PASSIVE_NOTICE_MARKER,
+        ],
+        json: observations.list,
+      },
+      resolve: {
+        human: installed ? [...resolveHuman, PASSIVE_NOTICE_MARKER] : resolveHuman,
+        json: observations.resolve,
+      },
+    },
+    fixture: {
+      executablePresent,
+      recordedInstallType,
+    },
+  }
+}
+
+function stableJson(value: unknown): string {
+  return JSON.stringify(value, (_key, entry) => {
+    if (!isRecord(entry)) return entry
+    return Object.fromEntries(Object.entries(entry).sort(([left], [right]) => left.localeCompare(right)))
+  })
+}
+
+function observationBaseline(
+  installed: boolean,
+  lifecycle: 'managed' | 'unmanaged',
+  sourceLabel?: string,
+  updateLabel?: string,
+): unknown {
+  return {
+    installed,
+    lifecycle,
+    sourceLabel: sourceLabel ?? null,
+    ...(updateLabel ? { updateLabel } : {}),
+  }
+}
+
+function resolveBaseline(
+  installed: boolean,
+  lifecycle: 'managed' | 'unmanaged' = 'unmanaged',
+  sourceLabel = 'not installed',
+  installSource = 'not-installed',
+): unknown {
+  return {
+    errorCode: installed ? null : 'AGENT_NOT_INSTALLED',
+    guidance: installed
+      ? null
+      : {
+          docsRef: 'skills/quantex-cli/references/command-recipes.md',
+          suggestedAction: 'ensure-agent-installed',
+          suggestedEnsureCommand: 'quantex ensure codex',
+        },
+    installed,
+    installSource,
+    lifecycle,
+    sourceLabel,
+  }
+}
+
+async function assertGuardedInvocations(logPath: string): Promise<void> {
+  const log = await readFile(logPath, 'utf8')
+  const commands = log
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map(line => JSON.parse(line) as unknown)
+
+  assert(commands.length > 0, 'Read-only spawn guard did not observe any child CLI processes.')
+  for (const command of commands) {
+    assert(
+      Array.isArray(command) && command.every(argument => typeof argument === 'string'),
+      'Invalid guard log entry.',
+    )
+    assertReadOnlyCommand(command)
+  }
+}
+
+function assertBytesEqual(actual: Uint8Array, expected: Uint8Array, label: string): void {
+  assert(actual.byteLength === expected.byteLength, `State file size changed during ${label}.`)
+  for (let index = 0; index < actual.byteLength; index += 1) {
+    assert(actual[index] === expected[index], `State file bytes changed during ${label}.`)
+  }
+}
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message)
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function failure(
+  command: SmokeCommand,
+  fixture: SmokeFixture,
+  mode: SmokeMode,
+  output: CommandOutput,
+  message: string,
+): string {
+  return [
+    `${fixture}/${mode}/${command}: ${message}.`,
+    `Exit code: ${output.exitCode}`,
+    `Stdout: ${output.stdout.trim() || '(empty)'}`,
+    `Stderr: ${output.stderr.trim() || '(empty)'}`,
+  ].join('\n')
+}
+
+if (import.meta.main) {
+  const summary = await runReadOnlyLifecycleSmoke()
+  console.log(`Read-only lifecycle smoke passed (${summary.invocations} real CLI invocations).`)
+  console.log(formatReadOnlyLifecycleSummary(summary.normalizedEvidence))
+}

--- a/scripts/read-only-spawn-guard.ts
+++ b/scripts/read-only-spawn-guard.ts
@@ -1,0 +1,93 @@
+import { appendFileSync } from 'node:fs'
+import { basename } from 'node:path'
+import process from 'node:process'
+
+const BLOCKED_SHELLS = new Set(['bash', 'curl', 'powershell', 'powershell.exe', 'pwsh', 'sh'])
+const OBSERVATION_RULES: Record<string, (args: string[]) => boolean> = {
+  brew: args => isOneOf(args[0], '--version', 'info', 'list'),
+  bun: args => args[0] === '--version' || matches(args, ['pm', '-g', 'ls']) || matches(args, ['pm', '-g', 'untrusted']),
+  cargo: args => args[0] === '--version',
+  deno: args => args[0] === '--version',
+  mise: args => isOneOf(args[0], '--version', 'ls'),
+  npm: args => isOneOf(args[0], '--version', 'list', 'root', 'view'),
+  pip: args => isOneOf(args[0], '--version', 'list', 'show'),
+  pip3: args => isOneOf(args[0], '--version', 'list', 'show'),
+  python: args => isReadOnlyPythonPip(args),
+  python3: args => isReadOnlyPythonPip(args),
+  uv: args => args[0] === '--version' || (args[0] === 'tool' && args[1] === 'list'),
+  where: () => true,
+  which: () => true,
+  winget: args => isOneOf(args[0], '--version', 'list', 'search', 'show'),
+}
+
+export function assertReadOnlyCommand(command: readonly string[]): void {
+  const [file, ...args] = command
+  if (!file) throw blocked(command, 'empty command')
+
+  const executable = basename(file).toLowerCase()
+  if (BLOCKED_SHELLS.has(executable)) throw blocked(command, 'shell or script execution effect')
+
+  const providerRule = OBSERVATION_RULES[executable]
+  if (providerRule) {
+    if (!providerRule(args)) throw blocked(command, `provider mutation or unknown ${executable} operation`)
+    return
+  }
+
+  if (args.length === 1 && (args[0] === '--version' || args[0] === 'version')) return
+  throw blocked(command, 'unknown executable effect')
+}
+
+function blocked(command: readonly string[], reason: string): Error {
+  return new Error(`READ_ONLY_MUTATION_BLOCKED: ${reason}: ${JSON.stringify(command)}`)
+}
+
+function isOneOf(value: string | undefined, ...allowed: string[]): boolean {
+  return value !== undefined && allowed.includes(value)
+}
+
+function isReadOnlyPythonPip(args: string[]): boolean {
+  return args[0] === '-m' && args[1] === 'pip' && isOneOf(args[2], '--version', 'list', 'show')
+}
+
+function matches(actual: string[], expected: string[]): boolean {
+  return actual.length === expected.length && actual.every((argument, index) => argument === expected[index])
+}
+
+function record(command: readonly string[]): void {
+  const logPath = process.env.QUANTEX_READ_ONLY_GUARD_LOG
+  if (logPath) appendFileSync(logPath, `${JSON.stringify(command)}\n`)
+}
+
+function normalizeCommand(value: unknown): string[] {
+  if (Array.isArray(value) && value.every(argument => typeof argument === 'string')) return value
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    'cmd' in value &&
+    Array.isArray(value.cmd) &&
+    value.cmd.every(argument => typeof argument === 'string')
+  ) {
+    return value.cmd
+  }
+  throw blocked([], 'unsupported Bun spawn input')
+}
+
+if (process.env.QUANTEX_READ_ONLY_GUARD === '1') {
+  const originalSpawn = Bun.spawn.bind(Bun)
+  Bun.spawn = ((commandOrOptions: unknown, options?: unknown) => {
+    const command = normalizeCommand(commandOrOptions)
+    assertReadOnlyCommand(command)
+    record(command)
+    return originalSpawn(commandOrOptions as never, options as never)
+  }) as typeof Bun.spawn
+
+  if (typeof Bun.spawnSync === 'function') {
+    const originalSpawnSync = Bun.spawnSync.bind(Bun)
+    Bun.spawnSync = ((commandOrOptions: unknown, options?: unknown) => {
+      const command = normalizeCommand(commandOrOptions)
+      assertReadOnlyCommand(command)
+      record(command)
+      return originalSpawnSync(commandOrOptions as never, options as never)
+    }) as typeof Bun.spawnSync
+  }
+}

--- a/src/command-runtime.ts
+++ b/src/command-runtime.ts
@@ -58,6 +58,7 @@ import { createErrorResult, emitCommandEvent, emitCommandResult } from './output
 import { maybeRenderSelfUpdateNotice } from './self/update-notice'
 import { resolveAgentInspection } from './services/agents'
 import { getStateFilePath, StateFileError } from './state'
+import { isProcessInterruptionError } from './utils/child-process'
 import { pc } from './utils/color'
 import { createStateReadError } from './utils/lifecycle-errors'
 
@@ -105,7 +106,10 @@ async function executeCommandWithRuntimeInternal<T>(options: ExecuteCommandOptio
 
       if (!result.ok && result.error?.code === 'TIMEOUT') {
         const lateResult = await waitForLateTerminalCompletion(runPromise, timeoutMs)
-        result = lateResult ?? (await emitTimeoutCancellation(options, timeoutMs))
+        result =
+          lateResult && lateResult.error?.code !== 'TIMEOUT'
+            ? lateResult
+            : await emitTimeoutCancellation(options, timeoutMs)
       }
 
       if (timeoutId !== undefined) {
@@ -270,6 +274,7 @@ async function runUntilTimeoutCancellation<T>(
   try {
     return await run()
   } catch (error) {
+    if (isProcessInterruptionError(error) && error.kind === 'timed-out') return getTimeoutResult()
     if (getCliContext().cancelled) return getTimeoutResult()
     throw error
   }

--- a/src/commands/capabilities.ts
+++ b/src/commands/capabilities.ts
@@ -2,20 +2,12 @@ import type { CommandResult } from '../output/types'
 import process from 'node:process'
 import { getAllAgents } from '../agents'
 import { createSuccessResult, emitCommandResult } from '../output'
-import { inspectSelf } from '../self'
+import { createCliOperationContext } from '../runtime/cli-operation-context'
+import { inspectSelfReadOnly } from '../self'
+import { getCommandCapabilitySnapshot, projectCommandCapabilitiesToV1Features } from '../services/command-capabilities'
+import { observeProviderSnapshot, projectProviderSnapshotToV1Installers } from '../services/provider-observations'
 import { pc } from '../utils/color'
-import {
-  getPlatform,
-  isBrewAvailable,
-  isBunAvailable,
-  isCargoAvailable,
-  isDenoAvailable,
-  isMiseAvailable,
-  isNpmAvailable,
-  isPipAvailable,
-  isUvAvailable,
-  isWingetAvailable,
-} from '../utils/detect'
+import { getPlatform } from '../utils/detect'
 
 interface CapabilitiesData {
   agents: string[]
@@ -80,88 +72,37 @@ interface CapabilitiesData {
 }
 
 export async function capabilitiesCommand(): Promise<CommandResult<CapabilitiesData>> {
-  const [
-    bunAvailable,
-    npmAvailable,
-    brewAvailable,
-    cargoAvailable,
-    denoAvailable,
-    miseAvailable,
-    pipAvailable,
-    uvAvailable,
-    wingetAvailable,
-    selfInspection,
-  ] = await Promise.all([
-    isBunAvailable(),
-    isNpmAvailable(),
-    isBrewAvailable(),
-    isCargoAvailable(),
-    isDenoAvailable(),
-    isMiseAvailable(),
-    isPipAvailable(),
-    isUvAvailable(),
-    isWingetAvailable(),
-    inspectSelf(),
-  ])
+  const operation = createCliOperationContext()
+  let providerSnapshot: Awaited<ReturnType<typeof observeProviderSnapshot>>
+  let selfInspection: Awaited<ReturnType<typeof inspectSelfReadOnly>>
+  try {
+    ;[providerSnapshot, selfInspection] = await operation.run(() =>
+      Promise.all([
+        observeProviderSnapshot({ context: operation.context }),
+        inspectSelfReadOnly({ context: operation.context }),
+      ]),
+    )
+  } finally {
+    operation.dispose()
+  }
+  const installers = projectProviderSnapshotToV1Installers(providerSnapshot, entry => {
+    const available = entry.availability.kind === 'success'
+    return {
+      available,
+      reason: available ? undefined : getUnavailableReason(entry.id),
+    }
+  })
+  const features = projectCommandCapabilitiesToV1Features(getCommandCapabilitySnapshot(), {
+    canAutoUpdateSelf: selfInspection.canAutoUpdate,
+  })
 
   return emitCommandResult(
     createSuccessResult<CapabilitiesData>({
       action: 'capabilities',
       data: {
         agents: getAllAgents().map(agent => agent.name),
-        features: {
-          assumeYes: true,
-          cacheBypass: true,
-          cacheRefresh: true,
-          channels: ['stable', 'beta'],
-          colorModes: ['auto', 'always', 'never'],
-          dryRun: true,
-          execInstallPolicies: ['never', 'if-missing', 'always'],
-          freshnessMetadata: true,
-          idempotencyKey: true,
-          logLevels: ['silent', 'error', 'warn', 'info', 'debug'],
-          quietLogs: true,
-          selfUpgrade: selfInspection.canAutoUpdate,
-          timeout: true,
-        },
-        installers: {
-          brew: {
-            available: brewAvailable,
-            reason: brewAvailable ? undefined : getUnavailableReason('brew'),
-          },
-          bun: {
-            available: bunAvailable,
-            reason: bunAvailable ? undefined : getUnavailableReason('bun'),
-          },
-          cargo: {
-            available: cargoAvailable,
-            reason: cargoAvailable ? undefined : getUnavailableReason('cargo'),
-          },
-          deno: {
-            available: denoAvailable,
-            reason: denoAvailable ? undefined : getUnavailableReason('deno'),
-          },
-          mise: {
-            available: miseAvailable,
-            reason: miseAvailable ? undefined : getUnavailableReason('mise'),
-          },
-          npm: {
-            available: npmAvailable,
-            reason: npmAvailable ? undefined : getUnavailableReason('npm'),
-          },
-          pip: {
-            available: pipAvailable,
-            reason: pipAvailable ? undefined : getUnavailableReason('pip'),
-          },
-          uv: {
-            available: uvAvailable,
-            reason: uvAvailable ? undefined : getUnavailableReason('uv'),
-          },
-          winget: {
-            available: wingetAvailable,
-            reason: wingetAvailable ? undefined : getUnavailableReason('winget'),
-          },
-        },
+        features,
+        installers,
         outputModes: ['human', 'json', 'ndjson'],
         platform: {
           arch: process.arch,

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,21 +1,13 @@
 import type { CommandResult } from '../output/types'
 import { getAgentUpdateFailureHint, getManualAgentUpdateMessage } from '../agent-update'
+import { projectObservationToV1Inspection } from '../compatibility/agent-inspection'
 import { BUILD_PACKAGE_NAME } from '../generated/build-meta'
 import { createSuccessResult, emitCommandResult } from '../output'
-import { getSelfUpgradeRecoveryHintForInspection, inspectSelf } from '../self'
-import { inspectRegisteredAgents } from '../services/agents'
+import { createCliOperationContext } from '../runtime/cli-operation-context'
+import { getSelfUpgradeRecoveryHintForInspection, inspectSelfReadOnly } from '../self'
+import { observeRegisteredAgents } from '../services/lifecycle-observations'
+import { observeProviderSnapshot, projectProviderSnapshotToV1Installers } from '../services/provider-observations'
 import { pc } from '../utils/color'
-import {
-  isBrewAvailable,
-  isBunAvailable,
-  isCargoAvailable,
-  isDenoAvailable,
-  isMiseAvailable,
-  isNpmAvailable,
-  isPipAvailable,
-  isUvAvailable,
-  isWingetAvailable,
-} from '../utils/detect'
 import { isVersionNewer } from '../utils/version'
 
 type DoctorIssueCategory = 'agent' | 'installers' | 'self'
@@ -76,24 +68,43 @@ interface DoctorData {
 }
 
 export async function doctorCommand(): Promise<CommandResult<DoctorData>> {
-  const bunAvailable = await isBunAvailable()
-  const npmAvailable = await isNpmAvailable()
-  const brewAvailable = await isBrewAvailable()
-  const cargoAvailable = await isCargoAvailable()
-  const denoAvailable = await isDenoAvailable()
-  const miseAvailable = await isMiseAvailable()
-  const pipAvailable = await isPipAvailable()
-  const uvAvailable = await isUvAvailable()
-  const wingetAvailable = await isWingetAvailable()
-
-  const selfInspection = await inspectSelf()
+  const operation = createCliOperationContext()
+  let providerSnapshot: Awaited<ReturnType<typeof observeProviderSnapshot>>
+  let selfInspection: Awaited<ReturnType<typeof inspectSelfReadOnly>>
+  let observations: Awaited<ReturnType<typeof observeRegisteredAgents>>
+  try {
+    ;[providerSnapshot, selfInspection, observations] = await operation.run(() =>
+      Promise.all([
+        observeProviderSnapshot({ context: operation.context }),
+        inspectSelfReadOnly({ context: operation.context }),
+        observeRegisteredAgents(),
+      ]),
+    )
+  } finally {
+    operation.dispose()
+  }
+  const installers = projectProviderSnapshotToV1Installers(
+    providerSnapshot,
+    entry => entry.availability.kind === 'success',
+  )
+  const { brew: brewAvailable, bun: bunAvailable, cargo: cargoAvailable, deno: denoAvailable } = installers
+  const {
+    mise: miseAvailable,
+    npm: npmAvailable,
+    pip: pipAvailable,
+    uv: uvAvailable,
+    winget: wingetAvailable,
+  } = installers
   const selfOutdated = selfInspection.latestVersion
     ? isVersionNewer(selfInspection.latestVersion, selfInspection.currentVersion)
     : false
-  const inspections = await inspectRegisteredAgents()
+  const inspections = observations.map(observation => ({
+    inspection: projectObservationToV1Inspection(observation),
+    observation,
+  }))
   const installedAgents = inspections
-    .filter(inspection => inspection.inPath)
-    .map(inspection => ({
+    .filter(({ inspection }) => inspection.inPath)
+    .map(({ inspection }) => ({
       displayName: inspection.agent.displayName,
       installedVersion: inspection.installedVersion,
       latestVersion: inspection.latestVersion,
@@ -182,8 +193,8 @@ export async function doctorCommand(): Promise<CommandResult<DoctorData>> {
     })
   }
 
-  for (const inspection of inspections.filter(candidate => candidate.inPath)) {
-    if (!inspection.installedState) {
+  for (const { inspection, observation } of inspections.filter(candidate => candidate.inspection.inPath)) {
+    if (observation.observation.drift.kind === 'untracked') {
       issues.push({
         blocking: false,
         category: 'agent',
@@ -232,17 +243,7 @@ export async function doctorCommand(): Promise<CommandResult<DoctorData>> {
       data: {
         agents: installedAgents,
         issues,
-        installers: {
-          brew: brewAvailable,
-          bun: bunAvailable,
-          cargo: cargoAvailable,
-          deno: denoAvailable,
-          mise: miseAvailable,
-          npm: npmAvailable,
-          pip: pipAvailable,
-          uv: uvAvailable,
-          winget: wingetAvailable,
-        },
+        installers,
         self: {
           canAutoUpdate: selfInspection.canAutoUpdate,
           currentVersion: selfInspection.currentVersion,

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,6 +1,7 @@
 import type { CommandResult } from '../output/types'
+import { projectObservationToV1Inspection } from '../compatibility/agent-inspection'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
-import { resolveAgentInspection } from '../services/agents'
+import { resolveAgentObservation } from '../services/lifecycle-observations'
 import { pc } from '../utils/color'
 import { formatInstallMethodCommand, formatInstallMethodLabel } from '../utils/install'
 
@@ -29,7 +30,7 @@ interface AgentInfoData {
 }
 
 export async function infoCommand(agentName: string): Promise<CommandResult<AgentInfoData>> {
-  const resolved = await resolveAgentInspection(agentName)
+  const resolved = await resolveAgentObservation(agentName)
   if (!resolved) {
     return emitCommandResult(
       createErrorResult<AgentInfoData>({
@@ -50,7 +51,8 @@ export async function infoCommand(agentName: string): Promise<CommandResult<Agen
     )
   }
 
-  const { agent, inspection } = resolved
+  const { agent } = resolved
+  const inspection = projectObservationToV1Inspection(resolved)
   const selfUpdateCommands = agent.selfUpdate
     ? [agent.selfUpdate.command, ...(agent.selfUpdate.fallbackCommands ?? [])].map(command => command.join(' '))
     : []

--- a/src/commands/inspect.ts
+++ b/src/commands/inspect.ts
@@ -1,6 +1,7 @@
 import type { CommandResult } from '../output/types'
+import { projectObservationToV1Inspection } from '../compatibility/agent-inspection'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
-import { resolveAgentInspection } from '../services/agents'
+import { resolveAgentObservation } from '../services/lifecycle-observations'
 import { pc } from '../utils/color'
 import { formatInstallMethodCommand, formatInstallMethodLabel } from '../utils/install'
 
@@ -36,7 +37,7 @@ interface InspectCommandData {
 }
 
 export async function inspectCommand(agentName: string): Promise<CommandResult<InspectCommandData>> {
-  const resolved = await resolveAgentInspection(agentName)
+  const resolved = await resolveAgentObservation(agentName)
   if (!resolved) {
     return emitCommandResult(
       createErrorResult<InspectCommandData>({
@@ -57,7 +58,8 @@ export async function inspectCommand(agentName: string): Promise<CommandResult<I
     )
   }
 
-  const { agent, inspection } = resolved
+  const { agent } = resolved
+  const inspection = projectObservationToV1Inspection(resolved)
   const selfUpdateCommands = agent.selfUpdate
     ? [agent.selfUpdate.command, ...(agent.selfUpdate.fallbackCommands ?? [])].map(command => command.join(' '))
     : []

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,6 +1,7 @@
 import type { CommandResult } from '../output/types'
+import { projectObservationToV1Inspection } from '../compatibility/agent-inspection'
 import { createSuccessResult, emitCommandResult } from '../output'
-import { inspectRegisteredAgents } from '../services/agents'
+import { observeRegisteredAgents } from '../services/lifecycle-observations'
 import { pc } from '../utils/color'
 
 interface ListedAgent {
@@ -16,7 +17,7 @@ interface ListedAgent {
 }
 
 export async function listCommand(): Promise<CommandResult<{ agents: ListedAgent[] }>> {
-  const inspections = await inspectRegisteredAgents()
+  const inspections = (await observeRegisteredAgents()).map(projectObservationToV1Inspection)
 
   return emitCommandResult(
     createSuccessResult<{ agents: ListedAgent[] }>({

--- a/src/commands/resolve.ts
+++ b/src/commands/resolve.ts
@@ -1,6 +1,7 @@
 import type { CommandResult } from '../output/types'
+import { projectObservationToV1Inspection } from '../compatibility/agent-inspection'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
-import { resolveAgentInspection } from '../services/agents'
+import { resolveAgentObservation } from '../services/lifecycle-observations'
 import { pc } from '../utils/color'
 import { formatInstallMethodCommand, formatInstallMethodLabel } from '../utils/install'
 
@@ -32,7 +33,7 @@ interface ResolveCommandData {
 }
 
 export async function resolveCommand(agentName: string): Promise<CommandResult<ResolveCommandData>> {
-  const resolved = await resolveAgentInspection(agentName)
+  const resolved = await resolveAgentObservation(agentName)
   if (!resolved) {
     return emitCommandResult(
       createErrorResult<ResolveCommandData>({
@@ -53,7 +54,8 @@ export async function resolveCommand(agentName: string): Promise<CommandResult<R
     )
   }
 
-  const { agent, inspection } = resolved
+  const { agent } = resolved
+  const inspection = projectObservationToV1Inspection(resolved)
   if (!inspection.inPath || !inspection.binaryPath) {
     const installMethods = inspection.methods
       .map(method => ({

--- a/src/compatibility/agent-inspection.ts
+++ b/src/compatibility/agent-inspection.ts
@@ -1,0 +1,21 @@
+import type { AgentInspection } from '../inspection'
+import type { ResolvedAgentObservation } from '../services/lifecycle-observations'
+import { formatInstalledSource, formatUpdateManagement, getInstallLifecycle } from '../utils/install'
+
+export function projectObservationToV1Inspection(result: ResolvedAgentObservation): AgentInspection {
+  const executable = result.pathExecutable
+
+  return {
+    agent: result.agent,
+    methods: result.methods,
+    installedState: result.installedState,
+    inPath: executable.present,
+    installedVersion: executable.present ? executable.version : undefined,
+    latestVersion: result.latestVersion,
+    binaryPath: executable.present ? executable.path : undefined,
+    resolvedBinaryPath: executable.present ? result.resolvedBinaryPath : undefined,
+    sourceLabel: formatInstalledSource(result.installedState),
+    updateLabel: formatUpdateManagement(result.agent, result.installedState),
+    lifecycle: result.installedState ? getInstallLifecycle(result.installedState.installType) : 'unmanaged',
+  }
+}

--- a/src/lifecycle/agent-observation.ts
+++ b/src/lifecycle/agent-observation.ts
@@ -1,0 +1,390 @@
+import type { AgentDefinition, Platform } from '../agents'
+import type { ProviderOperation, ProviderOutcome, ProviderObservation, ProviderRegistry } from '../providers'
+import type { InstalledAgentState } from '../state'
+import type { LifecycleObservation, LifecycleReceipt } from './model'
+import {
+  type LifecycleProviderBinding,
+  observeLifecycleProvider,
+  providerBindingsEqual,
+  resolveCatalogProviderEvidence,
+  resolveReceiptProviderBinding,
+  resolveStateProviderBinding,
+} from './provider-evidence'
+
+export interface AgentExecutableObservation {
+  readonly path?: string
+  readonly present: boolean
+  readonly version?: string
+}
+
+export interface AgentLifecycleObservationPorts {
+  readonly clock: () => string
+  readonly inspectExecutable: (agent: AgentDefinition) => Promise<AgentExecutableObservation>
+  readonly platform: Platform
+  readonly providerRegistry: ProviderRegistry
+  readonly readInstalledState: (agentName: string) => Promise<InstalledAgentState | undefined>
+  readonly readReceipt: (agentName: string) => Promise<LifecycleReceipt | undefined>
+  readonly signal: AbortSignal
+  readonly timeoutMs?: number
+  readonly observeProvider?: (
+    binding: LifecycleProviderBinding,
+    options: {
+      readonly registry: ProviderRegistry
+      readonly signal: AbortSignal
+      readonly timeoutMs?: number
+    },
+  ) => Promise<ProviderOutcome<ProviderObservation>>
+}
+
+export interface AgentLifecycleObservationResult {
+  readonly binding?: LifecycleProviderBinding
+  readonly capabilities: readonly ProviderOperation[]
+  readonly catalogMethods: readonly LifecycleProviderBinding[]
+  readonly executable: AgentExecutableObservation
+  readonly installedState?: InstalledAgentState
+  readonly observation: LifecycleObservation
+  readonly pathExecutable: AgentExecutableObservation
+  readonly providerOutcome?: ProviderOutcome<ProviderObservation>
+  readonly receipt?: LifecycleReceipt
+}
+
+export async function observeAgentLifecycle(
+  agent: AgentDefinition,
+  ports: AgentLifecycleObservationPorts,
+): Promise<AgentLifecycleObservationResult> {
+  const [executable, installedState, receipt] = await Promise.all([
+    ports.inspectExecutable(agent),
+    ports.readInstalledState(agent.name),
+    ports.readReceipt(agent.name),
+  ])
+  const observedAt = ports.clock()
+  const catalogEvidence = resolveCatalogProviderEvidence(agent, ports.platform)
+  const catalogMethods = catalogEvidence.bindings
+  const stateBinding = installedState ? resolveStateProviderBinding(agent, installedState) : undefined
+  const receiptBinding = receipt ? resolveReceiptProviderBinding(receipt) : undefined
+  const base = { catalogMethods, executable, installedState, pathExecutable: executable, receipt }
+
+  if ((installedState && !stateBinding) || (receipt && !receiptBinding)) {
+    return {
+      ...base,
+      capabilities: [],
+      observation: indeterminateObservation(agent, observedAt, 'Persisted provider binding cannot be resolved.'),
+    }
+  }
+
+  if (stateBinding && receiptBinding && !providerBindingsEqual(stateBinding, receiptBinding, agent.binaryName)) {
+    return {
+      ...base,
+      capabilities: [],
+      observation: executable.present
+        ? presentObservation(agent, executable, observedAt, {
+            kind: 'conflicting-source',
+            observedProviderId: stateBinding.providerId,
+            recordedProviderId: receiptBinding.providerId,
+          })
+        : {
+            drift: {
+              kind: 'conflicting-source',
+              observedProviderId: stateBinding.providerId,
+              recordedProviderId: receiptBinding.providerId,
+            },
+            kind: 'absent',
+            observedAt,
+            targetId: agent.name,
+          },
+    }
+  }
+
+  const recordedBinding = receiptBinding ?? stateBinding
+  if (recordedBinding) {
+    const providerOutcome = await observeProvider(recordedBinding, ports)
+    const capabilities = ports.providerRegistry.getCapabilities(recordedBinding.providerId)
+    if (providerOutcome.kind !== 'success') {
+      return {
+        ...base,
+        binding: recordedBinding,
+        capabilities,
+        observation: indeterminateObservation(agent, observedAt, providerOutcomeReason(providerOutcome)),
+        providerOutcome,
+      }
+    }
+
+    const providerObservation = providerOutcome.value
+    if (!providerTargetMatches(recordedBinding, providerObservation)) {
+      return {
+        ...base,
+        binding: recordedBinding,
+        capabilities,
+        observation: conflictingProviderTargetObservation(agent, executable, observedAt),
+        providerOutcome,
+      }
+    }
+    if (providerObservation.kind === 'absent' && !executable.present) {
+      return {
+        ...base,
+        binding: recordedBinding,
+        capabilities,
+        observation: {
+          drift: { kind: 'recorded-absent' },
+          kind: 'absent',
+          observedAt,
+          targetId: agent.name,
+        },
+        providerOutcome,
+      }
+    }
+
+    const evidenceConflicts =
+      providerObservation.kind !== (executable.present ? 'present' : 'absent') ||
+      (providerObservation.kind === 'present' &&
+        executable.present &&
+        providerObservation.executablePath !== undefined &&
+        executable.path !== undefined &&
+        providerObservation.executablePath !== executable.path) ||
+      (receipt?.executablePath !== undefined &&
+        executable.path !== undefined &&
+        receipt.executablePath !== executable.path) ||
+      executableIdentityConflicts(agent, installedState, receipt, recordedBinding)
+    const liveExecutable = mergeExecutableObservation(executable, providerObservation)
+
+    return {
+      ...base,
+      binding: recordedBinding,
+      capabilities,
+      executable: liveExecutable,
+      observation: presentObservation(
+        agent,
+        liveExecutable,
+        observedAt,
+        evidenceConflicts
+          ? {
+              kind: 'conflicting-source',
+              observedProviderId: providerObservation.kind === 'present' ? recordedBinding.providerId : undefined,
+              recordedProviderId: recordedBinding.providerId,
+            }
+          : { kind: 'none' },
+        providerObservation.kind === 'present' ? recordedBinding : undefined,
+      ),
+      providerOutcome,
+    }
+  }
+
+  const candidateOutcomes = await Promise.all(
+    catalogMethods.map(async binding => ({ binding, outcome: await observeProvider(binding, ports) })),
+  )
+  const mismatchedCandidate = candidateOutcomes.find(
+    candidate =>
+      candidate.outcome.kind === 'success' && !providerTargetMatches(candidate.binding, candidate.outcome.value),
+  )
+  if (mismatchedCandidate) {
+    return {
+      ...base,
+      capabilities: [],
+      observation: conflictingProviderTargetObservation(agent, executable, observedAt),
+      providerOutcome: mismatchedCandidate.outcome,
+    }
+  }
+
+  const liveCandidates = candidateOutcomes.filter(
+    (
+      candidate,
+    ): candidate is typeof candidate & {
+      outcome: { kind: 'success'; value: Extract<ProviderObservation, { kind: 'present' }> }
+    } => candidate.outcome.kind === 'success' && candidate.outcome.value.kind === 'present',
+  )
+  if (liveCandidates.length > 1) {
+    return {
+      ...base,
+      capabilities: [],
+      observation: executable.present
+        ? presentObservation(agent, executable, observedAt, { kind: 'conflicting-source' })
+        : {
+            drift: { kind: 'conflicting-source' },
+            kind: 'indeterminate',
+            observedAt,
+            reason: 'Multiple catalog providers report the agent as present.',
+            targetId: agent.name,
+          },
+    }
+  }
+
+  if (catalogEvidence.unresolvedCandidates.length > 0) {
+    return {
+      ...base,
+      capabilities: [],
+      observation: indeterminateObservation(agent, observedAt, 'A catalog provider binding cannot be resolved.'),
+    }
+  }
+
+  const unresolvedOutcome = candidateOutcomes.map(candidate => candidate.outcome).find(isNonSuccessProviderOutcome)
+  if (unresolvedOutcome) {
+    return {
+      ...base,
+      capabilities: [],
+      observation: indeterminateObservation(agent, observedAt, providerOutcomeReason(unresolvedOutcome)),
+      providerOutcome: unresolvedOutcome,
+    }
+  }
+
+  const liveCandidate = liveCandidates[0]
+  if (liveCandidate) {
+    const binding = liveCandidate.binding
+    const providerObservation = liveCandidate.outcome.value
+    const liveExecutable = mergeExecutableObservation(executable, providerObservation)
+    const evidenceConflicts =
+      !executable.present ||
+      (providerObservation.executablePath !== undefined &&
+        executable.path !== undefined &&
+        providerObservation.executablePath !== executable.path)
+    return {
+      ...base,
+      binding,
+      capabilities: ports.providerRegistry.getCapabilities(binding.providerId),
+      executable: liveExecutable,
+      observation: presentObservation(
+        agent,
+        liveExecutable,
+        observedAt,
+        evidenceConflicts
+          ? { kind: 'conflicting-source', observedProviderId: binding.providerId }
+          : { kind: 'untracked' },
+        binding,
+      ),
+      providerOutcome: liveCandidate.outcome,
+    }
+  }
+
+  return {
+    ...base,
+    capabilities: [],
+    observation: executable.present
+      ? presentObservation(agent, executable, observedAt, { kind: 'untracked' })
+      : { drift: { kind: 'none' }, kind: 'absent', observedAt, targetId: agent.name },
+  }
+}
+
+async function observeProvider(
+  binding: LifecycleProviderBinding,
+  ports: AgentLifecycleObservationPorts,
+): Promise<ProviderOutcome<ProviderObservation>> {
+  try {
+    return await (ports.observeProvider ?? observeLifecycleProvider)(binding, {
+      registry: ports.providerRegistry,
+      signal: ports.signal,
+      timeoutMs: ports.timeoutMs,
+    })
+  } catch (error) {
+    return {
+      kind: 'failed',
+      reason: safeProviderRejectionReason(error),
+      retryable: false,
+    }
+  }
+}
+
+function presentObservation(
+  agent: AgentDefinition,
+  executable: AgentExecutableObservation,
+  observedAt: string,
+  drift: LifecycleObservation['drift'],
+  binding?: LifecycleProviderBinding,
+): LifecycleObservation {
+  return {
+    drift,
+    ...(executable.path ? { executablePath: executable.path } : {}),
+    kind: 'present',
+    observedAt,
+    ...(binding
+      ? {
+          providerId: binding.providerId,
+          providerTargetId: binding.target.id,
+          providerTargetKind: binding.target.kind,
+        }
+      : {}),
+    targetId: agent.name,
+    ...(executable.version ? { version: executable.version } : {}),
+  }
+}
+
+function indeterminateObservation(agent: AgentDefinition, observedAt: string, reason: string): LifecycleObservation {
+  return {
+    drift: { kind: 'indeterminate', reason },
+    kind: 'indeterminate',
+    observedAt,
+    reason,
+    targetId: agent.name,
+  }
+}
+
+function mergeExecutableObservation(
+  executable: AgentExecutableObservation,
+  providerObservation: ProviderObservation,
+): AgentExecutableObservation {
+  if (providerObservation.kind === 'absent') return executable
+  return {
+    path: executable.path ?? providerObservation.executablePath,
+    present: true,
+    version: executable.version ?? providerObservation.version,
+  }
+}
+
+function executableIdentityConflicts(
+  agent: AgentDefinition,
+  state: InstalledAgentState | undefined,
+  receipt: LifecycleReceipt | undefined,
+  binding: LifecycleProviderBinding,
+): boolean {
+  const identities = [agent.binaryName, state?.binaryName, receipt?.executableName, binding.target.binaryName].filter(
+    (identity): identity is string => identity !== undefined,
+  )
+  return new Set(identities).size > 1
+}
+
+function providerTargetMatches(binding: LifecycleProviderBinding, observation: ProviderObservation): boolean {
+  return binding.target.id === observation.target.id && binding.target.kind === observation.target.kind
+}
+
+function conflictingProviderTargetObservation(
+  agent: AgentDefinition,
+  executable: AgentExecutableObservation,
+  observedAt: string,
+): LifecycleObservation {
+  if (executable.present) {
+    return presentObservation(agent, executable, observedAt, { kind: 'conflicting-source' })
+  }
+  return {
+    drift: { kind: 'conflicting-source' },
+    kind: 'indeterminate',
+    observedAt,
+    reason: 'Provider evidence does not match the requested target identity.',
+    targetId: agent.name,
+  }
+}
+
+function providerOutcomeReason(outcome: Exclude<ProviderOutcome<ProviderObservation>, { kind: 'success' }>): string {
+  switch (outcome.kind) {
+    case 'unsupported':
+      return outcome.reason ?? `Provider does not support ${outcome.operation}.`
+    case 'unavailable':
+    case 'failed':
+    case 'indeterminate':
+      return outcome.reason
+    case 'cancelled':
+      return outcome.reason ?? 'Provider observation was cancelled.'
+    case 'timed-out':
+      return `Provider observation timed out after ${outcome.timeoutMs}ms.`
+  }
+}
+
+function isNonSuccessProviderOutcome(
+  outcome: ProviderOutcome<ProviderObservation>,
+): outcome is Exclude<ProviderOutcome<ProviderObservation>, { kind: 'success' }> {
+  return outcome.kind !== 'success'
+}
+
+function safeProviderRejectionReason(error: unknown): string {
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return `Provider observation rejected: ${error.message.trim().slice(0, 500)}`
+  }
+  return 'Provider observation rejected unexpectedly.'
+}

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -18,6 +18,12 @@ export type {
   ProviderCapability,
 } from './model'
 export {
+  type AgentExecutableObservation,
+  type AgentLifecycleObservationPorts,
+  type AgentLifecycleObservationResult,
+  observeAgentLifecycle,
+} from './agent-observation'
+export {
   type LifecycleMutationDecision,
   type LifecycleMutationPlanningInput,
   type LifecycleMutationPlanningResult,
@@ -25,9 +31,13 @@ export {
 } from './mutation-planner'
 export { type PlanValidationIssue, type PlanValidationIssueCode, validateLifecyclePlan } from './plan-validation'
 export {
+  type CatalogProviderEvidence,
   type LifecycleProviderBinding,
   type ObserveLifecycleProviderOptions,
   observeLifecycleProvider,
+  providerBindingsEqual,
+  resolveCatalogProviderBindings,
+  resolveCatalogProviderEvidence,
   resolveReceiptProviderBinding,
   resolveStateProviderBinding,
 } from './provider-evidence'

--- a/src/lifecycle/model.ts
+++ b/src/lifecycle/model.ts
@@ -45,12 +45,24 @@ export type LifecycleObservation =
       readonly kind: 'present'
       readonly providerId?: string
       readonly providerTargetId?: string
+      readonly providerTargetKind?: 'binary' | 'cask' | 'formula' | 'id' | 'package' | 'script' | 'tool'
       readonly version?: string
     })
   | (LifecycleObservationBase & {
       readonly kind: 'indeterminate'
       readonly reason: string
     })
+
+export type LifecycleProviderTargetKind = NonNullable<
+  Extract<LifecycleObservation, { kind: 'present' }>['providerTargetKind']
+>
+
+export interface LifecyclePlanningProvider {
+  readonly capabilities: readonly string[]
+  readonly providerId: string
+  readonly targetId: string
+  readonly targetKind: LifecycleProviderTargetKind
+}
 
 interface ProviderEffectBase {
   readonly capability: ProviderCapability

--- a/src/lifecycle/mutation-planner.ts
+++ b/src/lifecycle/mutation-planner.ts
@@ -2,6 +2,7 @@ import type {
   LifecycleIntent,
   LifecycleObservation,
   LifecyclePlan,
+  LifecyclePlanningProvider,
   LifecyclePostcondition,
   LifecycleStep,
 } from './model'
@@ -13,11 +14,14 @@ export type LifecycleMutationDecision =
   | 'install'
   | 'preserve-unmanaged'
   | 'satisfied'
+  | 'unsupported'
   | 'uninstall'
 
 export interface LifecycleMutationPlanningInput {
   readonly intent: LifecycleIntent
   readonly observation: LifecycleObservation
+  readonly provider?: LifecyclePlanningProvider
+  /** Compatibility fields for the already-migrated Phase 6 mutation paths. */
   readonly providerId?: string
   readonly providerTargetId?: string
 }
@@ -45,12 +49,14 @@ function decideMutation(input: LifecycleMutationPlanningInput): LifecycleMutatio
 
   if (observation.kind === 'indeterminate' || observation.drift.kind === 'indeterminate') return 'blocked'
   if (observation.drift.kind === 'conflicting-source') return 'blocked'
+  if (providerContextConflicts(input)) return 'blocked'
 
   if (intent.kind === 'uninstall') {
     if (observation.kind === 'absent') {
       return observation.drift.kind === 'recorded-absent' ? 'clear-ghost' : 'preserve-unmanaged'
     }
-    return observation.providerId && input.providerTargetId ? 'uninstall' : 'preserve-unmanaged'
+    if (!observation.providerId || !providerTargetId(input)) return 'preserve-unmanaged'
+    return supports(input, 'uninstall') ? 'uninstall' : 'unsupported'
   }
 
   if (observation.kind === 'present') {
@@ -60,7 +66,23 @@ function decideMutation(input: LifecycleMutationPlanningInput): LifecycleMutatio
     return 'satisfied'
   }
 
-  return input.providerId && input.providerTargetId ? 'install' : 'blocked'
+  if (!providerId(input) || !providerTargetId(input)) return 'blocked'
+  return supports(input, 'install') ? 'install' : 'unsupported'
+}
+
+function providerContextConflicts(input: LifecycleMutationPlanningInput): boolean {
+  const { observation, provider } = input
+  if (observation.kind !== 'present' || provider === undefined) return false
+
+  return (
+    (observation.providerId !== undefined && observation.providerId !== provider.providerId) ||
+    (observation.providerTargetId !== undefined && observation.providerTargetId !== provider.targetId) ||
+    (observation.providerTargetKind !== undefined && observation.providerTargetKind !== provider.targetKind)
+  )
+}
+
+function supports(input: LifecycleMutationPlanningInput, operation: 'install' | 'uninstall'): boolean {
+  return input.provider === undefined || input.provider.capabilities.includes(operation)
 }
 
 function createSteps(
@@ -89,6 +111,7 @@ function createSteps(
     case 'blocked':
     case 'preserve-unmanaged':
     case 'satisfied':
+    case 'unsupported':
       return []
   }
 }
@@ -98,18 +121,17 @@ function providerMutationStep(
   input: LifecycleMutationPlanningInput,
   postcondition: LifecyclePostcondition,
 ): LifecycleStep {
-  const providerId =
-    input.observation.kind === 'present' ? (input.observation.providerId ?? input.providerId) : input.providerId
-  const providerTargetId = input.providerTargetId!
+  const resolvedProviderId = providerId(input)!
+  const resolvedProviderTargetId = providerTargetId(input)!
 
   return {
     dependsOn: [],
     effects: [
       {
-        capability: `${providerId}-${operation}`,
+        capability: `${resolvedProviderId}-${operation}`,
         kind: 'provider-mutation',
-        providerId,
-        targetId: providerTargetId,
+        providerId: resolvedProviderId,
+        targetId: resolvedProviderTargetId,
       },
     ],
     id: `${operation}-${input.intent.targetId}`,
@@ -125,10 +147,21 @@ function packagePostcondition(
 ): LifecyclePostcondition {
   return {
     kind,
-    providerId:
-      input.observation.kind === 'present' ? (input.observation.providerId ?? input.providerId!) : input.providerId!,
-    targetId: input.providerTargetId!,
+    providerId: providerId(input)!,
+    targetId: providerTargetId(input)!,
   }
+}
+
+function providerId(input: LifecycleMutationPlanningInput): string | undefined {
+  return input.observation.kind === 'present'
+    ? (input.observation.providerId ?? input.provider?.providerId ?? input.providerId)
+    : (input.provider?.providerId ?? input.providerId)
+}
+
+function providerTargetId(input: LifecycleMutationPlanningInput): string | undefined {
+  return input.observation.kind === 'present'
+    ? (input.observation.providerTargetId ?? input.provider?.targetId ?? input.providerTargetId)
+    : (input.provider?.targetId ?? input.providerTargetId)
 }
 
 function operationStep(id: string, postconditions: readonly LifecyclePostcondition[]): LifecycleStep {

--- a/src/lifecycle/provider-evidence.ts
+++ b/src/lifecycle/provider-evidence.ts
@@ -1,4 +1,4 @@
-import type { AgentDefinition } from '../agents'
+import type { AgentDefinition, InstallMethod, Platform } from '../agents'
 import type {
   ProviderId,
   ProviderObservation,
@@ -14,6 +14,11 @@ import { firstPartyProviderRegistry, firstPartyProviderIds } from '../providers'
 export interface LifecycleProviderBinding {
   readonly providerId: ProviderId
   readonly target: ProviderTarget
+}
+
+export interface CatalogProviderEvidence {
+  readonly bindings: readonly LifecycleProviderBinding[]
+  readonly unresolvedCandidates: readonly InstallMethod[]
 }
 
 export interface ObserveLifecycleProviderOptions {
@@ -81,6 +86,54 @@ export async function observeLifecycleProvider(
     },
     target: binding.target,
   })
+}
+
+export function resolveCatalogProviderBindings(
+  agent: AgentDefinition,
+  platform: Platform,
+): readonly LifecycleProviderBinding[] {
+  return resolveCatalogProviderEvidence(agent, platform).bindings
+}
+
+export function resolveCatalogProviderEvidence(agent: AgentDefinition, platform: Platform): CatalogProviderEvidence {
+  const resolved = (agent.platforms[platform] ?? []).map(method => ({
+    binding: resolveStateProviderBinding(agent, {
+      agentName: agent.name,
+      ...(method.binaryName ? { binaryName: method.binaryName } : {}),
+      ...(method.command ? { command: method.command } : {}),
+      installType: method.type,
+      ...(method.packageInstallArgs ? { packageInstallArgs: method.packageInstallArgs } : {}),
+      ...(method.packageName ? { packageName: method.packageName } : {}),
+      ...(method.packageTargetKind ? { packageTargetKind: method.packageTargetKind } : {}),
+    }),
+    method,
+  }))
+  const bindings = resolved
+    .map(candidate => candidate.binding)
+    .filter((binding): binding is LifecycleProviderBinding => binding !== undefined)
+
+  return {
+    bindings: bindings.filter(
+      (binding, index) =>
+        bindings.findIndex(candidate => providerBindingsEqual(candidate, binding, agent.binaryName)) === index,
+    ),
+    unresolvedCandidates: resolved
+      .filter(candidate => candidate.binding === undefined)
+      .map(candidate => candidate.method),
+  }
+}
+
+export function providerBindingsEqual(
+  left: LifecycleProviderBinding,
+  right: LifecycleProviderBinding,
+  defaultExecutableName?: string,
+): boolean {
+  return (
+    left.providerId === right.providerId &&
+    left.target.id === right.target.id &&
+    left.target.kind === right.target.kind &&
+    (left.target.binaryName ?? defaultExecutableName) === (right.target.binaryName ?? defaultExecutableName)
+  )
 }
 
 function resolveStateTargetId(agent: AgentDefinition, state: InstalledAgentState): string | undefined {

--- a/src/package-manager/bun.ts
+++ b/src/package-manager/bun.ts
@@ -1,8 +1,16 @@
+import type { ProviderOperationContext } from '../providers'
 import { readFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
-import { readProcessOutput, spawnCommand, spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
+import {
+  readProcessOutput,
+  readProcessOutputWithContext,
+  isProcessInterruptionError,
+  spawnCommand,
+  spawnWithQuantexStdio,
+  waitForSpawnedCommand,
+} from '../utils/child-process'
 import { normalizeRegistryUrl } from '../utils/registry'
 
 export type RegistryUpdateStrategy = 'latest-major' | 'respect-semver'
@@ -86,12 +94,16 @@ const defaultPresenceDependencies: BunPresenceProbeDependencies = {
 async function readPackagePresence(
   packageName: string,
   dependencies: BunPresenceProbeDependencies = defaultPresenceDependencies,
+  context?: ProviderOperationContext,
 ): Promise<{ presence: PackagePresenceProbe; version?: string }> {
   try {
     const proc = spawnCommand(['bun', 'pm', '-g', 'ls'], {
+      detached: context !== undefined && process.platform !== 'win32',
       stdio: createPipedStdio(),
     })
-    const { stderr, stdout } = await readProcessOutput(proc)
+    const { stderr, stdout } = context
+      ? await readProcessOutputWithContext(proc, context)
+      : await readProcessOutput(proc)
     if (!stdout.trim()) {
       if (stderr.includes('No package.json was found for directory')) return { presence: 'absent' }
       if (stderr.includes('Lockfile not found')) {
@@ -109,7 +121,8 @@ async function readPackagePresence(
     if (hasGlobalPackageEntry(stdout, packageName)) return { presence: 'present' }
 
     return { presence: 'absent' }
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return { presence: 'unknown' }
   }
 }
@@ -117,12 +130,16 @@ async function readPackagePresence(
 export async function probePackagePresence(
   packageName: string,
   dependencies: BunPresenceProbeDependencies = defaultPresenceDependencies,
+  context?: ProviderOperationContext,
 ): Promise<PackagePresenceProbe> {
-  return (await readPackagePresence(packageName, dependencies)).presence
+  return (await readPackagePresence(packageName, dependencies, context)).presence
 }
 
-export async function getInstalledVersion(packageName: string): Promise<string | undefined> {
-  return (await readPackagePresence(packageName)).version
+export async function getInstalledVersion(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<string | undefined> {
+  return (await readPackagePresence(packageName, defaultPresenceDependencies, context)).version
 }
 
 function hasGlobalPackageEntry(output: string, packageName: string): boolean {

--- a/src/package-manager/mise.ts
+++ b/src/package-manager/mise.ts
@@ -1,4 +1,13 @@
-import { readProcessOutput, spawnCommand, spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
+import type { ProviderOperationContext } from '../providers'
+import process from 'node:process'
+import {
+  readProcessOutput,
+  readProcessOutputWithContext,
+  isProcessInterruptionError,
+  spawnCommand,
+  spawnWithQuantexStdio,
+  waitForSpawnedCommand,
+} from '../utils/child-process'
 
 async function runMiseUseCommand(packageName: string, force = false): Promise<boolean> {
   try {
@@ -35,12 +44,16 @@ export async function uninstall(packageName: string): Promise<boolean> {
 
 export type PackagePresenceProbe = 'present' | 'absent' | 'unknown'
 
-async function readPackagePresence(packageName: string): Promise<{ presence: PackagePresenceProbe; version?: string }> {
+async function readPackagePresence(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<{ presence: PackagePresenceProbe; version?: string }> {
   try {
     const proc = spawnCommand(['mise', 'ls', '--installed', '--json', packageName], {
+      detached: context !== undefined && process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'ignore'],
     })
-    const { stdout } = await readProcessOutput(proc)
+    const { stdout } = context ? await readProcessOutputWithContext(proc, context) : await readProcessOutput(proc)
     if (!stdout.trim()) return { presence: 'unknown' }
 
     try {
@@ -56,17 +69,24 @@ async function readPackagePresence(packageName: string): Promise<{ presence: Pac
     } catch {
       return { presence: 'unknown' }
     }
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return { presence: 'unknown' }
   }
 }
 
-export async function probePackagePresence(packageName: string): Promise<PackagePresenceProbe> {
-  return (await readPackagePresence(packageName)).presence
+export async function probePackagePresence(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<PackagePresenceProbe> {
+  return (await readPackagePresence(packageName, context)).presence
 }
 
-export async function getInstalledVersion(packageName: string): Promise<string | undefined> {
-  return (await readPackagePresence(packageName)).version
+export async function getInstalledVersion(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<string | undefined> {
+  return (await readPackagePresence(packageName, context)).version
 }
 
 export function parseMiseInstalledVersion(output: string, packageName: string): string | undefined {

--- a/src/package-manager/npm.ts
+++ b/src/package-manager/npm.ts
@@ -1,5 +1,13 @@
+import type { ProviderOperationContext } from '../providers'
 import type { RegistryUpdateStrategy } from './bun'
-import { readProcessOutput, spawnCommand, spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
+import {
+  readProcessOutput,
+  readProcessOutputWithContext,
+  isProcessInterruptionError,
+  spawnCommand,
+  spawnWithQuantexStdio,
+  waitForSpawnedCommand,
+} from '../utils/child-process'
 import { normalizeRegistryUrl } from '../utils/registry'
 
 export async function install(packageName: string, distTag?: string, registry?: string): Promise<boolean> {
@@ -86,12 +94,16 @@ interface PackagePresenceResult {
   version?: string
 }
 
-async function readPackagePresence(packageName: string): Promise<PackagePresenceResult> {
+async function readPackagePresence(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<PackagePresenceResult> {
   try {
     const proc = spawnCommand(['npm', 'list', '-g', packageName, '--depth=0', '--json'], {
+      detached: context !== undefined && process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'ignore'],
     })
-    const { stdout } = await readProcessOutput(proc)
+    const { stdout } = context ? await readProcessOutputWithContext(proc, context) : await readProcessOutput(proc)
     if (!stdout.trim()) return { presence: 'unknown' }
 
     try {
@@ -112,17 +124,24 @@ async function readPackagePresence(packageName: string): Promise<PackagePresence
     } catch {
       return { presence: 'unknown' }
     }
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return { presence: 'unknown' }
   }
 }
 
-export async function probePackagePresence(packageName: string): Promise<PackagePresenceProbe> {
-  return (await readPackagePresence(packageName)).presence
+export async function probePackagePresence(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<PackagePresenceProbe> {
+  return (await readPackagePresence(packageName, context)).presence
 }
 
-export async function getInstalledVersion(packageName: string): Promise<string | undefined> {
-  return (await readPackagePresence(packageName)).version
+export async function getInstalledVersion(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<string | undefined> {
+  return (await readPackagePresence(packageName, context)).version
 }
 
 export function parseGlobalPackageVersion(output: string, packageName: string): string | undefined {

--- a/src/package-manager/uv.ts
+++ b/src/package-manager/uv.ts
@@ -1,4 +1,13 @@
-import { readProcessOutput, spawnCommand, spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
+import type { ProviderOperationContext } from '../providers'
+import process from 'node:process'
+import {
+  readProcessOutput,
+  readProcessOutputWithContext,
+  isProcessInterruptionError,
+  spawnCommand,
+  spawnWithQuantexStdio,
+  waitForSpawnedCommand,
+} from '../utils/child-process'
 
 async function runUvToolCommand(
   action: 'install' | 'upgrade',
@@ -44,12 +53,16 @@ export async function uninstall(packageName: string): Promise<boolean> {
 
 export type PackagePresenceProbe = 'present' | 'absent' | 'unknown'
 
-async function readPackagePresence(packageName: string): Promise<{ presence: PackagePresenceProbe; version?: string }> {
+async function readPackagePresence(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<{ presence: PackagePresenceProbe; version?: string }> {
   try {
     const proc = spawnCommand(['uv', 'tool', 'list'], {
+      detached: context !== undefined && process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'ignore'],
     })
-    const { stdout } = await readProcessOutput(proc)
+    const { stdout } = context ? await readProcessOutputWithContext(proc, context) : await readProcessOutput(proc)
     if (!stdout.trim()) return { presence: 'unknown' }
 
     const version = parseToolListVersion(stdout, packageName)
@@ -57,17 +70,24 @@ async function readPackagePresence(packageName: string): Promise<{ presence: Pac
     if (!hasUvToolEntries(stdout)) return { presence: 'unknown' }
 
     return { presence: 'absent' }
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return { presence: 'unknown' }
   }
 }
 
-export async function probePackagePresence(packageName: string): Promise<PackagePresenceProbe> {
-  return (await readPackagePresence(packageName)).presence
+export async function probePackagePresence(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<PackagePresenceProbe> {
+  return (await readPackagePresence(packageName, context)).presence
 }
 
-export async function getInstalledVersion(packageName: string): Promise<string | undefined> {
-  return (await readPackagePresence(packageName)).version
+export async function getInstalledVersion(
+  packageName: string,
+  context?: ProviderOperationContext,
+): Promise<string | undefined> {
+  return (await readPackagePresence(packageName, context)).version
 }
 
 function hasUvToolEntries(output: string): boolean {

--- a/src/providers/adapters/brew.ts
+++ b/src/providers/adapters/brew.ts
@@ -5,8 +5,9 @@ import * as detectUtils from '../../utils/detect'
 import { createSystemPackageAdapter } from './system-package'
 
 const defaultDependencies: SystemPackageAdapterDependencies = {
+  contextualObservation: true,
   install: target => brewPm.install(target.id, target.kind === 'cask' ? 'cask' : 'package'),
-  isAvailable: () => detectUtils.isBrewAvailable(),
+  isAvailable: context => detectUtils.isBrewAvailable(context),
   probePackagePresence: async () => 'unknown',
   uninstall: target => brewPm.uninstall(target.id, target.kind === 'cask' ? 'cask' : 'package'),
   update: target => brewPm.update(target.id, target.kind === 'cask' ? 'cask' : 'package'),

--- a/src/providers/adapters/bun.ts
+++ b/src/providers/adapters/bun.ts
@@ -34,13 +34,14 @@ const commands: RegistryPackageCommandBuilders = {
 }
 
 const defaultDependencies: BunProviderDependencies = {
-  getInstalledVersion: packageName => bunPm.getInstalledVersion(packageName),
+  contextualPackageObservation: true,
+  getInstalledVersion: (packageName, context) => bunPm.getInstalledVersion(packageName, context),
   install: (packageName, distTag, registry) =>
     distTag === undefined && registry === undefined
       ? bunPm.install(packageName)
       : bunPm.install(packageName, distTag, registry),
-  isAvailable: () => detectUtils.isBunAvailable(),
-  probePackagePresence: packageName => bunPm.probePackagePresence(packageName),
+  isAvailable: context => detectUtils.isBunAvailable(context),
+  probePackagePresence: (packageName, context) => bunPm.probePackagePresence(packageName, undefined, context),
   resolveLatestVersion: (packageName, distTag, registry) =>
     versionUtils.getLatestVersion(packageName, distTag, { registry }),
   uninstall: packageName => bunPm.uninstall(packageName),

--- a/src/providers/adapters/cargo.ts
+++ b/src/providers/adapters/cargo.ts
@@ -5,8 +5,9 @@ import * as detectUtils from '../../utils/detect'
 import { createSystemPackageAdapter } from './system-package'
 
 const defaultDependencies: SystemPackageAdapterDependencies = {
+  contextualObservation: true,
   install: target => cargoPm.install(target.id, target.arguments ? [...target.arguments] : undefined),
-  isAvailable: () => detectUtils.isCargoAvailable(),
+  isAvailable: context => detectUtils.isCargoAvailable(context),
   probePackagePresence: async () => 'unknown',
   uninstall: target => cargoPm.uninstall(target.id),
   update: target => cargoPm.update(target.id, target.arguments ? [...target.arguments] : undefined),

--- a/src/providers/adapters/deno.ts
+++ b/src/providers/adapters/deno.ts
@@ -5,8 +5,9 @@ import * as detectUtils from '../../utils/detect'
 import { createSystemPackageAdapter } from './system-package'
 
 const defaultDependencies: SystemPackageAdapterDependencies = {
+  contextualObservation: true,
   install: target => denoPm.install(target.id, target.arguments ? [...target.arguments] : undefined),
-  isAvailable: () => detectUtils.isDenoAvailable(),
+  isAvailable: context => detectUtils.isDenoAvailable(context),
   probePackagePresence: async () => 'unknown',
   uninstall: target => denoPm.uninstall(target.binaryName ?? target.id),
   update: target => denoPm.update(target.id, target.arguments ? [...target.arguments] : undefined),

--- a/src/providers/adapters/legacy-operation.ts
+++ b/src/providers/adapters/legacy-operation.ts
@@ -1,4 +1,5 @@
 import type { ProviderOperationContext, ProviderOutcome } from '../types'
+import { isProcessInterruptionError } from '../../utils/child-process'
 
 export type PendingOperation<T> =
   | { readonly kind: 'cancelled'; readonly reason?: string }
@@ -51,6 +52,23 @@ export async function runPendingOperation<T>(
   if (timeout) clearTimeout(timeout)
   context.signal.removeEventListener('abort', cancel)
   return outcome
+}
+
+export async function runContextualOperation<T>(
+  context: ProviderOperationContext,
+  invoke: () => Promise<T>,
+): Promise<PendingOperation<T>> {
+  if (context.signal.aborted) return { kind: 'cancelled', reason: abortReason(context.signal) }
+  try {
+    return { kind: 'resolved', value: await invoke() }
+  } catch (error) {
+    if (isProcessInterruptionError(error)) {
+      return error.kind === 'timed-out'
+        ? { kind: 'timed-out', timeoutMs: error.timeoutMs! }
+        : { kind: 'cancelled', ...(error.reason ? { reason: error.reason } : {}) }
+    }
+    return { kind: 'rejected', reason: safeErrorReason(error) }
+  }
 }
 
 function abortReason(signal: AbortSignal): string | undefined {

--- a/src/providers/adapters/mise.ts
+++ b/src/providers/adapters/mise.ts
@@ -5,10 +5,11 @@ import * as detectUtils from '../../utils/detect'
 import { createSystemPackageAdapter } from './system-package'
 
 const defaultDependencies: SystemPackageAdapterDependencies = {
-  getInstalledVersion: target => misePm.getInstalledVersion(target.id),
+  contextualObservation: true,
+  getInstalledVersion: (target, context) => misePm.getInstalledVersion(target.id, context),
   install: target => misePm.install(target.id),
-  isAvailable: () => detectUtils.isMiseAvailable(),
-  probePackagePresence: target => misePm.probePackagePresence(target.id),
+  isAvailable: context => detectUtils.isMiseAvailable(context),
+  probePackagePresence: (target, context) => misePm.probePackagePresence(target.id, context),
   uninstall: target => misePm.uninstall(target.id),
   update: target => misePm.update(target.id),
   updateMany: targets => misePm.updateMany(targets.map(target => ({ packageName: target.id }))),

--- a/src/providers/adapters/npm.ts
+++ b/src/providers/adapters/npm.ts
@@ -33,13 +33,14 @@ const commands: RegistryPackageCommandBuilders = {
 }
 
 const defaultDependencies: NpmProviderDependencies = {
-  getInstalledVersion: packageName => npmPm.getInstalledVersion(packageName),
+  contextualPackageObservation: true,
+  getInstalledVersion: (packageName, context) => npmPm.getInstalledVersion(packageName, context),
   install: (packageName, distTag, registry) =>
     distTag === undefined && registry === undefined
       ? npmPm.install(packageName)
       : npmPm.install(packageName, distTag, registry),
-  isAvailable: () => detectUtils.isNpmAvailable(),
-  probePackagePresence: packageName => npmPm.probePackagePresence(packageName),
+  isAvailable: context => detectUtils.isNpmAvailable(context),
+  probePackagePresence: (packageName, context) => npmPm.probePackagePresence(packageName, context),
   resolveLatestVersion: (packageName, distTag, registry) =>
     versionUtils.getLatestVersion(packageName, distTag, { registry }),
   uninstall: packageName => npmPm.uninstall(packageName),

--- a/src/providers/adapters/pip.ts
+++ b/src/providers/adapters/pip.ts
@@ -4,8 +4,9 @@ import * as detectUtils from '../../utils/detect'
 import { createSystemPackageAdapter } from './system-package'
 
 const defaultDependencies: SystemPackageAdapterDependencies = {
+  contextualObservation: true,
   install: target => pipPm.install(target.id),
-  isAvailable: () => detectUtils.isPipAvailable(),
+  isAvailable: context => detectUtils.isPipAvailable(context),
   probePackagePresence: async () => 'unknown',
   uninstall: target => pipPm.uninstall(target.id),
   update: target => pipPm.update(target.id),

--- a/src/providers/adapters/registry-package.ts
+++ b/src/providers/adapters/registry-package.ts
@@ -12,15 +12,24 @@ import type {
   RegistryPackageUpdateStrategy,
 } from '../types'
 import { normalizeRegistryUrl } from '../../utils/registry'
-import { interruptedOutcome, isInterruptedOperation, runPendingOperation } from './legacy-operation'
+import {
+  interruptedOutcome,
+  isInterruptedOperation,
+  runContextualOperation,
+  runPendingOperation,
+} from './legacy-operation'
 
 export type RegistryPackagePresence = 'absent' | 'present' | 'unknown'
 
 export interface RegistryPackageAdapterDependencies {
-  readonly getInstalledVersion: (packageName: string) => Promise<string | undefined>
+  readonly getInstalledVersion: (packageName: string, context?: ProviderOperationContext) => Promise<string | undefined>
   readonly install: (packageName: string, distTag?: string, registry?: string) => Promise<boolean>
-  readonly isAvailable: () => Promise<boolean>
-  readonly probePackagePresence: (packageName: string) => Promise<RegistryPackagePresence>
+  readonly isAvailable: (context?: ProviderOperationContext) => Promise<boolean>
+  readonly probePackagePresence: (
+    packageName: string,
+    context?: ProviderOperationContext,
+  ) => Promise<RegistryPackagePresence>
+  readonly contextualPackageObservation?: boolean
   readonly resolveLatestVersion: (
     packageName: string,
     distTag: string,
@@ -67,8 +76,8 @@ export function createRegistryPackageAdapter<Id extends Extract<ProviderId, 'bun
   const providerEvidence = evidence('provider', config.id)
 
   const observe = async (request: ProviderTargetRequest) => {
-    const presence = await runPendingOperation(request.context, () =>
-      dependencies.probePackagePresence(request.target.id),
+    const presence = await runPackageObservation(request.context, dependencies.contextualPackageObservation, () =>
+      dependencies.probePackagePresence(request.target.id, request.context),
     )
     if (isInterruptedOperation(presence)) return interruptedOutcome(presence)
 
@@ -89,8 +98,10 @@ export function createRegistryPackageAdapter<Id extends Extract<ProviderId, 'bun
       })
     }
 
-    const installedVersion = await runPendingOperation(request.context, () =>
-      dependencies.getInstalledVersion(request.target.id),
+    const installedVersion = await runPackageObservation(
+      request.context,
+      dependencies.contextualPackageObservation,
+      () => dependencies.getInstalledVersion(request.target.id, request.context),
     )
     if (isInterruptedOperation(installedVersion)) return interruptedOutcome(installedVersion)
 
@@ -110,7 +121,9 @@ export function createRegistryPackageAdapter<Id extends Extract<ProviderId, 'bun
 
   return {
     availability: async context => {
-      const available = await runPendingOperation(context, () => dependencies.isAvailable())
+      const available = await runPackageObservation(context, dependencies.contextualPackageObservation, () =>
+        dependencies.isAvailable(context),
+      )
       if (isInterruptedOperation(available)) return interruptedOutcome(available)
 
       if (available.kind === 'rejected' || !available.value) {
@@ -181,6 +194,14 @@ export function createRegistryPackageAdapter<Id extends Extract<ProviderId, 'bun
       })
     },
   }
+}
+
+function runPackageObservation<T>(
+  context: ProviderOperationContext,
+  contextual: boolean | undefined,
+  invoke: () => Promise<T>,
+): Promise<import('./legacy-operation').PendingOperation<T>> {
+  return contextual ? runContextualOperation(context, invoke) : runPendingOperation(context, invoke)
 }
 
 async function updateMany<Id extends Extract<ProviderId, 'bun' | 'npm'>>(

--- a/src/providers/adapters/system-package.ts
+++ b/src/providers/adapters/system-package.ts
@@ -8,15 +8,27 @@ import type {
   ProviderTarget,
   ProviderTargetRequest,
 } from '../types'
-import { interruptedOutcome, isInterruptedOperation, runPendingOperation } from './legacy-operation'
+import {
+  interruptedOutcome,
+  isInterruptedOperation,
+  runContextualOperation,
+  runPendingOperation,
+} from './legacy-operation'
 
 export type SystemPackagePresence = 'absent' | 'present' | 'unknown'
 
 export interface SystemPackageAdapterDependencies {
-  readonly getInstalledVersion?: (target: ProviderTarget) => Promise<string | undefined>
+  readonly contextualObservation?: boolean
+  readonly getInstalledVersion?: (
+    target: ProviderTarget,
+    context?: import('../types').ProviderOperationContext,
+  ) => Promise<string | undefined>
   readonly install: (target: ProviderTarget) => Promise<boolean>
-  readonly isAvailable: () => Promise<boolean>
-  readonly probePackagePresence: (target: ProviderTarget) => Promise<SystemPackagePresence>
+  readonly isAvailable: (context?: import('../types').ProviderOperationContext) => Promise<boolean>
+  readonly probePackagePresence: (
+    target: ProviderTarget,
+    context?: import('../types').ProviderOperationContext,
+  ) => Promise<SystemPackagePresence>
   readonly uninstall: (target: ProviderTarget) => Promise<boolean>
   readonly update: (target: ProviderTarget) => Promise<boolean>
   readonly updateMany: (targets: readonly ProviderTarget[]) => Promise<boolean>
@@ -41,7 +53,9 @@ export function createSystemPackageAdapter<Id extends SystemPackageProviderId>(
   dependencies: SystemPackageAdapterDependencies,
 ): ProviderAdapter & { readonly id: Id } {
   const observe = async (request: ProviderTargetRequest) => {
-    const presence = await runPendingOperation(request.context, () => dependencies.probePackagePresence(request.target))
+    const presence = await runObservation(request.context, dependencies.contextualObservation, () =>
+      dependencies.probePackagePresence(request.target, request.context),
+    )
     if (isInterruptedOperation(presence)) return interruptedOutcome(presence)
 
     if (presence.kind === 'rejected' || presence.value === 'unknown') {
@@ -60,7 +74,9 @@ export function createSystemPackageAdapter<Id extends SystemPackageProviderId>(
     }
 
     const version = dependencies.getInstalledVersion
-      ? await runPendingOperation(request.context, () => dependencies.getInstalledVersion!(request.target))
+      ? await runObservation(request.context, dependencies.contextualObservation, () =>
+          dependencies.getInstalledVersion!(request.target, request.context),
+        )
       : undefined
     if (version && isInterruptedOperation(version)) return interruptedOutcome(version)
 
@@ -74,7 +90,9 @@ export function createSystemPackageAdapter<Id extends SystemPackageProviderId>(
 
   return {
     availability: async context => {
-      const available = await runPendingOperation(context, () => dependencies.isAvailable())
+      const available = await runObservation(context, dependencies.contextualObservation, () =>
+        dependencies.isAvailable(context),
+      )
       if (isInterruptedOperation(available)) return interruptedOutcome(available)
       if (available.kind === 'rejected' || !available.value) {
         return { kind: 'unavailable', reason: `${config.id} executable is unavailable` }
@@ -102,6 +120,14 @@ export function createSystemPackageAdapter<Id extends SystemPackageProviderId>(
       return success({ evidence: observation.value.evidence ?? [], kind: 'satisfied' as const })
     },
   }
+}
+
+function runObservation<T>(
+  context: import('../types').ProviderOperationContext,
+  contextual: boolean | undefined,
+  invoke: () => Promise<T>,
+): Promise<import('./legacy-operation').PendingOperation<T>> {
+  return contextual ? runContextualOperation(context, invoke) : runPendingOperation(context, invoke)
 }
 
 async function mutate<Id extends SystemPackageProviderId>(

--- a/src/providers/adapters/uv.ts
+++ b/src/providers/adapters/uv.ts
@@ -5,10 +5,11 @@ import * as detectUtils from '../../utils/detect'
 import { createSystemPackageAdapter } from './system-package'
 
 const defaultDependencies: SystemPackageAdapterDependencies = {
-  getInstalledVersion: target => uvPm.getInstalledVersion(target.id),
+  contextualObservation: true,
+  getInstalledVersion: (target, context) => uvPm.getInstalledVersion(target.id, context),
   install: target => uvPm.install(target.id, target.arguments ? [...target.arguments] : undefined),
-  isAvailable: () => detectUtils.isUvAvailable(),
-  probePackagePresence: target => uvPm.probePackagePresence(target.id),
+  isAvailable: context => detectUtils.isUvAvailable(context),
+  probePackagePresence: (target, context) => uvPm.probePackagePresence(target.id, context),
   uninstall: target => uvPm.uninstall(target.id),
   update: target => uvPm.update(target.id, target.arguments ? [...target.arguments] : undefined),
   updateMany: targets =>

--- a/src/providers/adapters/winget.ts
+++ b/src/providers/adapters/winget.ts
@@ -5,8 +5,9 @@ import * as detectUtils from '../../utils/detect'
 import { createSystemPackageAdapter } from './system-package'
 
 const defaultDependencies: SystemPackageAdapterDependencies = {
+  contextualObservation: true,
   install: target => wingetPm.install(target.id),
-  isAvailable: () => detectUtils.isWingetAvailable(),
+  isAvailable: context => detectUtils.isWingetAvailable(context),
   probePackagePresence: async () => 'unknown',
   uninstall: target => wingetPm.uninstall(target.id),
   update: target => wingetPm.update(target.id),

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -22,6 +22,7 @@ export {
   type ProviderOperationContext,
   type ProviderOutcome,
   type ProviderResolvedVersion,
+  type ProviderResourceCleanup,
   type ProviderTarget,
   type ProviderTargetKind,
   type ProviderTargetOperation,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -29,8 +29,14 @@ export interface ProviderTarget {
 }
 
 export interface ProviderOperationContext {
+  readonly registerCleanup?: (cleanup: ProviderResourceCleanup) => () => void
   readonly signal: AbortSignal
   readonly timeoutMs?: number
+}
+
+export interface ProviderResourceCleanup {
+  cleanup(): Promise<void> | void
+  force?(): Promise<void> | void
 }
 
 export type RegistryPackageUpdateStrategy = 'latest-major' | 'respect-semver'

--- a/src/runtime/cli-operation-context.ts
+++ b/src/runtime/cli-operation-context.ts
@@ -1,0 +1,81 @@
+import type { ProviderOperationContext, ProviderResourceCleanup } from '../providers'
+import { getCliContext, registerCliCancellationHandler } from '../cli-context'
+import { ProcessInterruptionError } from '../utils/child-process'
+
+const CLEANUP_GRACE_MS = 500
+const FORCE_GRACE_MS = 250
+
+export interface CliOperationContext {
+  readonly context: ProviderOperationContext
+  dispose(): void
+  run<T>(invoke: () => Promise<T>): Promise<T>
+}
+
+export function createCliOperationContext(): CliOperationContext {
+  const cliContext = getCliContext()
+  const controller = new AbortController()
+  const cleanups = new Set<ProviderResourceCleanup>()
+  if (cliContext.cancelled) controller.abort('cancelled')
+  const unregister = registerCliCancellationHandler(async () => {
+    controller.abort('cancelled')
+    const resources = [...cleanups]
+    const graceful = Promise.allSettled(resources.map(resource => Promise.resolve().then(() => resource.cleanup())))
+    if (await settlesWithin(graceful, CLEANUP_GRACE_MS)) return
+    const forced = Promise.allSettled(resources.map(resource => Promise.resolve().then(() => resource.force?.())))
+    await settlesWithin(forced, FORCE_GRACE_MS)
+  })
+
+  return {
+    context: {
+      registerCleanup(cleanup): () => void {
+        cleanups.add(cleanup)
+        return () => cleanups.delete(cleanup)
+      },
+      signal: controller.signal,
+      timeoutMs: cliContext.timeoutMs,
+    },
+    dispose(): void {
+      unregister()
+      cleanups.clear()
+    },
+    async run<T>(invoke: () => Promise<T>): Promise<T> {
+      if (controller.signal.aborted) throw cancelledError(controller.signal)
+      let cancel!: () => void
+      const cancellation = new Promise<never>((_resolve, reject) => {
+        cancel = () => reject(cancelledError(controller.signal))
+        controller.signal.addEventListener('abort', cancel, { once: true })
+      })
+      try {
+        return await Promise.race([Promise.resolve().then(invoke), cancellation])
+      } finally {
+        controller.signal.removeEventListener('abort', cancel)
+      }
+    },
+  }
+}
+
+function cancelledError(signal: AbortSignal): ProcessInterruptionError {
+  const reason =
+    typeof signal.reason === 'string'
+      ? signal.reason
+      : signal.reason instanceof Error
+        ? signal.reason.message
+        : signal.reason === undefined
+          ? undefined
+          : String(signal.reason)
+  return new ProcessInterruptionError({ kind: 'cancelled', reason })
+}
+
+async function settlesWithin(work: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      work.then(() => true),
+      new Promise<false>(resolve => {
+        timeout = setTimeout(() => resolve(false), timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}

--- a/src/self/facts.ts
+++ b/src/self/facts.ts
@@ -15,13 +15,28 @@ const NODE_MODULES_SEGMENT = `/node_modules/${CLI_NPM_PACKAGE_NAME}`
 export async function resolveSelfInstallFacts(options?: {
   updateChannel?: SelfUpdateChannel
 }): Promise<SelfInstallFacts> {
+  return resolveSelfInstallFactsWithPersistence(options, true)
+}
+
+export async function resolveSelfInstallFactsReadOnly(options?: {
+  updateChannel?: SelfUpdateChannel
+}): Promise<SelfInstallFacts> {
+  return resolveSelfInstallFactsWithPersistence(options, false)
+}
+
+async function resolveSelfInstallFactsWithPersistence(
+  options: { updateChannel?: SelfUpdateChannel } | undefined,
+  persistDetectedSource: boolean,
+): Promise<SelfInstallFacts> {
   const metadata = await resolveSelfPackageMetadata()
   const executablePath = process.execPath
   const detectedInstallSource = metadata.foundPackageJson
     ? detectSelfInstallSource(metadata.packageRoot)
     : detectSelfInstallSource('', executablePath)
   const state = await getSelfState()
-  const installSource = await reconcileSelfInstallSource(state.installSource, detectedInstallSource)
+  const installSource = persistDetectedSource
+    ? await reconcileSelfInstallSource(state.installSource, detectedInstallSource)
+    : resolveSelfInstallSource(state.installSource, detectedInstallSource)
   const config = await loadConfig()
   const updateChannel = getSelfUpdateChannel(options?.updateChannel, config.selfUpdateChannel)
 
@@ -33,6 +48,13 @@ export async function resolveSelfInstallFacts(options?: {
     packageRoot: metadata.packageRoot,
     updateChannel,
   }
+}
+
+export function resolveSelfInstallSource(
+  storedInstallSource: SelfInstallSource | undefined,
+  detectedInstallSource: SelfInstallSource,
+): SelfInstallSource {
+  return detectedInstallSource !== 'unknown' ? detectedInstallSource : (storedInstallSource ?? detectedInstallSource)
 }
 
 export function canAutoUpdateSelf(installSource: SelfInstallSource): boolean {
@@ -48,7 +70,7 @@ export async function reconcileSelfInstallSource(
     return detectedInstallSource
   }
 
-  return storedInstallSource ?? detectedInstallSource
+  return resolveSelfInstallSource(storedInstallSource, detectedInstallSource)
 }
 
 export function detectSelfInstallSource(

--- a/src/self/index.ts
+++ b/src/self/index.ts
@@ -1,5 +1,7 @@
+import type { ProviderOperationContext } from '../providers'
 import type { SelfInspection, SelfInstallSource, SelfUpdateChannel, SelfUpdateResult, SelfUpgradePlan } from './types'
 import process from 'node:process'
+import { resolveSelfInstallFactsReadOnly } from './facts'
 import { acquireSelfUpgradeLock } from './lock'
 import {
   buildPlanFromInspection,
@@ -12,6 +14,14 @@ import { getSelfUpgradeRecoveryHint } from './recovery'
 
 export async function inspectSelf(options?: { updateChannel?: SelfUpdateChannel }): Promise<SelfInspection> {
   return buildSelfInspectionFromPlan(await planSelfUpgrade({ updateChannel: options?.updateChannel }))
+}
+
+export async function inspectSelfReadOnly(options?: {
+  context?: ProviderOperationContext
+  updateChannel?: SelfUpdateChannel
+}): Promise<SelfInspection> {
+  const facts = await resolveSelfInstallFactsReadOnly({ updateChannel: options?.updateChannel })
+  return buildSelfInspectionFromPlan(await planSelfUpgrade({ context: options?.context, facts }))
 }
 
 export async function upgradeSelf(planOrInspection?: SelfInspection | SelfUpgradePlan): Promise<SelfUpdateResult> {
@@ -69,6 +79,8 @@ export {
   getSelfVersion,
   reconcileSelfInstallSource,
   resolveSelfInstallFacts,
+  resolveSelfInstallFactsReadOnly,
+  resolveSelfInstallSource,
   resolveSelfPackageMetadata,
 } from './facts'
 export {

--- a/src/self/planning.ts
+++ b/src/self/planning.ts
@@ -1,20 +1,27 @@
+import type { ProviderOperationContext } from '../providers'
 import type { SelfInspection, SelfInstallFacts, SelfUpdateResult, SelfUpdateTarget, SelfUpgradePlan } from './types'
 import { join } from 'node:path'
 import process from 'node:process'
 import { loadConfig } from '../config'
 import { BUILD_PACKAGE_NAME } from '../generated/build-meta'
+import { isProcessInterruptionError } from '../utils/child-process'
 import { OFFICIAL_NPM_REGISTRY } from '../utils/registry'
 import { compareVersions, getInstalledVersion, getLatestVersion, isVersionNewer } from '../utils/version'
 import { resolveSelfInstallFacts } from './facts'
 import { resolveManagedSelfUpdateRegistry } from './registry'
 import { fetchBinaryReleaseManifest, resolveBinaryReleaseAsset } from './release'
 
-export async function resolveSelfUpdateTarget(facts: SelfInstallFacts): Promise<SelfUpdateTarget> {
+export async function resolveSelfUpdateTarget(
+  facts: SelfInstallFacts,
+  context?: ProviderOperationContext,
+): Promise<SelfUpdateTarget> {
   const config = await loadConfig()
 
   if (facts.installSource === 'binary') {
     try {
-      const manifest = await fetchBinaryReleaseManifest(facts.updateChannel)
+      const manifest = context
+        ? await fetchBinaryReleaseManifest(facts.updateChannel, context)
+        : await fetchBinaryReleaseManifest(facts.updateChannel)
       const asset = resolveBinaryReleaseAsset(manifest, facts.executablePath)
 
       if (!asset) {
@@ -33,7 +40,8 @@ export async function resolveSelfUpdateTarget(facts: SelfInstallFacts): Promise<
         binaryAsset: asset,
         targetVersion: manifest.version,
       }
-    } catch {
+    } catch (error) {
+      if (isProcessInterruptionError(error)) throw error
       return {
         resolutionError: {
           kind: 'network',
@@ -45,6 +53,7 @@ export async function resolveSelfUpdateTarget(facts: SelfInstallFacts): Promise<
 
   const packageTag = facts.updateChannel === 'beta' ? 'beta' : 'latest'
   const upstreamLatestVersion = await getLatestVersion(BUILD_PACKAGE_NAME, packageTag, {
+    ...(context ? { context } : {}),
     registry: OFFICIAL_NPM_REGISTRY,
   })
 
@@ -56,6 +65,7 @@ export async function resolveSelfUpdateTarget(facts: SelfInstallFacts): Promise<
       managedRegistryIsOverride: managedRegistry?.isOverride ?? false,
       packageTag,
       targetVersion: await getLatestVersion(BUILD_PACKAGE_NAME, packageTag, {
+        ...(context ? { context } : {}),
         registry: managedRegistry?.registry,
       }),
       upstreamLatestVersion,
@@ -71,12 +81,13 @@ export async function resolveSelfUpdateTarget(facts: SelfInstallFacts): Promise<
 }
 
 export async function planSelfUpgrade(options?: {
+  context?: ProviderOperationContext
   facts?: SelfInstallFacts
   target?: SelfUpdateTarget
   updateChannel?: SelfInstallFacts['updateChannel']
 }): Promise<SelfUpgradePlan> {
   const facts = options?.facts ?? (await resolveSelfInstallFacts({ updateChannel: options?.updateChannel }))
-  const target = options?.target ?? (await resolveSelfUpdateTarget(facts))
+  const target = options?.target ?? (await resolveSelfUpdateTarget(facts, options?.context))
   const updateAvailable = target.targetVersion ? isVersionNewer(target.targetVersion, facts.currentVersion) : false
 
   return {

--- a/src/self/release.ts
+++ b/src/self/release.ts
@@ -1,3 +1,4 @@
+import type { ProviderOperationContext } from '../providers'
 import type { SelfUpdateChannel } from './types'
 import { basename } from 'node:path'
 import process from 'node:process'
@@ -89,21 +90,29 @@ export async function fetchBinaryReleaseChecksum(assetName: string): Promise<str
   return checksum
 }
 
-export async function fetchBinaryReleaseManifest(channel: SelfUpdateChannel): Promise<BinaryReleaseManifest> {
-  const manifestUrl = await resolveBinaryReleaseManifestUrl(channel)
-  const manifest = await fetchJsonWithCache<BinaryReleaseManifest>(manifestUrl, `self:manifest:${channel}`)
+export async function fetchBinaryReleaseManifest(
+  channel: SelfUpdateChannel,
+  context?: ProviderOperationContext,
+): Promise<BinaryReleaseManifest> {
+  const manifestUrl = await resolveBinaryReleaseManifestUrl(channel, context)
+  const manifest = await fetchJsonWithCache<BinaryReleaseManifest>(manifestUrl, `self:manifest:${channel}`, {
+    context,
+  })
 
   if (!manifest) throw new Error('Failed to download release manifest.')
 
   return manifest
 }
 
-export async function resolveBinaryReleaseManifestUrl(channel: SelfUpdateChannel): Promise<string> {
+export async function resolveBinaryReleaseManifestUrl(
+  channel: SelfUpdateChannel,
+  context?: ProviderOperationContext,
+): Promise<string> {
   if (!BUILD_REPOSITORY_URL) throw new Error('No repository URL is configured for Quantex releases.')
 
   if (channel === 'stable') return `${BUILD_REPOSITORY_URL}/releases/latest/download/manifest.json`
 
-  const release = await fetchGitHubReleaseSummary(channel)
+  const release = await fetchGitHubReleaseSummary(channel, context)
   const manifestAsset = release.assets.find(asset => asset.name === 'manifest.json')
 
   if (!manifestAsset?.browser_download_url)
@@ -112,7 +121,10 @@ export async function resolveBinaryReleaseManifestUrl(channel: SelfUpdateChannel
   return manifestAsset.browser_download_url
 }
 
-export async function fetchGitHubReleaseSummary(channel: SelfUpdateChannel): Promise<GitHubReleaseSummary> {
+export async function fetchGitHubReleaseSummary(
+  channel: SelfUpdateChannel,
+  context?: ProviderOperationContext,
+): Promise<GitHubReleaseSummary> {
   const repositorySlug = getRepositorySlug()
 
   if (!repositorySlug) throw new Error('Failed to resolve the GitHub repository slug for Quantex releases.')
@@ -120,6 +132,7 @@ export async function fetchGitHubReleaseSummary(channel: SelfUpdateChannel): Pro
   const releases = await fetchJsonWithCache<GitHubReleaseSummary[]>(
     `https://api.github.com/repos/${repositorySlug}/releases?per_page=20`,
     'self:github-releases',
+    { context },
   )
 
   if (!releases) throw new Error('Failed to query GitHub releases.')

--- a/src/self/update-notice.ts
+++ b/src/self/update-notice.ts
@@ -1,9 +1,9 @@
 import { getCliContext } from '../cli-context'
-import { getSelfState, setSelfUpdateNoticeState } from '../state'
+import { getSelfState } from '../state'
 import { pc } from '../utils/color'
 import { printInfo } from '../utils/user-output'
 import { isVersionNewer } from '../utils/version'
-import { inspectSelf } from './index'
+import { inspectSelfReadOnly } from './index'
 
 const UPDATE_NOTICE_THROTTLE_MS = 24 * 60 * 60 * 1000
 const SELF_UPGRADE_NOTICE_SKIPPED_ACTIONS = new Set(['doctor', 'upgrade'])
@@ -14,7 +14,7 @@ export async function maybeRenderSelfUpdateNotice(options: { action: string; ok:
   const context = getCliContext()
   if (context.outputMode !== 'human' || context.quiet) return
 
-  const inspection = await inspectSelf()
+  const inspection = await inspectSelfReadOnly()
   if (!inspection.latestVersion || !isVersionNewer(inspection.latestVersion, inspection.currentVersion)) return
 
   const selfState = await getSelfState()
@@ -33,7 +33,6 @@ export async function maybeRenderSelfUpdateNotice(options: { action: string; ok:
       `Quantex CLI ${inspection.latestVersion} is available (current ${inspection.currentVersion}). ${nextStep}`,
     ),
   )
-  await setSelfUpdateNoticeState(inspection.latestVersion, new Date(now).toISOString())
 }
 
 export function shouldSuppressUpdateNotice(

--- a/src/services/agents.ts
+++ b/src/services/agents.ts
@@ -12,6 +12,7 @@ export function resolveAgent(agentName: string): AgentDefinition | undefined {
   return agentRegistry.getAgentByNameOrAlias(agentName)
 }
 
+// Mutation and execution consumers intentionally remain on the legacy inspection implementation.
 export async function resolveAgentInspection(agentName: string): Promise<ResolvedAgentInspection | undefined> {
   const agent = resolveAgent(agentName)
   if (!agent) return undefined

--- a/src/services/command-capabilities.ts
+++ b/src/services/command-capabilities.ts
@@ -1,0 +1,65 @@
+import type { CommandContract, CommandEffect, StableCommandName } from '../command-contract/registry'
+import { getCommandContracts } from '../command-contract/registry'
+
+export interface CommandCapabilitySnapshot {
+  readonly effects: ReadonlySet<CommandEffect>
+  readonly effectsByCommand: ReadonlyMap<StableCommandName, ReadonlySet<CommandEffect>>
+  readonly flags: ReadonlySet<string>
+  readonly flagsByCommand: ReadonlyMap<StableCommandName, ReadonlySet<string>>
+}
+
+export interface V1CommandCapabilities {
+  readonly assumeYes: boolean
+  readonly cacheBypass: boolean
+  readonly cacheRefresh: boolean
+  readonly channels: string[]
+  readonly colorModes: string[]
+  readonly dryRun: boolean
+  readonly execInstallPolicies: string[]
+  readonly freshnessMetadata: boolean
+  readonly idempotencyKey: boolean
+  readonly logLevels: string[]
+  readonly quietLogs: boolean
+  readonly selfUpgrade: boolean
+  readonly timeout: boolean
+}
+
+export function getCommandCapabilitySnapshot(
+  contracts: readonly CommandContract[] = getCommandContracts(),
+): CommandCapabilitySnapshot {
+  const effectsByCommand = new Map(contracts.map(contract => [contract.name, new Set(contract.effects)] as const))
+  const flagsByCommand = new Map(contracts.map(contract => [contract.name, new Set(contract.flags)] as const))
+
+  return {
+    effects: new Set(contracts.flatMap(contract => contract.effects)),
+    effectsByCommand,
+    flags: new Set(contracts.flatMap(contract => contract.flags)),
+    flagsByCommand,
+  }
+}
+
+export function projectCommandCapabilitiesToV1Features(
+  snapshot: CommandCapabilitySnapshot,
+  options: { readonly canAutoUpdateSelf: boolean },
+): V1CommandCapabilities {
+  const upgradeEffects = snapshot.effectsByCommand.get('upgrade')
+  const upgradeFlags = snapshot.flagsByCommand.get('upgrade')
+  const execFlags = snapshot.flagsByCommand.get('exec')
+
+  return {
+    assumeYes: snapshot.flags.has('--yes'),
+    cacheBypass: snapshot.flags.has('--no-cache'),
+    cacheRefresh: snapshot.flags.has('--refresh'),
+    channels: upgradeFlags?.has('--channel') ? ['stable', 'beta'] : [],
+    colorModes: snapshot.flags.has('--color') ? ['auto', 'always', 'never'] : [],
+    dryRun: snapshot.flags.has('--dry-run'),
+    execInstallPolicies: execFlags?.has('--install') ? ['never', 'if-missing', 'always'] : [],
+    freshnessMetadata:
+      snapshot.effects.has('network') && snapshot.flags.has('--refresh') && snapshot.flags.has('--no-cache'),
+    idempotencyKey: snapshot.flags.has('--idempotency-key'),
+    logLevels: snapshot.flags.has('--log-level') ? ['silent', 'error', 'warn', 'info', 'debug'] : [],
+    quietLogs: snapshot.flags.has('--quiet'),
+    selfUpgrade: options.canAutoUpdateSelf && Boolean(upgradeEffects?.has('mutation') && upgradeEffects.has('network')),
+    timeout: snapshot.flags.has('--timeout'),
+  }
+}

--- a/src/services/lifecycle-observations.ts
+++ b/src/services/lifecycle-observations.ts
@@ -1,0 +1,174 @@
+import type { AgentDefinition, InstallMethod, Platform } from '../agents'
+import type {
+  AgentExecutableObservation,
+  AgentLifecycleObservationPorts,
+  AgentLifecycleObservationResult,
+  LifecycleReceipt,
+} from '../lifecycle'
+import type { ProviderOperationContext, ProviderRegistry } from '../providers'
+import type { InstalledAgentState } from '../state'
+import * as agentRegistry from '../agents'
+import { observeAgentLifecycle } from '../lifecycle'
+import { getOrderedInstallMethods } from '../package-manager'
+import { firstPartyProviderRegistry } from '../providers'
+import { createCliOperationContext } from '../runtime/cli-operation-context'
+import { getInstalledAgentState, getLifecycleReceipt } from '../state'
+import { getPlatform, isBinaryInPath } from '../utils/detect'
+import { getLatestVersionPackage } from '../utils/install'
+import { getBinaryPath, getInstalledVersion, getLatestVersion, getResolvedBinaryPath } from '../utils/version'
+
+export interface ResolvedAgentObservation extends AgentLifecycleObservationResult {
+  readonly agent: AgentDefinition
+  readonly latestVersion?: string
+  readonly methods: InstallMethod[]
+  readonly resolvedBinaryPath?: string
+}
+
+export interface LifecycleObservationServicePorts {
+  readonly clock: () => string
+  readonly getAllAgents: () => AgentDefinition[]
+  readonly getAgentByNameOrAlias: (name: string) => AgentDefinition | undefined
+  readonly getLatestVersion: (
+    agent: AgentDefinition,
+    installedState: InstalledAgentState | undefined,
+    methods: InstallMethod[],
+  ) => Promise<string | undefined>
+  readonly getOrderedInstallMethods: (agent: AgentDefinition) => Promise<InstallMethod[]>
+  readonly getPlatform: () => Platform
+  readonly getResolvedBinaryPath: (binaryPath?: string) => Promise<string | undefined>
+  readonly inspectExecutable: (
+    agent: AgentDefinition,
+    installedState: InstalledAgentState | undefined,
+  ) => Promise<AgentExecutableObservation>
+  readonly observeAgentLifecycle: (
+    agent: AgentDefinition,
+    ports: AgentLifecycleObservationPorts,
+  ) => Promise<AgentLifecycleObservationResult>
+  readonly providerRegistry: ProviderRegistry
+  readonly readInstalledState: (agentName: string) => Promise<InstalledAgentState | undefined>
+  readonly readReceipt: (agentName: string) => Promise<LifecycleReceipt | undefined>
+  readonly signal: AbortSignal
+  readonly timeoutMs?: number
+}
+
+export interface LifecycleObservationService {
+  observeRegisteredAgents(): Promise<ResolvedAgentObservation[]>
+  resolveAgentObservation(agentName: string): Promise<ResolvedAgentObservation | undefined>
+}
+
+export function createLifecycleObservationService(
+  ports: LifecycleObservationServicePorts,
+): LifecycleObservationService {
+  async function observe(agent: AgentDefinition): Promise<ResolvedAgentObservation> {
+    let installedStatePromise: Promise<InstalledAgentState | undefined> | undefined
+    const readInstalledState = (): Promise<InstalledAgentState | undefined> => {
+      installedStatePromise ??= ports.readInstalledState(agent.name)
+      return installedStatePromise
+    }
+    const [methods, result] = await Promise.all([
+      ports.getOrderedInstallMethods(agent),
+      ports.observeAgentLifecycle(agent, {
+        clock: ports.clock,
+        inspectExecutable: async () => ports.inspectExecutable(agent, await readInstalledState()),
+        platform: ports.getPlatform(),
+        providerRegistry: ports.providerRegistry,
+        readInstalledState,
+        readReceipt: ports.readReceipt,
+        signal: ports.signal,
+        timeoutMs: ports.timeoutMs,
+      }),
+    ])
+    const [latestVersion, resolvedBinaryPath] = await Promise.all([
+      ports.getLatestVersion(agent, result.installedState, methods),
+      ports.getResolvedBinaryPath(result.pathExecutable.path),
+    ])
+
+    return {
+      agent,
+      ...result,
+      latestVersion,
+      methods,
+      resolvedBinaryPath,
+    }
+  }
+
+  return {
+    observeRegisteredAgents(): Promise<ResolvedAgentObservation[]> {
+      return Promise.all(ports.getAllAgents().map(observe))
+    },
+    async resolveAgentObservation(agentName: string): Promise<ResolvedAgentObservation | undefined> {
+      const agent = ports.getAgentByNameOrAlias(agentName)
+      return agent ? observe(agent) : undefined
+    },
+  }
+}
+
+export function resolveAgentObservation(agentName: string): Promise<ResolvedAgentObservation | undefined> {
+  return withProductionObservationService(service => service.resolveAgentObservation(agentName))
+}
+
+export function observeRegisteredAgents(): Promise<ResolvedAgentObservation[]> {
+  return withProductionObservationService(service => service.observeRegisteredAgents())
+}
+
+async function withProductionObservationService<T>(
+  observe: (service: LifecycleObservationService) => Promise<T>,
+): Promise<T> {
+  const operation = createCliOperationContext()
+  const service = createLifecycleObservationService({
+    clock: () => new Date().toISOString(),
+    getAllAgents: agentRegistry.getAllAgents,
+    getAgentByNameOrAlias: agentRegistry.getAgentByNameOrAlias,
+    getLatestVersion: (agent, installedState, methods) =>
+      resolveLatestVersion(agent, installedState, methods, operation.context),
+    getOrderedInstallMethods,
+    getPlatform,
+    getResolvedBinaryPath: binaryPath => getResolvedBinaryPath(binaryPath, operation.context),
+    inspectExecutable: (agent, installedState) => inspectExecutable(agent, installedState, operation.context),
+    observeAgentLifecycle,
+    providerRegistry: firstPartyProviderRegistry,
+    readInstalledState: getInstalledAgentState,
+    readReceipt: getLifecycleReceipt,
+    signal: operation.context.signal,
+    timeoutMs: operation.context.timeoutMs,
+  })
+
+  try {
+    return await operation.run(() => observe(service))
+  } finally {
+    operation.dispose()
+  }
+}
+
+async function inspectExecutable(
+  agent: AgentDefinition,
+  installedState: InstalledAgentState | undefined,
+  context?: ProviderOperationContext,
+): Promise<AgentExecutableObservation> {
+  const present = await isBinaryInPath(agent.binaryName, context)
+  if (!present) return { present: false }
+
+  const [path, version] = await Promise.all([
+    getBinaryPath(agent.binaryName, context),
+    getObservedInstalledVersion(agent, installedState, context),
+  ])
+  return { path, present, version }
+}
+
+async function getObservedInstalledVersion(
+  agent: AgentDefinition,
+  _installedState: InstalledAgentState | undefined,
+  context?: ProviderOperationContext,
+): Promise<string | undefined> {
+  return getInstalledVersion(agent.binaryName, agent.versionProbe, context)
+}
+
+async function resolveLatestVersion(
+  agent: AgentDefinition,
+  installedState: InstalledAgentState | undefined,
+  methods: InstallMethod[],
+  context?: ProviderOperationContext,
+): Promise<string | undefined> {
+  const packageName = getLatestVersionPackage(agent, installedState, methods)
+  return packageName ? getLatestVersion(packageName, 'latest', { context }) : undefined
+}

--- a/src/services/provider-observations.ts
+++ b/src/services/provider-observations.ts
@@ -1,0 +1,77 @@
+import type {
+  ProviderAvailability,
+  ProviderId,
+  ProviderOperation,
+  ProviderOperationContext,
+  ProviderOutcome,
+  ProviderRegistry,
+} from '../providers'
+import { firstPartyProviderRegistry } from '../providers'
+
+const strictV1InstallerIds = Object.freeze([
+  'brew',
+  'bun',
+  'cargo',
+  'deno',
+  'mise',
+  'npm',
+  'pip',
+  'uv',
+  'winget',
+] as const)
+
+type StrictV1InstallerId = (typeof strictV1InstallerIds)[number]
+type StrictV1ProviderSnapshotEntry = ProviderSnapshotEntry & { readonly id: StrictV1InstallerId }
+
+export interface ProviderSnapshotEntry {
+  readonly availability: ProviderOutcome<ProviderAvailability>
+  readonly capabilities: readonly ProviderOperation[]
+  readonly id: ProviderId
+}
+
+export interface ObserveProviderSnapshotOptions {
+  readonly context: ProviderOperationContext
+  readonly registry?: ProviderRegistry
+}
+
+export async function observeProviderSnapshot(
+  options: ObserveProviderSnapshotOptions,
+): Promise<readonly ProviderSnapshotEntry[]> {
+  const registry = options.registry ?? firstPartyProviderRegistry
+  return Promise.all(
+    registry.list().map(async adapter => ({
+      availability: await observeAvailability(adapter.availability, options.context),
+      capabilities: registry.getCapabilities(adapter.id),
+      id: adapter.id,
+    })),
+  )
+}
+
+export function projectProviderSnapshotToV1Installers<T>(
+  snapshot: readonly ProviderSnapshotEntry[],
+  project: (entry: StrictV1ProviderSnapshotEntry) => T,
+): Record<StrictV1InstallerId, T> {
+  const byId = new Map(snapshot.map(entry => [entry.id, entry] as const))
+  return Object.fromEntries(
+    strictV1InstallerIds.map(id => {
+      const entry = byId.get(id)
+      if (!entry) throw new Error(`Provider snapshot is missing first-party adapter: ${id}`)
+      return [id, project(entry as StrictV1ProviderSnapshotEntry)]
+    }),
+  ) as Record<StrictV1InstallerId, T>
+}
+
+async function observeAvailability(
+  availability: (context: ProviderOperationContext) => Promise<ProviderOutcome<ProviderAvailability>>,
+  context: ProviderOperationContext,
+): Promise<ProviderOutcome<ProviderAvailability>> {
+  try {
+    return await availability(context)
+  } catch (error) {
+    return {
+      kind: 'failed',
+      reason: error instanceof Error ? error.message : String(error),
+      retryable: false,
+    }
+  }
+}

--- a/src/utils/child-process.ts
+++ b/src/utils/child-process.ts
@@ -1,4 +1,7 @@
+import type { ProviderOperationContext } from '../providers'
 import { spawn, type ChildProcess, type SpawnOptions as NodeSpawnOptions } from 'node:child_process'
+import { accessSync, constants } from 'node:fs'
+import { delimiter, join } from 'node:path'
 import process from 'node:process'
 import { text as readText } from 'node:stream/consumers'
 import { getCliContext, registerCliCancellationHandler } from '../cli-context'
@@ -33,6 +36,24 @@ export interface SpawnHandle {
   cleanup: () => void
   outputDrained: Promise<void>
   proc: SpawnedProcessHandle
+}
+
+export class ProcessInterruptionError extends Error {
+  readonly kind: 'cancelled' | 'timed-out'
+  readonly reason?: string
+  readonly timeoutMs?: number
+
+  constructor(input: { kind: 'cancelled'; reason?: string } | { kind: 'timed-out'; timeoutMs: number }) {
+    super(input.kind === 'timed-out' ? `Process timed out after ${input.timeoutMs}ms.` : 'Process was cancelled.')
+    this.name = 'ProcessInterruptionError'
+    this.kind = input.kind
+    if (input.kind === 'timed-out') this.timeoutMs = input.timeoutMs
+    else this.reason = input.reason
+  }
+}
+
+export function isProcessInterruptionError(error: unknown): error is ProcessInterruptionError {
+  return error instanceof ProcessInterruptionError
 }
 
 export function spawnWithQuantexStdio(command: SpawnCommand, options: SpawnOptions = {}): SpawnHandle {
@@ -73,15 +94,17 @@ export async function waitForSpawnedCommand(handle: SpawnHandle): Promise<number
 }
 
 export function spawnCommand(command: SpawnCommand, options: SpawnOptions = {}): SpawnedProcessHandle {
-  const bunSpawn = getBunSpawn()
+  const bunSpawn = options.detached ? undefined : getBunSpawn()
   if (bunSpawn) return spawnWithBun(command, options, bunSpawn)
 
-  const [file, ...args] = command
+  const [requestedFile, ...args] = command
+  const file = requestedFile ? resolveDetachedExecutable(requestedFile, options) : undefined
   if (!file) {
     throw new Error('spawnCommand requires a non-empty command array.')
   }
   const child = spawn(file, args, {
     ...options,
+    env: options.env ?? process.env,
     shell: options.shell ?? shouldUseShellOnWindows(file),
   })
 
@@ -96,6 +119,20 @@ export function spawnCommand(command: SpawnCommand, options: SpawnOptions = {}):
     kill: child.kill.bind(child),
     unref: () => child.unref(),
   }
+}
+
+function resolveDetachedExecutable(file: string, options: SpawnOptions): string {
+  if (!options.detached || process.platform === 'win32' || file.includes('/')) return file
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    const candidate = join(directory, file)
+    try {
+      accessSync(candidate, constants.X_OK)
+      return candidate
+    } catch {
+      // Continue through PATH.
+    }
+  }
+  return file
 }
 
 export async function readProcessOutput(proc: SpawnedProcessHandle): Promise<{
@@ -114,6 +151,63 @@ export async function readProcessOutput(proc: SpawnedProcessHandle): Promise<{
     stderr,
     stdout,
   }
+}
+
+export async function readProcessOutputWithContext(
+  proc: SpawnedProcessHandle,
+  context: ProviderOperationContext,
+): Promise<{ exitCode: number; stderr: string; stdout: string }> {
+  let cleanupPromise: Promise<void> | undefined
+  const cleanup = (): Promise<void> => (cleanupPromise ??= terminateProcessTree(proc, context.timeoutMs))
+  const unregisterCleanup = context.registerCleanup?.({
+    cleanup,
+    force: () => forceTerminateProcessTree(proc),
+  })
+  if (context.signal.aborted) {
+    await cleanup()
+    unregisterCleanup?.()
+    throw new ProcessInterruptionError({ kind: 'cancelled', reason: abortReason(context.signal) })
+  }
+
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let cancel!: () => void
+  let interrupt!: (kind: 'cancelled' | 'timed-out') => void
+  let interrupted = false
+  const interruption = new Promise<never>((_resolve, reject) => {
+    interrupt = kind => {
+      if (interrupted) return
+      interrupted = true
+      void cleanup().then(() =>
+        setTimeout(
+          () =>
+            reject(
+              kind === 'timed-out'
+                ? new ProcessInterruptionError({ kind, timeoutMs: context.timeoutMs! })
+                : new ProcessInterruptionError({ kind, reason: abortReason(context.signal) }),
+            ),
+          10,
+        ),
+      )
+    }
+    cancel = () => interrupt('cancelled')
+    context.signal.addEventListener('abort', cancel, { once: true })
+    if (context.timeoutMs !== undefined) timeout = setTimeout(() => interrupt('timed-out'), context.timeoutMs)
+  })
+
+  try {
+    const output = readProcessOutput(proc).then(result => (interrupted ? interruption : result))
+    return await Promise.race([output, interruption])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+    context.signal.removeEventListener('abort', cancel)
+    unregisterCleanup?.()
+  }
+}
+
+function abortReason(signal: AbortSignal): string | undefined {
+  if (typeof signal.reason === 'string') return signal.reason
+  if (signal.reason instanceof Error) return signal.reason.message
+  return signal.reason === undefined ? undefined : String(signal.reason)
 }
 
 async function forwardToStderr(stream: unknown): Promise<void> {
@@ -175,24 +269,60 @@ function spawnWithBun(
 }
 
 async function terminateManagedProcess(proc: SpawnedProcessHandle): Promise<void> {
+  await terminateProcessTree(proc)
+}
+
+export async function terminateProcessTree(proc: SpawnedProcessHandle, requestedGraceMs?: number): Promise<void> {
   if (process.platform === 'win32' && proc.pid !== undefined)
-    await runWithDeadline(killWindowsProcessTree(proc.pid), 2_000)
+    await runWithDeadline(terminateWindowsProcessTree(proc.pid), 2_000)
 
-  try {
-    proc.kill?.('SIGTERM')
-  } catch {
-    // Continue to the bounded join.
-  }
+  signalProcessTree(proc, 'SIGTERM')
 
+  const exited = proc.exited.then(() => true).catch(() => true)
+  const graceMs = requestedGraceMs === undefined ? 2_000 : Math.max(10, Math.min(requestedGraceMs, 250))
+  const exitedDuringGrace = await Promise.race([
+    exited,
+    new Promise<false>(resolve => setTimeout(() => resolve(false), graceMs)),
+  ])
+  if (exitedDuringGrace) return
+
+  signalProcessTree(proc, 'SIGKILL')
   await runWithDeadline(
     proc.exited.then(() => undefined).catch(() => undefined),
-    2_000,
+    250,
   )
 }
 
-async function killWindowsProcessTree(pid: number): Promise<void> {
+export async function forceTerminateProcessTree(proc: SpawnedProcessHandle): Promise<void> {
+  if (process.platform === 'win32' && proc.pid !== undefined)
+    await runWithDeadline(terminateWindowsProcessTree(proc.pid), 250)
+  signalProcessTree(proc, 'SIGKILL')
+  await runWithDeadline(
+    proc.exited.then(() => undefined).catch(() => undefined),
+    250,
+  )
+}
+
+function signalProcessTree(proc: SpawnedProcessHandle, signal: NodeJS.Signals): void {
+  if (process.platform !== 'win32' && proc.pid !== undefined) {
+    try {
+      process.kill(-proc.pid, signal)
+      return
+    } catch {
+      // Fall through when the child is not a process-group leader.
+    }
+  }
+
+  try {
+    proc.kill?.(signal)
+  } catch {
+    // Best-effort termination.
+  }
+}
+
+export async function terminateWindowsProcessTree(pid: number, spawnProcess: typeof spawn = spawn): Promise<void> {
   await new Promise<void>(resolve => {
-    const killer = spawn('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
+    const killer = spawnProcess('taskkill.exe', ['/PID', String(pid), '/T', '/F'], {
       stdio: ['ignore', 'ignore', 'ignore'],
       windowsHide: true,
     })

--- a/src/utils/detect.ts
+++ b/src/utils/detect.ts
@@ -1,6 +1,12 @@
 import type { Platform } from '../agents/types'
+import type { ProviderOperationContext } from '../providers'
 import process from 'node:process'
-import { readProcessOutput, spawnCommand } from './child-process'
+import {
+  isProcessInterruptionError,
+  readProcessOutput,
+  readProcessOutputWithContext,
+  spawnCommand,
+} from './child-process'
 
 export function getPlatform(): Platform {
   switch (process.platform) {
@@ -13,74 +19,90 @@ export function getPlatform(): Platform {
   }
 }
 
-async function isCommandAvailable(command: string): Promise<boolean> {
+async function isCommandAvailable(command: string, context?: ProviderOperationContext): Promise<boolean> {
   try {
-    const { exitCode } = await readProcessOutput(spawnCommand([command, '--version']))
+    const proc = spawnCommand([command, '--version'], {
+      detached: context !== undefined && process.platform !== 'win32',
+    })
+    const { exitCode } = context ? await readProcessOutputWithContext(proc, context) : await readProcessOutput(proc)
     return exitCode === 0
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return false
   }
 }
 
-export async function isBunAvailable(): Promise<boolean> {
-  return isCommandAvailable('bun')
+export async function isBunAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  return isCommandAvailable('bun', context)
 }
 
-export async function isNpmAvailable(): Promise<boolean> {
-  return isCommandAvailable('npm')
+export async function isNpmAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  return isCommandAvailable('npm', context)
 }
 
-export async function isBrewAvailable(): Promise<boolean> {
-  return isCommandAvailable('brew')
+export async function isBrewAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  return isCommandAvailable('brew', context)
 }
 
-export async function isDenoAvailable(): Promise<boolean> {
-  return isCommandAvailable('deno')
+export async function isDenoAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  return isCommandAvailable('deno', context)
 }
 
-export async function isCargoAvailable(): Promise<boolean> {
-  return isCommandAvailable('cargo')
+export async function isCargoAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  return isCommandAvailable('cargo', context)
 }
 
-export async function isMiseAvailable(): Promise<boolean> {
-  return isCommandAvailable('mise')
+export async function isMiseAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  return isCommandAvailable('mise', context)
 }
 
-export async function isWingetAvailable(): Promise<boolean> {
-  return isCommandAvailable('winget')
+export async function isWingetAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  return isCommandAvailable('winget', context)
 }
 
-export async function isPipAvailable(): Promise<boolean> {
-  if (await isCommandAvailable('pip')) return true
-  if (await isCommandAvailable('pip3')) return true
-  return isPythonModulePipAvailable()
+export async function isPipAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  if (await isCommandAvailable('pip', context)) return true
+  if (await isCommandAvailable('pip3', context)) return true
+  return isPythonModulePipAvailable(context)
 }
 
-export async function isUvAvailable(): Promise<boolean> {
-  return isCommandAvailable('uv')
+export async function isUvAvailable(context?: ProviderOperationContext): Promise<boolean> {
+  return isCommandAvailable('uv', context)
 }
 
-async function isPythonModulePipAvailable(): Promise<boolean> {
+async function isPythonModulePipAvailable(context?: ProviderOperationContext): Promise<boolean> {
   try {
-    const { exitCode } = await readProcessOutput(spawnCommand(['python', '-m', 'pip', '--version']))
+    const proc = spawnCommand(['python', '-m', 'pip', '--version'], {
+      detached: context !== undefined && process.platform !== 'win32',
+    })
+    const { exitCode } = context ? await readProcessOutputWithContext(proc, context) : await readProcessOutput(proc)
     if (exitCode === 0) return true
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     /* ignore */
   }
   try {
-    const { exitCode } = await readProcessOutput(spawnCommand(['python3', '-m', 'pip', '--version']))
+    const proc = spawnCommand(['python3', '-m', 'pip', '--version'], {
+      detached: context !== undefined && process.platform !== 'win32',
+    })
+    const { exitCode } = context ? await readProcessOutputWithContext(proc, context) : await readProcessOutput(proc)
     return exitCode === 0
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return false
   }
 }
 
-export async function isBinaryInPath(binaryName: string): Promise<boolean> {
+export async function isBinaryInPath(binaryName: string, context?: ProviderOperationContext): Promise<boolean> {
   try {
     const cmd = process.platform === 'win32' ? 'where' : 'which'
-    const { exitCode } = await readProcessOutput(spawnCommand([cmd, binaryName]))
+    const proc = spawnCommand([cmd, binaryName], {
+      detached: context !== undefined && process.platform !== 'win32',
+    })
+    const { exitCode } = context ? await readProcessOutputWithContext(proc, context) : await readProcessOutput(proc)
     return exitCode === 0
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return false
   }
 }

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,7 +1,9 @@
+import type { ProviderOperationContext } from '../providers'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { getCliContext, recordCliFreshness } from '../cli-context'
 import { getConfigDir, loadConfig } from '../config'
+import { ProcessInterruptionError } from './child-process'
 
 interface CachedResponseEntry {
   body: string
@@ -14,8 +16,35 @@ interface CachedResponseStore {
   entries: Record<string, CachedResponseEntry>
 }
 
-export async function fetchJsonWithCache<T>(url: string, cacheKey: string): Promise<T | undefined> {
-  const body = await fetchTextWithCache(url, cacheKey, 'json')
+interface NetworkOperationOptions {
+  context?: ProviderOperationContext
+  signal?: AbortSignal
+}
+
+interface FetchedTextResponse {
+  body?: string
+  etag?: string
+  ok: boolean
+  status: number
+  valid: boolean
+}
+
+class NetworkAttemptTimeoutError extends Error {
+  readonly timeoutMs: number
+
+  constructor(timeoutMs: number) {
+    super(`Network attempt timed out after ${timeoutMs}ms.`)
+    this.name = 'NetworkAttemptTimeoutError'
+    this.timeoutMs = timeoutMs
+  }
+}
+
+export async function fetchJsonWithCache<T>(
+  url: string,
+  cacheKey: string,
+  options: NetworkOperationOptions = {},
+): Promise<T | undefined> {
+  const body = await fetchTextWithCache(url, cacheKey, 'json', options)
   if (!body) return undefined
 
   try {
@@ -29,93 +58,278 @@ export async function fetchTextWithCache(
   url: string,
   cacheKey: string,
   mode: 'json' | 'text' = 'text',
+  options: NetworkOperationOptions = {},
 ): Promise<string | undefined> {
+  const signal = options.context?.signal ?? options.signal
+  throwIfAborted(signal)
   const config = await loadConfig()
+  throwIfAborted(signal)
   const ttlMs = config.versionCacheTtlHours * 60 * 60 * 1000
   const cacheMode = getCliContext().cacheMode
   const cache = cacheMode === 'no-cache' ? { entries: {} } : await loadResponseCache()
+  throwIfAborted(signal)
   const cachedEntry = cache.entries[cacheKey]
   const now = Date.now()
 
   if (cacheMode === 'default' && cachedEntry && cachedEntry.expiresAt > now) {
+    throwIfAborted(signal)
     recordCachedEntryFreshness(cachedEntry, ttlMs)
     return cachedEntry.body
   }
 
-  const response = await fetchWithRetries(url, {
+  const response = await fetchTextWithRetries(url, {
+    context: options.context,
     headers: cacheMode !== 'no-cache' && cachedEntry?.etag ? { 'If-None-Match': cachedEntry.etag } : undefined,
+    mode,
     retries: config.networkRetries,
+    signal,
     timeoutMs: config.networkTimeoutMs,
   })
+  throwIfAborted(signal)
 
   if (!response) {
-    if (cachedEntry) recordCachedEntryFreshness(cachedEntry, ttlMs)
+    if (cachedEntry) {
+      throwIfAborted(signal)
+      recordCachedEntryFreshness(cachedEntry, ttlMs)
+    }
     return cachedEntry?.body
   }
 
   if (response.status === 304 && cachedEntry) {
+    throwIfAborted(signal)
     cache.entries[cacheKey] = {
       ...cachedEntry,
       expiresAt: now + ttlMs,
       fetchedAt: now,
     }
-    if (cacheMode !== 'no-cache') await saveResponseCache(cache)
+    if (cacheMode !== 'no-cache') {
+      throwIfAborted(signal)
+      await saveResponseCache(cache)
+    }
+    throwIfAborted(signal)
     recordNetworkFreshness(now, now + ttlMs)
     return cachedEntry.body
   }
 
   if (!response.ok) {
-    if (cachedEntry) recordCachedEntryFreshness(cachedEntry, ttlMs)
+    if (cachedEntry) {
+      throwIfAborted(signal)
+      recordCachedEntryFreshness(cachedEntry, ttlMs)
+    }
     return cachedEntry?.body
   }
 
-  const body = await response.text()
-
-  if (mode === 'json') {
-    try {
-      JSON.parse(body)
-    } catch {
-      if (cachedEntry) recordCachedEntryFreshness(cachedEntry, ttlMs)
-      return cachedEntry?.body
+  if (!response.valid || response.body === undefined) {
+    if (cachedEntry) {
+      throwIfAborted(signal)
+      recordCachedEntryFreshness(cachedEntry, ttlMs)
     }
+    return cachedEntry?.body
   }
 
+  throwIfAborted(signal)
   const entry = {
-    body,
-    etag: response.headers.get('etag') ?? undefined,
+    body: response.body,
+    etag: response.etag,
     expiresAt: now + ttlMs,
     fetchedAt: now,
   }
   if (cacheMode !== 'no-cache') {
     cache.entries[cacheKey] = entry
+    throwIfAborted(signal)
     await saveResponseCache(cache)
   }
+  throwIfAborted(signal)
   recordNetworkFreshness(now, now + ttlMs)
 
-  return body
+  return response.body
 }
 
-async function fetchWithRetries(
+async function fetchTextWithRetries(
   url: string,
-  options: { headers?: Record<string, string>; retries: number; timeoutMs: number },
-): Promise<Response | undefined> {
+  options: {
+    context?: ProviderOperationContext
+    headers?: Record<string, string>
+    mode: 'json' | 'text'
+    retries: number
+    signal?: AbortSignal
+    timeoutMs: number
+  },
+): Promise<FetchedTextResponse | undefined> {
+  const invocationDeadline =
+    options.context?.timeoutMs === undefined ? undefined : Date.now() + options.context.timeoutMs
   for (let attempt = 0; attempt <= options.retries; attempt++) {
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), options.timeoutMs)
-
     try {
-      return await fetch(url, {
-        headers: options.headers,
-        signal: controller.signal,
-      })
-    } catch {
+      return await fetchTextAttempt(url, { ...options, invocationDeadline })
+    } catch (error) {
+      if (error instanceof ProcessInterruptionError) throw error
       if (attempt === options.retries) return undefined
-    } finally {
-      clearTimeout(timeout)
     }
   }
 
   return undefined
+}
+
+async function fetchTextAttempt(
+  url: string,
+  options: {
+    context?: ProviderOperationContext
+    headers?: Record<string, string>
+    invocationDeadline?: number
+    mode: 'json' | 'text'
+    signal?: AbortSignal
+    timeoutMs: number
+  },
+): Promise<FetchedTextResponse> {
+  const controller = new AbortController()
+  let reader: { cancel(reason?: unknown): Promise<void> } | undefined
+  let response: Response | undefined
+  let interruption: NetworkAttemptTimeoutError | ProcessInterruptionError | undefined
+  let rejectInterruption!: (error: NetworkAttemptTimeoutError | ProcessInterruptionError) => void
+  let cancellation: Promise<void> | undefined
+  const interrupted = new Promise<never>((_resolve, reject) => (rejectInterruption = reject))
+  const cancelResponse = (): Promise<void> =>
+    (cancellation ??= settleBounded(
+      Promise.resolve()
+        .then(async () => {
+          if (reader) await reader.cancel(interruption)
+          else if (response?.body && !response.body.locked) await response.body.cancel(interruption)
+          return undefined
+        })
+        .then(() => undefined)
+        .catch(() => undefined),
+      250,
+    ))
+  const interrupt = (kind: 'cancelled' | 'invocation-timeout' | 'network-timeout'): Promise<void> => {
+    const nextInterruption =
+      kind === 'cancelled'
+        ? cancelledError(options.signal)
+        : kind === 'invocation-timeout'
+          ? new ProcessInterruptionError({
+              kind: 'timed-out',
+              timeoutMs: options.context?.timeoutMs ?? 0,
+            })
+          : new NetworkAttemptTimeoutError(options.timeoutMs)
+    const firstInterruption = interruption === undefined
+    if (
+      firstInterruption ||
+      (interruption instanceof NetworkAttemptTimeoutError && nextInterruption instanceof ProcessInterruptionError)
+    )
+      interruption = nextInterruption
+    if (firstInterruption) {
+      controller.abort(interruption)
+      void cancelResponse().finally(() => rejectInterruption(interruption!))
+    }
+    return cancelResponse()
+  }
+  const abort = () => void interrupt('cancelled')
+  options.signal?.addEventListener('abort', abort, { once: true })
+  const unregisterCleanup = options.context?.registerCleanup?.({
+    cleanup: () => interrupt('cancelled'),
+    force: cancelResponse,
+  })
+  const networkDeadline = Date.now() + options.timeoutMs
+  const timeout = setTimeout(() => void interrupt('network-timeout'), options.timeoutMs)
+  const invocationTimeout =
+    options.invocationDeadline === undefined
+      ? undefined
+      : setTimeout(() => void interrupt('invocation-timeout'), Math.max(0, options.invocationDeadline - Date.now()))
+  const ensureActive = async (): Promise<void> => {
+    if (interruption) throw interruption
+    if (options.signal?.aborted) await interrupt('cancelled')
+    else if (options.invocationDeadline !== undefined && Date.now() >= options.invocationDeadline)
+      await interrupt('invocation-timeout')
+    else if (Date.now() >= networkDeadline) await interrupt('network-timeout')
+    if (interruption) throw interruption
+  }
+
+  try {
+    if (options.signal?.aborted) await interrupt('cancelled')
+    const consume = (async (): Promise<FetchedTextResponse> => {
+      response = await fetch(url, { headers: options.headers, signal: controller.signal })
+      await ensureActive()
+      const status = response.status
+      const etag = response.headers?.get?.('etag') ?? undefined
+      if (!response.ok) {
+        await cancelResponse()
+        return { etag, ok: false, status, valid: true }
+      }
+      const body = await readResponseBody(response, value => (reader = value))
+      await ensureActive()
+      let valid = true
+      if (options.mode === 'json') {
+        try {
+          JSON.parse(body)
+        } catch {
+          valid = false
+        }
+      }
+      await ensureActive()
+      return { body, etag, ok: true, status, valid }
+    })()
+    try {
+      return await Promise.race([consume, interrupted])
+    } catch (error) {
+      if (interruption) {
+        await cancelResponse()
+        throw interruption
+      }
+      throw error
+    }
+  } finally {
+    clearTimeout(timeout)
+    if (invocationTimeout) clearTimeout(invocationTimeout)
+    options.signal?.removeEventListener('abort', abort)
+    unregisterCleanup?.()
+  }
+}
+
+async function readResponseBody(
+  response: Response,
+  setReader: (reader: { cancel(reason?: unknown): Promise<void> }) => void,
+): Promise<string> {
+  if (!response.body) return ''
+  const reader = response.body.getReader()
+  setReader(reader)
+  const decoder = new TextDecoder()
+  let body = ''
+  while (true) {
+    const chunk = await reader.read()
+    if (chunk.done) break
+    body += decoder.decode(chunk.value, { stream: true })
+  }
+  return body + decoder.decode()
+}
+
+async function settleBounded(work: Promise<void>, timeoutMs: number): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      work,
+      new Promise<void>(resolve => {
+        timeout = setTimeout(resolve, timeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw cancelledError(signal)
+}
+
+function cancelledError(signal?: AbortSignal): ProcessInterruptionError {
+  if (signal?.reason instanceof ProcessInterruptionError) return signal.reason
+  const reason =
+    typeof signal?.reason === 'string'
+      ? signal.reason
+      : signal?.reason instanceof Error
+        ? signal.reason.message
+        : signal?.reason === undefined
+          ? undefined
+          : String(signal.reason)
+  return new ProcessInterruptionError({ kind: 'cancelled', reason })
 }
 
 async function loadResponseCache(): Promise<CachedResponseStore> {

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,7 +1,14 @@
 import type { AgentVersionProbe } from '../agents'
+import type { ProviderOperationContext } from '../providers'
 import { realpath } from 'node:fs/promises'
 import process from 'node:process'
-import { readProcessOutput, spawnCommand } from './child-process'
+import {
+  isProcessInterruptionError,
+  ProcessInterruptionError,
+  readProcessOutput,
+  readProcessOutputWithContext,
+  spawnCommand,
+} from './child-process'
 import { fetchJsonWithCache } from './network'
 import { buildRegistryPackageVersionUrl, OFFICIAL_NPM_REGISTRY, normalizeRegistryUrl } from './registry'
 
@@ -37,15 +44,20 @@ export function isVersionNewer(candidate: string, current: string): boolean {
 export async function getInstalledVersion(
   binaryName: string,
   versionProbe?: AgentVersionProbe,
+  context?: ProviderOperationContext,
 ): Promise<string | undefined> {
   const command = versionProbe?.command ?? [binaryName, '--version']
 
   try {
-    const { exitCode, stdout } = await readProcessOutput(spawnCommand(command))
+    const proc = spawnCommand(command, { detached: context !== undefined && process.platform !== 'win32' })
+    const { exitCode, stdout } = context
+      ? await readProcessOutputWithContext(proc, context)
+      : await readProcessOutput(proc)
     if (exitCode !== 0) return undefined
     const text = stdout
     return parseInstalledVersionOutput(text, versionProbe?.parser)
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return undefined
   }
 }
@@ -53,40 +65,65 @@ export async function getInstalledVersion(
 export async function getLatestVersion(
   packageName: string,
   distTag: string = 'latest',
-  options: { registry?: string } = {},
+  options: { context?: ProviderOperationContext; registry?: string } = {},
 ): Promise<string | undefined> {
   try {
     const registry = normalizeRegistryUrl(options.registry) ?? OFFICIAL_NPM_REGISTRY
     const data = await fetchJsonWithCache<{ version: string }>(
       buildRegistryPackageVersionUrl(packageName, distTag, registry),
       `npm:${registry}:${packageName}:${distTag}`,
+      { context: options.context },
     )
+    if (options.context?.signal.aborted) throw cancelledError(options.context.signal)
     return data?.version
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
+    if (options.context?.signal.aborted) throw cancelledError(options.context.signal)
     return undefined
   }
 }
 
-export async function getBinaryPath(binaryName: string): Promise<string | undefined> {
+export async function getBinaryPath(
+  binaryName: string,
+  context?: ProviderOperationContext,
+): Promise<string | undefined> {
   try {
     const cmd = process.platform === 'win32' ? 'where' : 'which'
-    const { exitCode, stdout } = await readProcessOutput(spawnCommand([cmd, binaryName]))
+    const proc = spawnCommand([cmd, binaryName], {
+      detached: context !== undefined && process.platform !== 'win32',
+    })
+    const { exitCode, stdout } = context
+      ? await readProcessOutputWithContext(proc, context)
+      : await readProcessOutput(proc)
     if (exitCode !== 0) return undefined
     const text = stdout
     return text.trim().split('\n')[0]
-  } catch {
+  } catch (error) {
+    if (isProcessInterruptionError(error)) throw error
     return undefined
   }
 }
 
-export async function getResolvedBinaryPath(binaryPath?: string): Promise<string | undefined> {
+export async function getResolvedBinaryPath(
+  binaryPath?: string,
+  context?: ProviderOperationContext,
+): Promise<string | undefined> {
   if (!binaryPath) return undefined
+  if (context?.signal.aborted) throw cancelledError(context.signal)
 
   try {
-    return await realpath(binaryPath)
+    const path = await realpath(binaryPath)
+    if (context?.signal.aborted) throw cancelledError(context.signal)
+    return path
   } catch {
+    if (context?.signal.aborted) throw cancelledError(context.signal)
     return binaryPath
   }
+}
+
+function cancelledError(signal: AbortSignal): ProcessInterruptionError {
+  const reason = typeof signal.reason === 'string' ? signal.reason : undefined
+  return new ProcessInterruptionError({ kind: 'cancelled', reason })
 }
 
 interface ParsedVersion {

--- a/test/commands/capabilities.test.ts
+++ b/test/commands/capabilities.test.ts
@@ -1,8 +1,10 @@
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as agents from '../../src/agents'
 import { setCliContext } from '../../src/cli-context'
+import * as commandRegistry from '../../src/command-contract/registry'
 import { capabilitiesCommand } from '../../src/commands/capabilities'
 import * as selfModule from '../../src/self'
+import * as providerObservations from '../../src/services/provider-observations'
 import * as detect from '../../src/utils/detect'
 
 const allAgentsSpy = vi.spyOn(agents, 'getAllAgents')
@@ -15,7 +17,10 @@ const isMiseSpy = vi.spyOn(detect, 'isMiseAvailable')
 const isPipSpy = vi.spyOn(detect, 'isPipAvailable')
 const isUvSpy = vi.spyOn(detect, 'isUvAvailable')
 const isWingetSpy = vi.spyOn(detect, 'isWingetAvailable')
-const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelf')
+const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelfReadOnly')
+const providerSnapshotSpy = vi.spyOn(providerObservations, 'observeProviderSnapshot')
+const originalCommandContracts = commandRegistry.getCommandContracts()
+const commandContractsSpy = vi.spyOn(commandRegistry, 'getCommandContracts')
 
 afterAll(() => {
   allAgentsSpy.mockRestore()
@@ -29,6 +34,8 @@ afterAll(() => {
   isUvSpy.mockRestore()
   isWingetSpy.mockRestore()
   inspectSelfSpy.mockRestore()
+  providerSnapshotSpy.mockRestore()
+  commandContractsSpy.mockRestore()
 })
 
 describe('capabilitiesCommand', () => {
@@ -47,6 +54,9 @@ describe('capabilitiesCommand', () => {
     isUvSpy.mockClear()
     isWingetSpy.mockClear()
     inspectSelfSpy.mockClear()
+    providerSnapshotSpy.mockReset()
+    commandContractsSpy.mockReset()
+    commandContractsSpy.mockReturnValue(originalCommandContracts)
     allAgentsSpy.mockReturnValue([
       {
         binaryName: 'claude',
@@ -73,6 +83,20 @@ describe('capabilitiesCommand', () => {
       recommendedUpgradeCommand: 'quantex upgrade',
       updateChannel: 'stable',
     })
+    providerSnapshotSpy.mockResolvedValue(providerSnapshot())
+    for (const directAvailabilitySpy of [
+      isBunSpy,
+      isNpmSpy,
+      isBrewSpy,
+      isCargoSpy,
+      isDenoSpy,
+      isMiseSpy,
+      isPipSpy,
+      isUvSpy,
+      isWingetSpy,
+    ]) {
+      directAvailabilitySpy.mockRejectedValue(new Error('direct availability route used'))
+    }
   })
 
   afterEach(() => {
@@ -80,15 +104,7 @@ describe('capabilitiesCommand', () => {
   })
 
   it('shows installer availability and feature summary', async () => {
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(true)
-    isBrewSpy.mockResolvedValue(false)
-    isCargoSpy.mockResolvedValue(false)
-    isDenoSpy.mockResolvedValue(true)
-    isMiseSpy.mockResolvedValue(false)
-    isPipSpy.mockResolvedValue(false)
-    isUvSpy.mockResolvedValue(false)
-    isWingetSpy.mockResolvedValue(false)
+    providerSnapshotSpy.mockResolvedValue(providerSnapshot({ bun: true, deno: true, npm: true }))
 
     await capabilitiesCommand()
 
@@ -108,15 +124,9 @@ describe('capabilitiesCommand', () => {
       outputMode: 'json',
       runId: 'cap-run-id',
     })
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(true)
-    isBrewSpy.mockResolvedValue(false)
-    isCargoSpy.mockResolvedValue(true)
-    isDenoSpy.mockResolvedValue(true)
-    isMiseSpy.mockResolvedValue(true)
-    isPipSpy.mockResolvedValue(true)
-    isUvSpy.mockResolvedValue(true)
-    isWingetSpy.mockResolvedValue(false)
+    providerSnapshotSpy.mockResolvedValue(
+      providerSnapshot({ bun: true, cargo: true, deno: true, mise: true, npm: true, pip: true, uv: true }),
+    )
 
     await capabilitiesCommand()
 
@@ -139,7 +149,69 @@ describe('capabilitiesCommand', () => {
     expect(payload.data.features.logLevels).toEqual(['silent', 'error', 'warn', 'info', 'debug'])
     expect(payload.data.features.quietLogs).toBe(true)
     expect(payload.data.features.timeout).toBe(true)
+    expect(payload.data.features).toEqual({
+      assumeYes: true,
+      cacheBypass: true,
+      cacheRefresh: true,
+      channels: ['stable', 'beta'],
+      colorModes: ['auto', 'always', 'never'],
+      dryRun: true,
+      execInstallPolicies: ['never', 'if-missing', 'always'],
+      freshnessMetadata: true,
+      idempotencyKey: true,
+      logLevels: ['silent', 'error', 'warn', 'info', 'debug'],
+      quietLogs: true,
+      selfUpgrade: true,
+      timeout: true,
+    })
     expect(payload.data.outputModes).toEqual(['human', 'json', 'ndjson'])
+    expect(Object.keys(payload.data.installers)).toEqual([
+      'brew',
+      'bun',
+      'cargo',
+      'deno',
+      'mise',
+      'npm',
+      'pip',
+      'uv',
+      'winget',
+    ])
+    expect(payload.data.installers.brew.reason).toBe(process.platform === 'win32' ? 'not-on-platform' : 'not-found')
+    expect(payload.data.installers.winget.reason).toBe(process.platform === 'win32' ? 'not-found' : 'not-on-platform')
+    expect(payload.data.features.selfUpgrade).toBe(true)
     expect(payload.meta.runId).toBe('cap-run-id')
+    expect(providerSnapshotSpy).toHaveBeenCalledTimes(1)
+    expect(inspectSelfSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('derives v1 feature support from command registry flags and effects', async () => {
+    setCliContext({ interactive: false, outputMode: 'json', runId: 'cap-registry-run-id' })
+    commandContractsSpy.mockReturnValue(
+      originalCommandContracts.map(contract => ({
+        ...contract,
+        effects:
+          contract.name === 'upgrade'
+            ? contract.effects.filter(effect => effect !== 'mutation' && effect !== 'network')
+            : contract.effects,
+        flags: contract.flags.filter(flag => flag !== '--yes' && flag !== '--refresh'),
+      })),
+    )
+
+    const result = await capabilitiesCommand()
+
+    expect(result.data?.features.assumeYes).toBe(false)
+    expect(result.data?.features.cacheRefresh).toBe(false)
+    expect(result.data?.features.selfUpgrade).toBe(false)
+    expect(commandContractsSpy).toHaveBeenCalledTimes(1)
   })
 })
+
+function providerSnapshot(available: Partial<Record<string, boolean>> = {}) {
+  return ['bun', 'npm', 'brew', 'cargo', 'deno', 'mise', 'pip', 'uv', 'winget', 'script', 'binary'].map(id => ({
+    availability: available[id]
+      ? { kind: 'success' as const, value: { executable: id } }
+      : { kind: 'unavailable' as const, reason: `${id} unavailable` },
+    capabilities: ['availability', 'observe'] as const,
+    id: id as any,
+  }))
+}

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -1,8 +1,14 @@
+import type { AgentDefinition } from '../../src/agents'
+import type { ProviderId } from '../../src/providers'
+import type { ResolvedAgentObservation } from '../../src/services/lifecycle-observations'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as agents from '../../src/agents'
 import { resetCliContext, setCliContext } from '../../src/cli-context'
 import { doctorCommand } from '../../src/commands/doctor'
+import { observeAgentLifecycle } from '../../src/lifecycle'
 import * as selfModule from '../../src/self'
+import * as lifecycleObservations from '../../src/services/lifecycle-observations'
+import * as providerObservations from '../../src/services/provider-observations'
 import * as state from '../../src/state'
 import * as detect from '../../src/utils/detect'
 import * as version from '../../src/utils/version'
@@ -21,7 +27,9 @@ const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
 const installedStateSpy = vi.spyOn(state, 'getInstalledAgentState')
 const installedVerSpy = vi.spyOn(version, 'getInstalledVersion')
 const latestVerSpy = vi.spyOn(version, 'getLatestVersion')
-const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelf')
+const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelfReadOnly')
+const observeRegisteredAgentsSpy = vi.spyOn(lifecycleObservations, 'observeRegisteredAgents')
+const providerSnapshotSpy = vi.spyOn(providerObservations, 'observeProviderSnapshot')
 
 afterAll(() => {
   allAgentsSpy.mockRestore()
@@ -39,6 +47,8 @@ afterAll(() => {
   installedVerSpy.mockRestore()
   latestVerSpy.mockRestore()
   inspectSelfSpy.mockRestore()
+  observeRegisteredAgentsSpy.mockRestore()
+  providerSnapshotSpy.mockRestore()
 })
 
 const testAgent = {
@@ -49,11 +59,11 @@ const testAgent = {
   packages: { npm: 'test-pkg' },
   binaryName: 'test-bin',
   platforms: {
-    linux: [{ type: 'bun' as const }],
-    macos: [{ type: 'bun' as const }],
-    windows: [{ type: 'bun' as const }],
+    linux: [{ packageName: 'test-pkg', type: 'bun' as const }],
+    macos: [{ packageName: 'test-pkg', type: 'bun' as const }],
+    windows: [{ packageName: 'test-pkg', type: 'bun' as const }],
   },
-}
+} satisfies AgentDefinition
 
 const selfUpdatingAgent = {
   ...testAgent,
@@ -64,7 +74,7 @@ const selfUpdatingAgent = {
     command: ['self-updating-bin', 'update'],
     versionAfter: 'same-process' as const,
   },
-}
+} satisfies AgentDefinition
 
 describe('doctorCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
@@ -87,13 +97,57 @@ describe('doctorCommand', () => {
     installedVerSpy.mockClear()
     latestVerSpy.mockClear()
     inspectSelfSpy.mockClear()
-    isBrewSpy.mockResolvedValue(false)
-    isCargoSpy.mockResolvedValue(false)
-    isDenoSpy.mockResolvedValue(false)
-    isMiseSpy.mockResolvedValue(false)
-    isPipSpy.mockResolvedValue(false)
-    isUvSpy.mockResolvedValue(false)
-    isWingetSpy.mockResolvedValue(false)
+    observeRegisteredAgentsSpy.mockReset()
+    providerSnapshotSpy.mockReset()
+    for (const directAvailabilitySpy of [
+      isBunSpy,
+      isNpmSpy,
+      isBrewSpy,
+      isCargoSpy,
+      isDenoSpy,
+      isMiseSpy,
+      isPipSpy,
+      isUvSpy,
+      isWingetSpy,
+    ]) {
+      directAvailabilitySpy.mockRejectedValue(new Error('direct availability route used'))
+    }
+    providerSnapshotSpy.mockResolvedValue(providerSnapshot())
+    observeRegisteredAgentsSpy.mockImplementation(async () => {
+      const observations: ResolvedAgentObservation[] = []
+      for (const agent of agents.getAllAgents()) {
+        const inPath = await detect.isBinaryInPath(agent.binaryName)
+        const installedState = await state.getInstalledAgentState(agent.name)
+        const installedVersion = inPath
+          ? await version.getInstalledVersion(agent.binaryName, agent.versionProbe)
+          : undefined
+        const latestVersion = inPath ? await version.getLatestVersion(agent.packages?.npm ?? agent.name) : undefined
+        const executable = {
+          ...(inPath ? { path: `/path/${agent.binaryName}`, version: installedVersion } : {}),
+          present: inPath,
+        }
+        observations.push({
+          agent,
+          capabilities: [],
+          catalogMethods: [],
+          executable,
+          installedState,
+          latestVersion,
+          methods: [],
+          observation: inPath
+            ? {
+                drift: installedState ? { kind: 'none' as const } : { kind: 'untracked' as const },
+                kind: 'present' as const,
+                targetId: agent.name,
+                version: installedVersion,
+              }
+            : { drift: { kind: 'none' as const }, kind: 'absent' as const, targetId: agent.name },
+          pathExecutable: executable,
+          resolvedBinaryPath: inPath ? `/path/${agent.binaryName}` : undefined,
+        })
+      }
+      return observations
+    })
     installedStateSpy.mockResolvedValue(undefined)
     inspectSelfSpy.mockResolvedValue({
       canAutoUpdate: true,
@@ -113,8 +167,7 @@ describe('doctorCommand', () => {
   })
 
   it('shows package manager availability', async () => {
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(true)
+    setProviderAvailability({ bun: true, npm: true })
     allAgentsSpy.mockReturnValue([])
     await doctorCommand()
     const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
@@ -133,8 +186,7 @@ describe('doctorCommand', () => {
   })
 
   it('shows manual recovery for outdated bun installs', async () => {
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(false)
+    setProviderAvailability({ bun: true })
     allAgentsSpy.mockReturnValue([])
     inspectSelfSpy.mockResolvedValue({
       canAutoUpdate: true,
@@ -155,8 +207,7 @@ describe('doctorCommand', () => {
   })
 
   it('does not flag self as outdated when latest version is lower than current', async () => {
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(true)
+    setProviderAvailability({ bun: true, npm: true })
     allAgentsSpy.mockReturnValue([])
     inspectSelfSpy.mockResolvedValue({
       canAutoUpdate: true,
@@ -181,8 +232,7 @@ describe('doctorCommand', () => {
 
   it('shows manual recovery for outdated binary installs', async () => {
     const executablePath = process.platform === 'win32' ? 'C:\\Program Files\\Quantex\\qtx.exe' : '/usr/local/bin/qtx'
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(false)
+    setProviderAvailability({ bun: true })
     allAgentsSpy.mockReturnValue([])
     inspectSelfSpy.mockResolvedValue({
       canAutoUpdate: true,
@@ -203,8 +253,7 @@ describe('doctorCommand', () => {
   })
 
   it('shows installed agents with versions', async () => {
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(false)
+    setProviderAvailability({ bun: true })
     allAgentsSpy.mockReturnValue([testAgent])
     binaryInPathSpy.mockResolvedValue(true)
     installedStateSpy.mockResolvedValue({
@@ -224,8 +273,7 @@ describe('doctorCommand', () => {
   })
 
   it('shows no agents installed when none found', async () => {
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(false)
+    setProviderAvailability({ bun: true })
     allAgentsSpy.mockReturnValue([testAgent])
     binaryInPathSpy.mockResolvedValue(false)
     await doctorCommand()
@@ -234,17 +282,38 @@ describe('doctorCommand', () => {
   })
 
   it('reports issues when no package managers', async () => {
-    isBunSpy.mockResolvedValue(false)
-    isNpmSpy.mockResolvedValue(false)
+    setProviderAvailability({})
     allAgentsSpy.mockReturnValue([])
-    await doctorCommand()
+    const result = await doctorCommand()
     const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
     expect(output).toContain('No managed installer found')
+    expect(result.data?.installers).toEqual({
+      brew: false,
+      bun: false,
+      cargo: false,
+      deno: false,
+      mise: false,
+      npm: false,
+      pip: false,
+      uv: false,
+      winget: false,
+    })
+    expect(result.data?.issues.find(issue => issue.code === 'NO_MANAGED_INSTALLER')).toEqual({
+      blocking: true,
+      category: 'installers',
+      code: 'NO_MANAGED_INSTALLER',
+      docsRef: 'docs/runbooks/quantex-troubleshooting.md',
+      message:
+        'No managed installer found. Install bun, npm, brew, cargo, deno, mise, pip, uv, or winget before relying on managed lifecycle operations.',
+      severity: 'warning',
+      subject: { kind: 'system' },
+      suggestedAction: 'restore-managed-installer',
+      suggestedCommands: [],
+    })
   })
 
   it('warns when the detected self package manager is missing from PATH', async () => {
-    isBunSpy.mockResolvedValue(false)
-    isNpmSpy.mockResolvedValue(true)
+    setProviderAvailability({ npm: true })
     allAgentsSpy.mockReturnValue([])
     inspectSelfSpy.mockResolvedValue({
       canAutoUpdate: true,
@@ -265,8 +334,7 @@ describe('doctorCommand', () => {
   })
 
   it('warns when Quantex cannot auto-update from the current install source', async () => {
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(true)
+    setProviderAvailability({ bun: true, npm: true })
     allAgentsSpy.mockReturnValue([])
     inspectSelfSpy.mockResolvedValue({
       canAutoUpdate: false,
@@ -287,8 +355,7 @@ describe('doctorCommand', () => {
   })
 
   it('warns when an agent is only detected in PATH and not managed by Quantex', async () => {
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(true)
+    setProviderAvailability({ bun: true, npm: true })
     allAgentsSpy.mockReturnValue([testAgent])
     binaryInPathSpy.mockResolvedValue(true)
     installedStateSpy.mockResolvedValue(undefined)
@@ -308,8 +375,7 @@ describe('doctorCommand', () => {
       outputMode: 'json',
       runId: 'doctor-run-id',
     })
-    isBunSpy.mockResolvedValue(false)
-    isNpmSpy.mockResolvedValue(true)
+    setProviderAvailability({ npm: true })
     allAgentsSpy.mockReturnValue([])
     inspectSelfSpy.mockResolvedValue({
       canAutoUpdate: true,
@@ -349,8 +415,7 @@ describe('doctorCommand', () => {
       outputMode: 'json',
       runId: 'doctor-agent-run-id',
     })
-    isBunSpy.mockResolvedValue(true)
-    isNpmSpy.mockResolvedValue(true)
+    setProviderAvailability({ bun: true, npm: true })
     allAgentsSpy.mockReturnValue([selfUpdatingAgent])
     binaryInPathSpy.mockResolvedValue(true)
     installedStateSpy.mockResolvedValue(undefined)
@@ -374,4 +439,94 @@ describe('doctorCommand', () => {
       suggestedCommands: ['self-updating-bin update'],
     })
   })
+
+  it('preserves issue pairings for a reachable timed-out provider observation', async () => {
+    setCliContext({ interactive: false, outputMode: 'json', runId: 'doctor-drift-run-id' })
+    setProviderAvailability({ npm: true })
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: '/Users/test/.bun/bin/qtx',
+      installSource: 'bun',
+      latestVersion: '1.0.0',
+      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+    const observation = await timedOutAgentObservation()
+    observeRegisteredAgentsSpy.mockResolvedValue([observation])
+
+    const result = await doctorCommand()
+    const payload = JSON.parse(logSpy.mock.calls[0][0])
+
+    expect(observation.providerOutcome).toEqual({ kind: 'timed-out', timeoutMs: 25 })
+    expect(observation.observation).toMatchObject({
+      drift: { kind: 'indeterminate' },
+      kind: 'indeterminate',
+    })
+    expect(result.data?.issues.find(issue => issue.code === 'AGENT_UNTRACKED_IN_PATH')).toBeUndefined()
+    expect(result.data?.issues.find(issue => issue.code === 'SELF_INSTALLER_MISSING')).toMatchObject({
+      blocking: true,
+      category: 'self',
+      suggestedAction: 'restore-self-installer',
+      suggestedCommands: ['bun add -g quantex-cli@latest'],
+    })
+    expect(payload.data.agents[0]).not.toHaveProperty('drift')
+    expect(providerSnapshotSpy).toHaveBeenCalledTimes(1)
+    expect(observeRegisteredAgentsSpy).toHaveBeenCalledTimes(1)
+    expect(inspectSelfSpy).toHaveBeenCalledTimes(1)
+  })
 })
+
+function setProviderAvailability(available: Partial<Record<string, boolean>>): void {
+  providerSnapshotSpy.mockResolvedValue(providerSnapshot(available))
+}
+
+function providerSnapshot(available: Partial<Record<string, boolean>> = {}) {
+  const providerIds: ProviderId[] = [
+    'bun',
+    'npm',
+    'brew',
+    'cargo',
+    'deno',
+    'mise',
+    'pip',
+    'uv',
+    'winget',
+    'script',
+    'binary',
+  ]
+  return providerIds.map(id => ({
+    availability: available[id]
+      ? { kind: 'success' as const, value: { executable: id } }
+      : { kind: 'unavailable' as const, reason: `${id} unavailable` },
+    capabilities: ['availability', 'observe'] as const,
+    id,
+  }))
+}
+
+async function timedOutAgentObservation(): Promise<ResolvedAgentObservation> {
+  const result = await observeAgentLifecycle(testAgent, {
+    clock: () => '2026-07-12T08:00:00.000Z',
+    inspectExecutable: async () => ({ path: '/path/test-bin', present: true, version: '1.0.0' }),
+    observeProvider: async () => ({ kind: 'timed-out', timeoutMs: 25 }),
+    platform: 'linux',
+    providerRegistry: {
+      get: () => undefined,
+      getCapabilities: () => ['availability', 'observe'],
+      list: () => [],
+    },
+    readInstalledState: async () => undefined,
+    readReceipt: async () => undefined,
+    signal: new AbortController().signal,
+    timeoutMs: 25,
+  })
+
+  return {
+    agent: testAgent,
+    ...result,
+    latestVersion: '1.0.0',
+    methods: [],
+    resolvedBinaryPath: '/path/test-bin',
+  }
+}

--- a/test/commands/info.test.ts
+++ b/test/commands/info.test.ts
@@ -1,99 +1,157 @@
+import type { AgentDefinition, InstallMethod } from '../../src/agents'
+import type { ResolvedAgentObservation } from '../../src/services/lifecycle-observations'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import * as agents from '../../src/agents'
+import { setCliContext } from '../../src/cli-context'
 import { infoCommand } from '../../src/commands/info'
-import * as state from '../../src/state'
-import * as detect from '../../src/utils/detect'
-import * as version from '../../src/utils/version'
+import * as legacyAgentsService from '../../src/services/agents'
+import * as lifecycleObservations from '../../src/services/lifecycle-observations'
 
-const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
-const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
-const installedStateSpy = vi.spyOn(state, 'getInstalledAgentState')
-const installedVerSpy = vi.spyOn(version, 'getInstalledVersion')
-const latestVerSpy = vi.spyOn(version, 'getLatestVersion')
-const binaryPathSpy = vi.spyOn(version, 'getBinaryPath')
+const resolveAgentInspectionSpy = vi.spyOn(legacyAgentsService, 'resolveAgentInspection')
+const resolveAgentObservationSpy = vi.spyOn(lifecycleObservations, 'resolveAgentObservation')
 
-afterAll(() => {
-  agentSpy.mockRestore()
-  binaryInPathSpy.mockRestore()
-  installedStateSpy.mockRestore()
-  installedVerSpy.mockRestore()
-  latestVerSpy.mockRestore()
-  binaryPathSpy.mockRestore()
-})
-
-const testAgent = {
-  name: 'test-agent',
-  lookupAliases: ['ta'],
+const testAgent: AgentDefinition = {
+  binaryName: 'test-bin',
   displayName: 'Test Agent',
   homepage: 'https://example.com',
+  lookupAliases: ['ta'],
+  name: 'test-agent',
   packages: { npm: 'test-pkg' },
-  binaryName: 'test-bin',
-  selfUpdate: {
-    command: ['test-bin', 'update'],
-  },
-  platforms: {
-    linux: [{ type: 'bun' as const }],
-    macos: [{ type: 'bun' as const }],
-    windows: [{ type: 'bun' as const }],
-  },
+  platforms: { linux: [{ packageName: 'test-pkg', type: 'bun' }] },
+  selfUpdate: { command: ['test-bin', 'update'] },
 }
+
+afterAll(() => {
+  resolveAgentInspectionSpy.mockRestore()
+  resolveAgentObservationSpy.mockRestore()
+})
 
 describe('infoCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    setCliContext({ interactive: false, outputMode: 'human', runId: 'info-test' })
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    agentSpy.mockClear()
-    binaryInPathSpy.mockClear()
-    installedStateSpy.mockClear()
-    installedVerSpy.mockClear()
-    latestVerSpy.mockClear()
-    binaryPathSpy.mockClear()
+    resolveAgentInspectionSpy.mockReset()
+    resolveAgentInspectionSpy.mockRejectedValue(new Error('legacy info inspection must not run'))
+    resolveAgentObservationSpy.mockReset()
   })
 
   afterEach(() => {
     logSpy.mockRestore()
   })
 
-  it('shows error for unknown agent', async () => {
-    agentSpy.mockReturnValue(undefined)
-    await infoCommand('unknown')
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown agent'))
-  })
+  it('routes the exact v1 success projection through lifecycle observation', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(observed())
 
-  it('shows all agent details for known agent', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    installedStateSpy.mockResolvedValue({
-      agentName: 'test-agent',
-      installType: 'bun',
-      packageName: 'test-pkg',
-      command: 'bun add -g test-pkg',
+    const result = await infoCommand('ta')
+
+    expect(resolveAgentObservationSpy).toHaveBeenCalledWith('ta')
+    expect(resolveAgentInspectionSpy).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      action: 'info',
+      data: {
+        agent: {
+          aliases: ['ta'],
+          binaryName: 'test-bin',
+          displayName: 'Test Agent',
+          installMethods: [{ command: 'bun add -g test-pkg', label: 'managed/bun (test-pkg)', type: 'bun' }],
+          name: 'test-agent',
+          packageName: 'test-pkg',
+          selfUpdateCommands: ['test-bin update'],
+        },
+        inspection: {
+          binaryPath: '/usr/bin/test-bin',
+          installed: true,
+          installedVersion: '1.2.3',
+          latestVersion: '2.0.0',
+          lifecycle: 'managed',
+          sourceLabel: 'managed via bun (test-pkg)',
+        },
+      },
+      error: null,
+      ok: true,
+      target: { kind: 'agent', name: 'test-agent' },
     })
-    installedVerSpy.mockResolvedValue('1.0.0')
-    latestVerSpy.mockResolvedValue('2.0.0')
-    binaryPathSpy.mockResolvedValue('/usr/bin/test-bin')
-    await infoCommand('test-agent')
-    const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
-    expect(output).toContain('test-agent')
-    expect(output).toContain('ta')
-    expect(output).toContain('test-pkg')
-    expect(output).toContain('test-bin')
-    expect(output).toContain('test-bin update')
-    expect(output).toContain('managed via bun (test-pkg)')
-    expect(output).toContain('managed')
-    expect(output).toContain('1.0.0')
-    expect(output).toContain('2.0.0')
-    expect(output).toContain('/usr/bin/test-bin')
+    expect(result.data?.inspection).not.toHaveProperty('drift')
+    expect(result.data?.inspection).not.toHaveProperty('receipt')
+    expect(result.data?.inspection).not.toHaveProperty('capabilities')
   })
 
-  it('shows install methods with platform support indicators', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
+  it('preserves human details and install-method rendering', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(observed())
+
     await infoCommand('test-agent')
-    const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
-    expect(output).toContain('Install Methods')
-    expect(output).toContain('managed/bun')
-    expect(output).toContain('bun add -g test-pkg')
+
+    const output = logSpy.mock.calls.map((call: any[]) => call[0]).join('\n')
+    for (const value of [
+      'test-agent',
+      'ta',
+      'test-pkg',
+      'test-bin',
+      'test-bin update',
+      'managed via bun (test-pkg)',
+      'managed',
+      '1.2.3',
+      '2.0.0',
+      '/usr/bin/test-bin',
+      'Install Methods',
+      'managed/bun (test-pkg)',
+      'bun add -g test-pkg',
+    ]) {
+      expect(output).toContain(value)
+    }
+  })
+
+  it('preserves the v1 unknown-agent error through lifecycle observation', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(undefined)
+
+    const result = await infoCommand('missing')
+
+    expect(resolveAgentObservationSpy).toHaveBeenCalledWith('missing')
+    expect(resolveAgentInspectionSpy).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      action: 'info',
+      data: undefined,
+      error: {
+        code: 'AGENT_NOT_FOUND',
+        details: { input: 'missing' },
+        message: 'Unknown agent: missing',
+      },
+      ok: false,
+      target: { kind: 'agent', name: 'missing' },
+    })
   })
 })
+
+function observed(): ResolvedAgentObservation {
+  const methods: InstallMethod[] = [{ packageName: 'test-pkg', type: 'bun' }]
+  const executable = { path: '/usr/bin/test-bin', present: true as const, version: '1.2.3' }
+
+  return {
+    agent: testAgent,
+    capabilities: ['observe', 'update'],
+    catalogMethods: [],
+    executable,
+    installedState: { agentName: 'test-agent', installType: 'bun', packageName: 'test-pkg' },
+    latestVersion: '2.0.0',
+    methods,
+    observation: {
+      drift: { kind: 'none' },
+      executablePath: '/usr/bin/test-bin',
+      kind: 'present',
+      targetId: 'test-agent',
+      version: '1.2.3',
+    },
+    pathExecutable: executable,
+    receipt: {
+      kind: 'lifecycle-receipt',
+      providerId: 'bun',
+      providerTargetId: 'test-pkg',
+      providerTargetKind: 'package',
+      schemaVersion: 1,
+      targetId: 'test-agent',
+      verifiedAt: '2026-07-12T08:00:00.000Z',
+    },
+    resolvedBinaryPath: '/usr/bin/test-bin',
+  }
+}

--- a/test/commands/inspect.test.ts
+++ b/test/commands/inspect.test.ts
@@ -1,108 +1,239 @@
+import type { AgentDefinition, InstallMethod } from '../../src/agents'
+import type { LifecycleObservation } from '../../src/lifecycle'
+import type { ResolvedAgentObservation } from '../../src/services/lifecycle-observations'
+import type { InstalledAgentState } from '../../src/state'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import * as agents from '../../src/agents'
 import { setCliContext } from '../../src/cli-context'
 import { inspectCommand } from '../../src/commands/inspect'
-import * as state from '../../src/state'
-import * as detect from '../../src/utils/detect'
-import * as version from '../../src/utils/version'
+import * as legacyAgentsService from '../../src/services/agents'
+import * as lifecycleObservations from '../../src/services/lifecycle-observations'
 
-const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
-const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
-const installedStateSpy = vi.spyOn(state, 'getInstalledAgentState')
-const installedVerSpy = vi.spyOn(version, 'getInstalledVersion')
-const latestVerSpy = vi.spyOn(version, 'getLatestVersion')
-const binaryPathSpy = vi.spyOn(version, 'getBinaryPath')
+const resolveAgentInspectionSpy = vi.spyOn(legacyAgentsService, 'resolveAgentInspection')
+const resolveAgentObservationSpy = vi.spyOn(lifecycleObservations, 'resolveAgentObservation')
 
-afterAll(() => {
-  agentSpy.mockRestore()
-  binaryInPathSpy.mockRestore()
-  installedStateSpy.mockRestore()
-  installedVerSpy.mockRestore()
-  latestVerSpy.mockRestore()
-  binaryPathSpy.mockRestore()
-})
-
-const testAgent = {
-  name: 'test-agent',
-  lookupAliases: ['ta'],
+const testAgent: AgentDefinition = {
+  binaryName: 'test-bin',
   displayName: 'Test Agent',
   homepage: 'https://example.com',
+  lookupAliases: ['ta'],
+  name: 'test-agent',
   packages: { npm: 'test-pkg' },
-  binaryName: 'test-bin',
-  selfUpdate: {
-    command: ['test-bin', 'update'],
-  },
-  platforms: {
-    linux: [{ type: 'bun' as const }],
-    macos: [{ type: 'bun' as const }],
-    windows: [{ type: 'bun' as const }],
-  },
+  platforms: { linux: [{ packageName: 'test-pkg', type: 'bun' }] },
+  selfUpdate: { command: ['test-bin', 'update'] },
 }
+const trackedState: InstalledAgentState = {
+  agentName: 'test-agent',
+  installType: 'bun',
+  packageName: 'test-pkg',
+}
+
+afterAll(() => {
+  resolveAgentInspectionSpy.mockRestore()
+  resolveAgentObservationSpy.mockRestore()
+})
 
 describe('inspectCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    setCliContext({ colorMode: 'never', interactive: false, outputMode: 'human', runId: 'inspect-test' })
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    agentSpy.mockClear()
-    binaryInPathSpy.mockClear()
-    installedStateSpy.mockClear()
-    installedVerSpy.mockClear()
-    latestVerSpy.mockClear()
-    binaryPathSpy.mockClear()
+    resolveAgentInspectionSpy.mockReset()
+    resolveAgentInspectionSpy.mockRejectedValue(new Error('legacy inspect inspection must not run'))
+    resolveAgentObservationSpy.mockReset()
   })
 
   afterEach(() => {
     logSpy.mockRestore()
   })
 
-  it('shows error for unknown agent', async () => {
-    agentSpy.mockReturnValue(undefined)
-    await inspectCommand('unknown')
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown agent'))
+  it('routes alias resolution through observation and preserves the exact managed v1 shape', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(observed(present({ kind: 'none' }), trackedState))
+
+    const result = await inspectCommand('ta')
+
+    expect(resolveAgentObservationSpy).toHaveBeenCalledWith('ta')
+    expect(resolveAgentInspectionSpy).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      action: 'inspect',
+      data: {
+        agent: {
+          aliases: ['ta'],
+          binaryName: 'test-bin',
+          displayName: 'Test Agent',
+          installMethods: [{ command: 'bun add -g test-pkg', label: 'managed/bun (test-pkg)', type: 'bun' }],
+          name: 'test-agent',
+          packageName: 'test-pkg',
+          selfUpdateCommands: ['test-bin update'],
+        },
+        capabilities: {
+          canAutoInstall: true,
+          canAutoUninstall: true,
+          canRun: true,
+          canSelfUpdate: true,
+        },
+        inspection: {
+          binaryPath: '/usr/bin/test-bin',
+          installed: true,
+          installedVersion: '1.2.3',
+          latestVersion: '2.0.0',
+          lifecycle: 'managed',
+          sourceLabel: 'managed via bun (test-pkg)',
+          updateLabel: 'managed update',
+        },
+      },
+      error: null,
+      ok: true,
+      target: { kind: 'agent', name: 'test-agent' },
+    })
+    expect(Object.keys(result.data ?? {}).sort()).toEqual(['agent', 'capabilities', 'inspection'])
+    expectNoInternalObservationFields(result.data)
+    expect(logSpy.mock.calls.map((call: unknown[]) => call[0])).toEqual([
+      '\nTest Agent\n',
+      '  Name:         test-agent',
+      '  Aliases:      ta',
+      '  Package:      test-pkg',
+      '  Binary:       test-bin',
+      '  Installed:    Yes',
+      '  Update Mode:  managed update',
+      '  Self Update:  test-bin update',
+      '  Source:       managed via bun (test-pkg)',
+      '  Version:      1.2.3',
+      '  Latest:       2.0.0',
+      '  Path:         /usr/bin/test-bin',
+      '\n  Capabilities:',
+      '    auto-install:   yes',
+      '    self-update:    yes',
+      '    auto-uninstall: yes',
+      '    runnable:       yes',
+      '\n  Install Methods:',
+      '    + [managed/bun (test-pkg)] bun add -g test-pkg',
+      undefined,
+    ])
   })
 
-  it('shows capabilities and update mode for a known agent', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    installedStateSpy.mockResolvedValue({
-      agentName: 'test-agent',
-      installType: 'bun',
-      packageName: 'test-pkg',
-      command: 'bun add -g test-pkg',
+  it('preserves untracked PATH installations as runnable unmanaged agents', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(observed(present({ kind: 'untracked' })))
+
+    const result = await inspectCommand('test-agent')
+
+    expect(result.data?.inspection).toEqual({
+      binaryPath: '/usr/bin/test-bin',
+      installed: true,
+      installedVersion: '1.2.3',
+      latestVersion: '2.0.0',
+      lifecycle: 'unmanaged',
+      sourceLabel: 'detected in PATH',
+      updateLabel: 'command update',
     })
-    installedVerSpy.mockResolvedValue('1.0.0')
-    latestVerSpy.mockResolvedValue('2.0.0')
-    binaryPathSpy.mockResolvedValue('/usr/bin/test-bin')
-
-    await inspectCommand('test-agent')
-
-    const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
-    expect(output).toContain('Capabilities')
-    expect(output).toContain('Update Mode:')
-    expect(output).toContain('managed update')
-    expect(output).toContain('auto-install:')
-    expect(output).toContain('self-update:')
-    expect(output).toContain('/usr/bin/test-bin')
+    expect(result.data?.capabilities).toEqual({
+      canAutoInstall: true,
+      canAutoUninstall: false,
+      canRun: true,
+      canSelfUpdate: true,
+    })
   })
 
-  it('emits a structured envelope in json mode', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'json',
-      runId: 'inspect-run-id',
+  it.each([
+    ['absent', absent({ kind: 'none' }), undefined],
+    ['ghost', absent({ kind: 'recorded-absent' }), trackedState],
+    ['conflicting', absent({ kind: 'conflicting-source' }), trackedState],
+    ['indeterminate', indeterminate(), trackedState],
+  ] as const)(
+    'does not report %s persisted evidence as installed without PATH evidence',
+    async (_name, observation, state) => {
+      resolveAgentObservationSpy.mockResolvedValueOnce(observed(observation, state, { present: false }))
+
+      const result = await inspectCommand('test-agent')
+
+      expect(result.data?.inspection.installed).toBe(false)
+      expect(result.data?.inspection).toHaveProperty('binaryPath', undefined)
+      expect(result.data?.inspection).toHaveProperty('installedVersion', undefined)
+      expect(result.data?.inspection).toHaveProperty('sourceLabel', undefined)
+      expect(result.data?.capabilities.canRun).toBe(false)
+      expect(result.data?.capabilities.canAutoUninstall).toBe(false)
+      expect(resolveAgentInspectionSpy).not.toHaveBeenCalled()
+    },
+  )
+
+  it('preserves the v1 unknown-agent error', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(undefined)
+
+    const result = await inspectCommand('unknown')
+
+    expect(result).toMatchObject({
+      action: 'inspect',
+      data: undefined,
+      error: { code: 'AGENT_NOT_FOUND', details: { input: 'unknown' }, message: 'Unknown agent: unknown' },
+      ok: false,
+      target: { kind: 'agent', name: 'unknown' },
     })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-
-    await inspectCommand('test-agent')
-
-    const payload = JSON.parse(logSpy.mock.calls[0][0])
-    expect(payload.ok).toBe(true)
-    expect(payload.action).toBe('inspect')
-    expect(payload.data.agent.name).toBe('test-agent')
-    expect(payload.data.capabilities.canAutoInstall).toBe(true)
-    expect(payload.data.capabilities.canRun).toBe(false)
-    expect(payload.meta.runId).toBe('inspect-run-id')
+    expect(resolveAgentInspectionSpy).not.toHaveBeenCalled()
+    expect(logSpy.mock.calls.map((call: unknown[]) => call[0])).toEqual(['Unknown agent: unknown'])
   })
 })
+
+function observed(
+  observation: LifecycleObservation,
+  installedState?: InstalledAgentState,
+  pathExecutable: ResolvedAgentObservation['pathExecutable'] = {
+    path: '/usr/bin/test-bin',
+    present: true,
+    version: '1.2.3',
+  },
+): ResolvedAgentObservation {
+  const methods: InstallMethod[] = [{ packageName: 'test-pkg', type: 'bun' }]
+  return {
+    agent: testAgent,
+    capabilities: ['observe', 'update'],
+    catalogMethods: [],
+    executable: pathExecutable,
+    installedState,
+    latestVersion: '2.0.0',
+    methods,
+    observation,
+    pathExecutable,
+    receipt: installedState
+      ? {
+          kind: 'lifecycle-receipt',
+          providerId: 'bun',
+          providerTargetId: 'test-pkg',
+          providerTargetKind: 'package',
+          schemaVersion: 1,
+          targetId: 'test-agent',
+          verifiedAt: '2026-07-12T08:00:00.000Z',
+        }
+      : undefined,
+    resolvedBinaryPath: pathExecutable.path,
+  }
+}
+
+function present(drift: LifecycleObservation['drift']): LifecycleObservation {
+  return {
+    drift,
+    executablePath: '/usr/bin/test-bin',
+    kind: 'present',
+    targetId: 'test-agent',
+    version: '1.2.3',
+  }
+}
+
+function absent(drift: LifecycleObservation['drift']): LifecycleObservation {
+  return { drift, kind: 'absent', targetId: 'test-agent' }
+}
+
+function indeterminate(): LifecycleObservation {
+  return {
+    drift: { kind: 'indeterminate', reason: 'provider unavailable' },
+    kind: 'indeterminate',
+    reason: 'provider unavailable',
+    targetId: 'test-agent',
+  }
+}
+
+function expectNoInternalObservationFields(value: unknown): void {
+  expect(JSON.stringify(value)).not.toMatch(
+    /"(?:binding|drift|providerTarget|providerTargetId|providerTargetKind|receipt)"/,
+  )
+  expect((value as { capabilities?: unknown }).capabilities).not.toBeInstanceOf(Array)
+}

--- a/test/commands/list.test.ts
+++ b/test/commands/list.test.ts
@@ -1,178 +1,177 @@
+import type { AgentDefinition, InstallMethod } from '../../src/agents'
+import type { ResolvedAgentObservation } from '../../src/services/lifecycle-observations'
+import type { InstalledAgentState } from '../../src/state'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import * as agents from '../../src/agents'
 import { setCliContext } from '../../src/cli-context'
 import { listCommand } from '../../src/commands/list'
-import * as state from '../../src/state'
-import * as detect from '../../src/utils/detect'
-import * as version from '../../src/utils/version'
+import * as legacyAgentsService from '../../src/services/agents'
+import * as lifecycleObservations from '../../src/services/lifecycle-observations'
 
-const allAgentsSpy = vi.spyOn(agents, 'getAllAgents')
-const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
-const installedStateSpy = vi.spyOn(state, 'getInstalledAgentState')
-const installedVerSpy = vi.spyOn(version, 'getInstalledVersion')
+const inspectRegisteredAgentsSpy = vi.spyOn(legacyAgentsService, 'inspectRegisteredAgents')
+const observeRegisteredAgentsSpy = vi.spyOn(lifecycleObservations, 'observeRegisteredAgents')
+
+const testAgent = agent('test-agent', 'Test Agent', 'test-bin', 'test-pkg')
+const secondAgent = agent('second-agent', 'Second Agent', 'second-bin', 'second-pkg')
 
 afterAll(() => {
-  allAgentsSpy.mockRestore()
-  binaryInPathSpy.mockRestore()
-  installedStateSpy.mockRestore()
-  installedVerSpy.mockRestore()
+  inspectRegisteredAgentsSpy.mockRestore()
+  observeRegisteredAgentsSpy.mockRestore()
 })
-
-const testAgent = {
-  name: 'test-agent',
-  lookupAliases: ['ta'],
-  displayName: 'Test Agent',
-  homepage: 'https://example.com',
-  packages: { npm: 'test-pkg' },
-  binaryName: 'test-bin',
-  platforms: {
-    linux: [{ type: 'bun' as const }],
-    macos: [{ type: 'bun' as const }],
-    windows: [{ type: 'bun' as const }],
-  },
-}
 
 describe('listCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    setCliContext({ interactive: false, outputMode: 'human', runId: 'list-test' })
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    allAgentsSpy.mockClear()
-    binaryInPathSpy.mockClear()
-    installedStateSpy.mockClear()
-    installedVerSpy.mockClear()
-    installedStateSpy.mockResolvedValue(undefined)
+    inspectRegisteredAgentsSpy.mockReset()
+    inspectRegisteredAgentsSpy.mockRejectedValue(new Error('legacy list inspection must not run'))
+    observeRegisteredAgentsSpy.mockReset()
   })
 
   afterEach(() => {
     logSpy.mockRestore()
   })
 
-  it('lists all agents with installed status', async () => {
-    allAgentsSpy.mockReturnValue([testAgent])
-    binaryInPathSpy.mockResolvedValue(true)
-    installedStateSpy.mockResolvedValue({
-      agentName: 'test-agent',
-      installType: 'bun',
-      packageName: 'test-pkg',
-      command: 'bun add -g test-pkg',
-    })
-    installedVerSpy.mockResolvedValue('1.0.0')
-    await listCommand()
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('AI Agents'))
-    expect(binaryInPathSpy).toHaveBeenCalledWith('test-bin')
-  })
+  it('routes ordered v1 rows through lifecycle observations without exposing internal fields', async () => {
+    observeRegisteredAgentsSpy.mockResolvedValueOnce([
+      observed(testAgent, {
+        installedState: trackedState('test-agent', 'test-pkg'),
+        latestVersion: '2.0.0',
+        version: '1.2.3',
+      }),
+      observed(secondAgent, { latestVersion: '4.0.0', version: '3.4.5' }),
+    ])
 
-  it('shows version for installed agents', async () => {
-    allAgentsSpy.mockReturnValue([testAgent])
-    binaryInPathSpy.mockResolvedValue(true)
-    installedStateSpy.mockResolvedValue({
-      agentName: 'test-agent',
-      installType: 'bun',
-      packageName: 'test-pkg',
-      command: 'bun add -g test-pkg',
-    })
-    installedVerSpy.mockResolvedValue('2.0.0')
-    await listCommand()
-    const calls = logSpy.mock.calls.map((c: any[]) => c[0])
-    const versionCall = calls.find((c: string) => c.includes('2.0.0'))
-    expect(versionCall).toBeDefined()
-  })
+    const result = await listCommand()
 
-  it('shows install source and managed updates for tracked installs', async () => {
-    allAgentsSpy.mockReturnValue([testAgent])
-    binaryInPathSpy.mockResolvedValue(true)
-    installedStateSpy.mockResolvedValue({
-      agentName: 'test-agent',
-      installType: 'bun',
-      packageName: 'test-pkg',
-      command: 'bun add -g test-pkg',
-    })
-    installedVerSpy.mockResolvedValue('1.0.0')
-    await listCommand()
-    const calls = logSpy.mock.calls.map((c: any[]) => c[0])
-    const installedCall = calls.find(
-      (c: string) => c.includes('managed update') && c.includes('managed via bun (test-pkg)'),
-    )
-    expect(installedCall).toBeDefined()
-  })
-
-  it('shows installed with unknown version when version cannot be obtained', async () => {
-    allAgentsSpy.mockReturnValue([testAgent])
-    binaryInPathSpy.mockResolvedValue(true)
-    installedVerSpy.mockResolvedValue(undefined)
-    await listCommand()
-    const calls = logSpy.mock.calls.map((c: any[]) => c[0])
-    const installedCall = calls.find((c: string) => c.includes('installed') && c.includes('unknown version'))
-    expect(installedCall).toBeDefined()
-  })
-
-  it('shows manual updates when install source is only detected from PATH', async () => {
-    allAgentsSpy.mockReturnValue([testAgent])
-    binaryInPathSpy.mockResolvedValue(true)
-    installedVerSpy.mockResolvedValue('1.0.0')
-    installedStateSpy.mockResolvedValue(undefined)
-    await listCommand()
-    const calls = logSpy.mock.calls.map((c: any[]) => c[0])
-    const manualUpdateCall = calls.find((c: string) => c.includes('manual update') && c.includes('detected in PATH'))
-    expect(manualUpdateCall).toBeDefined()
-  })
-
-  it('shows command updates when the agent provides a self-update command', async () => {
-    const selfUpdatingAgent = {
-      ...testAgent,
-      selfUpdate: {
-        command: ['test-bin', 'update'],
+    expect(observeRegisteredAgentsSpy).toHaveBeenCalledOnce()
+    expect(inspectRegisteredAgentsSpy).not.toHaveBeenCalled()
+    expect(result.data?.agents).toEqual([
+      {
+        binaryName: 'test-bin',
+        displayName: 'Test Agent',
+        installed: true,
+        installedVersion: '1.2.3',
+        latestVersion: '2.0.0',
+        lifecycle: 'managed',
+        name: 'test-agent',
+        sourceLabel: 'managed via bun (test-pkg)',
+        updateLabel: 'managed update',
       },
-    }
-
-    allAgentsSpy.mockReturnValue([selfUpdatingAgent])
-    binaryInPathSpy.mockResolvedValue(true)
-    installedVerSpy.mockResolvedValue('1.0.0')
-    installedStateSpy.mockResolvedValue(undefined)
-    await listCommand()
-    const calls = logSpy.mock.calls.map((c: any[]) => c[0])
-    const commandUpdateCall = calls.find((c: string) => c.includes('command update') && c.includes('detected in PATH'))
-    expect(commandUpdateCall).toBeDefined()
+      {
+        binaryName: 'second-bin',
+        displayName: 'Second Agent',
+        installed: true,
+        installedVersion: '3.4.5',
+        latestVersion: '4.0.0',
+        lifecycle: 'unmanaged',
+        name: 'second-agent',
+        sourceLabel: 'detected in PATH',
+        updateLabel: 'manual update',
+      },
+    ])
   })
 
-  it('shows not installed for missing agents', async () => {
-    allAgentsSpy.mockReturnValue([testAgent])
-    binaryInPathSpy.mockResolvedValue(false)
+  it('preserves human status, version, source, and update labels', async () => {
+    const selfUpdatingAgent = { ...secondAgent, selfUpdate: { command: ['second-bin', 'update'] } }
+    observeRegisteredAgentsSpy.mockResolvedValueOnce([
+      observed(testAgent, {
+        installedState: trackedState('test-agent', 'test-pkg'),
+        version: undefined,
+      }),
+      observed(selfUpdatingAgent, { version: '3.4.5' }),
+      observed(agent('missing-agent', 'Missing Agent', 'missing-bin', 'missing-pkg'), { present: false }),
+    ])
+
     await listCommand()
-    const calls = logSpy.mock.calls.map((c: any[]) => c[0])
-    const notInstalledCall = calls.find((c: string) => c.includes('not installed'))
-    expect(notInstalledCall).toBeDefined()
-    expect(installedVerSpy).not.toHaveBeenCalled()
+
+    const output = logSpy.mock.calls.map((call: any[]) => call[0]).join('\n')
+    expect(output).toContain('unknown version')
+    expect(output).toContain('managed update')
+    expect(output).toContain('managed via bun (test-pkg)')
+    expect(output).toContain('command update')
+    expect(output).toContain('detected in PATH')
+    expect(output).toContain('not installed')
   })
 
-  it('emits structured agent rows in json mode', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'json',
-      runId: 'test-run-id',
-    })
-    allAgentsSpy.mockReturnValue([testAgent])
-    binaryInPathSpy.mockResolvedValue(true)
-    installedStateSpy.mockResolvedValue({
-      agentName: 'test-agent',
-      installType: 'bun',
-      packageName: 'test-pkg',
-      command: 'bun add -g test-pkg',
-    })
-    installedVerSpy.mockResolvedValue('1.2.3')
+  it('emits the unchanged structured list envelope in json mode', async () => {
+    setCliContext({ interactive: false, outputMode: 'json', runId: 'list-json-test' })
+    observeRegisteredAgentsSpy.mockResolvedValueOnce([
+      observed(testAgent, {
+        installedState: trackedState('test-agent', 'test-pkg'),
+        version: '1.2.3',
+      }),
+    ])
 
-    await listCommand()
+    const result = await listCommand()
 
     const payload = JSON.parse(logSpy.mock.calls[0][0])
-    expect(payload.ok).toBe(true)
-    expect(payload.action).toBe('list')
-    expect(payload.data.agents).toHaveLength(1)
-    expect(payload.data.agents[0]).toMatchObject({
-      displayName: 'Test Agent',
-      installed: true,
-      installedVersion: '1.2.3',
-      name: 'test-agent',
-    })
+    expect(payload).toMatchObject({ action: 'list', error: null, ok: true })
+    expect(payload.data.agents).toEqual([
+      {
+        binaryName: 'test-bin',
+        displayName: 'Test Agent',
+        installed: true,
+        installedVersion: '1.2.3',
+        lifecycle: 'managed',
+        name: 'test-agent',
+        sourceLabel: 'managed via bun (test-pkg)',
+        updateLabel: 'managed update',
+      },
+    ])
+    expect(result.data?.agents[0]).toHaveProperty('latestVersion', undefined)
   })
 })
+
+function agent(name: string, displayName: string, binaryName: string, packageName: string): AgentDefinition {
+  return {
+    binaryName,
+    displayName,
+    homepage: 'https://example.com',
+    name,
+    packages: { npm: packageName },
+    platforms: { linux: [{ packageName, type: 'bun' }] },
+  }
+}
+
+function observed(
+  target: AgentDefinition,
+  options: {
+    installedState?: InstalledAgentState
+    latestVersion?: string
+    present?: boolean
+    version?: string
+  } = {},
+): ResolvedAgentObservation {
+  const present = options.present ?? true
+  const executable = present
+    ? { path: `/usr/bin/${target.binaryName}`, present: true as const, version: options.version }
+    : { present: false as const }
+  const methods: InstallMethod[] = [{ packageName: target.packages?.npm, type: 'bun' }]
+
+  return {
+    agent: target,
+    capabilities: ['observe'],
+    catalogMethods: [],
+    executable,
+    installedState: options.installedState,
+    latestVersion: options.latestVersion,
+    methods,
+    observation: present
+      ? {
+          drift: { kind: options.installedState ? 'none' : 'untracked' },
+          executablePath: executable.path,
+          kind: 'present',
+          targetId: target.name,
+          version: options.version,
+        }
+      : { drift: { kind: 'none' }, kind: 'absent', targetId: target.name },
+    pathExecutable: executable,
+    resolvedBinaryPath: present ? executable.path : undefined,
+  }
+}
+
+function trackedState(agentName: string, packageName: string): InstalledAgentState {
+  return { agentName, installType: 'bun', packageName }
+}

--- a/test/commands/resolve.test.ts
+++ b/test/commands/resolve.test.ts
@@ -1,145 +1,234 @@
+import type { AgentDefinition, InstallMethod } from '../../src/agents'
+import type { LifecycleObservation } from '../../src/lifecycle'
+import type { ResolvedAgentObservation } from '../../src/services/lifecycle-observations'
+import type { InstalledAgentState } from '../../src/state'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import * as agents from '../../src/agents'
 import { setCliContext } from '../../src/cli-context'
 import { resolveCommand } from '../../src/commands/resolve'
-import * as state from '../../src/state'
-import * as detect from '../../src/utils/detect'
-import * as version from '../../src/utils/version'
+import * as legacyAgentsService from '../../src/services/agents'
+import * as lifecycleObservations from '../../src/services/lifecycle-observations'
 
-const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
-const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
-const installedStateSpy = vi.spyOn(state, 'getInstalledAgentState')
-const installedVerSpy = vi.spyOn(version, 'getInstalledVersion')
-const latestVerSpy = vi.spyOn(version, 'getLatestVersion')
-const binaryPathSpy = vi.spyOn(version, 'getBinaryPath')
+const resolveAgentInspectionSpy = vi.spyOn(legacyAgentsService, 'resolveAgentInspection')
+const resolveAgentObservationSpy = vi.spyOn(lifecycleObservations, 'resolveAgentObservation')
 
-afterAll(() => {
-  agentSpy.mockRestore()
-  binaryInPathSpy.mockRestore()
-  installedStateSpy.mockRestore()
-  installedVerSpy.mockRestore()
-  latestVerSpy.mockRestore()
-  binaryPathSpy.mockRestore()
-})
-
-const testAgent = {
-  name: 'test-agent',
-  lookupAliases: ['ta'],
+const testAgent: AgentDefinition = {
+  binaryName: 'test-bin',
   displayName: 'Test Agent',
   homepage: 'https://example.com',
+  lookupAliases: ['ta'],
+  name: 'test-agent',
   packages: { npm: 'test-pkg' },
-  binaryName: 'test-bin',
-  platforms: {
-    linux: [{ type: 'bun' as const }],
-    macos: [{ type: 'bun' as const }],
-    windows: [{ type: 'bun' as const }],
-  },
+  platforms: { linux: [{ packageName: 'test-pkg', type: 'bun' }] },
 }
+const trackedState: InstalledAgentState = {
+  agentName: 'test-agent',
+  installType: 'bun',
+  packageName: 'test-pkg',
+}
+
+afterAll(() => {
+  resolveAgentInspectionSpy.mockRestore()
+  resolveAgentObservationSpy.mockRestore()
+})
 
 describe('resolveCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    setCliContext({ colorMode: 'never', interactive: false, outputMode: 'human', runId: 'resolve-test' })
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
-    agentSpy.mockClear()
-    binaryInPathSpy.mockClear()
-    installedStateSpy.mockClear()
-    installedVerSpy.mockClear()
-    latestVerSpy.mockClear()
-    binaryPathSpy.mockClear()
+    resolveAgentInspectionSpy.mockReset()
+    resolveAgentInspectionSpy.mockRejectedValue(new Error('legacy resolve inspection must not run'))
+    resolveAgentObservationSpy.mockReset()
   })
 
   afterEach(() => {
     logSpy.mockRestore()
   })
 
-  it('shows error for unknown agent', async () => {
-    agentSpy.mockReturnValue(undefined)
-    await resolveCommand('unknown')
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown agent'))
+  it('resolves an alias through observation and preserves managed source, version, and launch argv', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(observed(present({ kind: 'none' }), trackedState))
+
+    const result = await resolveCommand('ta')
+
+    expect(resolveAgentObservationSpy).toHaveBeenCalledWith('ta')
+    expect(resolveAgentInspectionSpy).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      action: 'resolve',
+      data: {
+        agent: { binaryName: 'test-bin', displayName: 'Test Agent', name: 'test-agent' },
+        resolution: {
+          binaryPath: '/usr/bin/test-bin',
+          installed: true,
+          installSource: 'bun',
+          installedVersion: '1.2.3',
+          lifecycle: 'managed',
+          sourceLabel: 'managed via bun (test-pkg)',
+          suggestedLaunchCommand: ['/usr/bin/test-bin'],
+        },
+      },
+      error: null,
+      ok: true,
+      target: { kind: 'agent', name: 'test-agent' },
+    })
+    expectNoInternalObservationFields(result.data)
+    expect(logSpy.mock.calls.map((call: unknown[]) => call[0])).toEqual([
+      '\nTest Agent\n',
+      '  Name:         test-agent',
+      '  Binary:       test-bin',
+      '  Path:         /usr/bin/test-bin',
+      '  Source:       managed via bun (test-pkg)',
+      '  Lifecycle:    managed',
+      '  Install Type: bun',
+      '  Version:      1.2.3',
+      '  Launch:       /usr/bin/test-bin',
+      undefined,
+    ])
   })
 
-  it('shows error when the agent is not installed', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
+  it('preserves untracked PATH resolution semantics', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(observed(present({ kind: 'untracked' })))
 
-    await resolveCommand('test-agent')
+    const result = await resolveCommand('test-agent')
 
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('is not installed'))
-    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('quantex ensure test-agent'))
+    expect(result.data?.resolution).toEqual({
+      binaryPath: '/usr/bin/test-bin',
+      installed: true,
+      installSource: 'detected-in-path',
+      installedVersion: '1.2.3',
+      lifecycle: 'unmanaged',
+      sourceLabel: 'detected in PATH',
+      suggestedLaunchCommand: ['/usr/bin/test-bin'],
+    })
   })
 
-  it('shows resolved executable information for an installed agent', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    installedStateSpy.mockResolvedValue({
-      agentName: 'test-agent',
-      installType: 'bun',
-      packageName: 'test-pkg',
-      command: 'bun add -g test-pkg',
+  it.each([
+    ['absent', absent({ kind: 'none' }), undefined],
+    ['ghost', absent({ kind: 'recorded-absent' }), trackedState],
+    ['conflicting', absent({ kind: 'conflicting-source' }), trackedState],
+    ['indeterminate', indeterminate(), trackedState],
+  ] as const)(
+    'returns unchanged install guidance for %s evidence without PATH presence',
+    async (_name, observation, state) => {
+      resolveAgentObservationSpy.mockResolvedValueOnce(observed(observation, state, { present: false }))
+
+      const result = await resolveCommand('test-agent')
+
+      const installGuidance = {
+        docsRef: 'skills/quantex-cli/references/command-recipes.md',
+        installMethods: [{ command: 'bun add -g test-pkg', label: 'managed/bun (test-pkg)', type: 'bun' }],
+        suggestedAction: 'ensure-agent-installed',
+        suggestedEnsureCommand: 'quantex ensure test-agent',
+      }
+      expect(result).toMatchObject({
+        action: 'resolve',
+        data: {
+          agent: { binaryName: 'test-bin', displayName: 'Test Agent', name: 'test-agent' },
+          resolution: {
+            binaryPath: '',
+            installGuidance,
+            installed: false,
+            installSource: 'not-installed',
+            lifecycle: 'unmanaged',
+            sourceLabel: 'not installed',
+            suggestedLaunchCommand: [],
+          },
+        },
+        error: {
+          code: 'AGENT_NOT_INSTALLED',
+          details: installGuidance,
+          message: 'Test Agent is not installed.',
+        },
+        ok: false,
+        target: { kind: 'agent', name: 'test-agent' },
+      })
+      expect(resolveAgentInspectionSpy).not.toHaveBeenCalled()
+      expectNoInternalObservationFields(result.data)
+      expect(logSpy.mock.calls.map((call: unknown[]) => call[0])).toEqual([
+        'Test Agent is not installed.',
+        'Try: quantex ensure test-agent',
+        'Install: [managed/bun (test-pkg)] bun add -g test-pkg',
+      ])
+    },
+  )
+
+  it('preserves the v1 unknown-agent error', async () => {
+    resolveAgentObservationSpy.mockResolvedValueOnce(undefined)
+
+    const result = await resolveCommand('unknown')
+
+    expect(result).toMatchObject({
+      action: 'resolve',
+      data: undefined,
+      error: { code: 'AGENT_NOT_FOUND', details: { input: 'unknown' }, message: 'Unknown agent: unknown' },
+      ok: false,
+      target: { kind: 'agent', name: 'unknown' },
     })
-    installedVerSpy.mockResolvedValue('1.0.0')
-    latestVerSpy.mockResolvedValue('2.0.0')
-    binaryPathSpy.mockResolvedValue('/usr/bin/test-bin')
-
-    await resolveCommand('test-agent')
-
-    const output = logSpy.mock.calls.map((c: any[]) => c[0]).join('\n')
-    expect(output).toContain('Path:')
-    expect(output).toContain('/usr/bin/test-bin')
-    expect(output).toContain('Launch:')
-    expect(output).toContain('Install Type:')
-  })
-
-  it('emits a structured envelope in json mode', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'json',
-      runId: 'resolve-run-id',
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    installedStateSpy.mockResolvedValue({
-      agentName: 'test-agent',
-      installType: 'bun',
-      packageName: 'test-pkg',
-      command: 'bun add -g test-pkg',
-    })
-    installedVerSpy.mockResolvedValue('1.0.0')
-    binaryPathSpy.mockResolvedValue('/usr/bin/test-bin')
-
-    await resolveCommand('test-agent')
-
-    const payload = JSON.parse(logSpy.mock.calls[0][0])
-    expect(payload.ok).toBe(true)
-    expect(payload.action).toBe('resolve')
-    expect(payload.data.agent.name).toBe('test-agent')
-    expect(payload.data.resolution.binaryPath).toBe('/usr/bin/test-bin')
-    expect(payload.data.resolution.suggestedLaunchCommand).toEqual(['/usr/bin/test-bin'])
-    expect(payload.meta.runId).toBe('resolve-run-id')
-  })
-
-  it('emits machine-actionable install guidance when the agent is not installed', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'json',
-      runId: 'resolve-missing-run-id',
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-
-    await resolveCommand('test-agent')
-
-    const payload = JSON.parse(logSpy.mock.calls[0][0])
-    expect(payload.ok).toBe(false)
-    expect(payload.error.code).toBe('AGENT_NOT_INSTALLED')
-    expect(payload.data.agent.name).toBe('test-agent')
-    expect(payload.data.resolution.installed).toBe(false)
-    expect(payload.data.resolution.installGuidance.suggestedAction).toBe('ensure-agent-installed')
-    expect(payload.data.resolution.installGuidance.suggestedEnsureCommand).toBe('quantex ensure test-agent')
-    expect(payload.data.resolution.installGuidance.installMethods[0]).toMatchObject({
-      command: 'bun add -g test-pkg',
-      type: 'bun',
-    })
+    expect(resolveAgentInspectionSpy).not.toHaveBeenCalled()
+    expect(logSpy.mock.calls.map((call: unknown[]) => call[0])).toEqual(['Unknown agent: unknown'])
   })
 })
+
+function observed(
+  observation: LifecycleObservation,
+  installedState?: InstalledAgentState,
+  pathExecutable: ResolvedAgentObservation['pathExecutable'] = {
+    path: '/usr/bin/test-bin',
+    present: true,
+    version: '1.2.3',
+  },
+): ResolvedAgentObservation {
+  const methods: InstallMethod[] = [{ packageName: 'test-pkg', type: 'bun' }]
+  return {
+    agent: testAgent,
+    capabilities: ['observe', 'update'],
+    catalogMethods: [],
+    executable: pathExecutable,
+    installedState,
+    latestVersion: '2.0.0',
+    methods,
+    observation,
+    pathExecutable,
+    receipt: installedState
+      ? {
+          kind: 'lifecycle-receipt',
+          providerId: 'bun',
+          providerTargetId: 'test-pkg',
+          providerTargetKind: 'package',
+          schemaVersion: 1,
+          targetId: 'test-agent',
+          verifiedAt: '2026-07-12T08:00:00.000Z',
+        }
+      : undefined,
+    resolvedBinaryPath: pathExecutable.path,
+  }
+}
+
+function present(drift: LifecycleObservation['drift']): LifecycleObservation {
+  return {
+    drift,
+    executablePath: '/usr/bin/test-bin',
+    kind: 'present',
+    targetId: 'test-agent',
+    version: '1.2.3',
+  }
+}
+
+function absent(drift: LifecycleObservation['drift']): LifecycleObservation {
+  return { drift, kind: 'absent', targetId: 'test-agent' }
+}
+
+function indeterminate(): LifecycleObservation {
+  return {
+    drift: { kind: 'indeterminate', reason: 'provider unavailable' },
+    kind: 'indeterminate',
+    reason: 'provider unavailable',
+    targetId: 'test-agent',
+  }
+}
+
+function expectNoInternalObservationFields(value: unknown): void {
+  expect(JSON.stringify(value)).not.toMatch(
+    /"(?:binding|capabilities|drift|providerTarget|providerTargetId|providerTargetKind|receipt)"/,
+  )
+}

--- a/test/compatibility/agent-inspection.test.ts
+++ b/test/compatibility/agent-inspection.test.ts
@@ -1,0 +1,194 @@
+import type { AgentDefinition, InstallMethod } from '../../src/agents'
+import type { LifecycleObservation } from '../../src/lifecycle'
+import type { ResolvedAgentObservation } from '../../src/services/lifecycle-observations'
+import type { InstalledAgentState } from '../../src/state'
+import { describe, expect, it } from 'vitest'
+import { projectObservationToV1Inspection } from '../../src/compatibility/agent-inspection'
+
+const agent: AgentDefinition = {
+  binaryName: 'test-bin',
+  displayName: 'Test Agent',
+  homepage: 'https://example.com',
+  name: 'test-agent',
+  packages: { npm: 'test-package' },
+  platforms: { linux: [{ packageName: 'test-package', type: 'bun' }] },
+}
+const methods: InstallMethod[] = [{ packageName: 'test-package', type: 'bun' }]
+const trackedState: InstalledAgentState = {
+  agentName: 'test-agent',
+  installType: 'bun',
+  packageName: 'test-package',
+}
+
+describe('v1 agent inspection projection', () => {
+  it('keeps a tracked provider-present PATH-absent conflict absent in v1', () => {
+    const result = Object.assign(resolved(present({ kind: 'conflicting-source' }), trackedState), {
+      pathExecutable: { present: false },
+    })
+
+    expect(projectObservationToV1Inspection(result)).toMatchObject({
+      binaryPath: undefined,
+      inPath: false,
+      installedVersion: undefined,
+      resolvedBinaryPath: undefined,
+    })
+  })
+
+  it.each([
+    {
+      expected: {
+        binaryPath: '/usr/local/bin/test-bin',
+        inPath: true,
+        installedVersion: '1.2.3',
+        latestVersion: '2.0.0',
+        lifecycle: 'managed',
+        resolvedBinaryPath: '/opt/test/bin/test-bin',
+        sourceLabel: 'managed via bun (test-package)',
+        updateLabel: 'managed update',
+      },
+      name: 'tracked',
+      result: resolved(present({ kind: 'none' }), trackedState),
+    },
+    {
+      expected: {
+        binaryPath: '/usr/local/bin/test-bin',
+        inPath: true,
+        installedVersion: '1.2.3',
+        latestVersion: '2.0.0',
+        lifecycle: 'unmanaged',
+        resolvedBinaryPath: '/opt/test/bin/test-bin',
+        sourceLabel: 'detected in PATH',
+        updateLabel: 'manual update',
+      },
+      name: 'untracked',
+      result: resolved(present({ kind: 'untracked' })),
+    },
+    {
+      expected: {
+        inPath: false,
+        latestVersion: '2.0.0',
+        lifecycle: 'managed',
+        sourceLabel: 'managed via bun (test-package)',
+        updateLabel: 'managed update',
+      },
+      name: 'ghost',
+      result: resolved(absent({ kind: 'recorded-absent' }), trackedState, { present: false }),
+    },
+    {
+      expected: {
+        binaryPath: '/usr/local/bin/test-bin',
+        inPath: true,
+        installedVersion: '1.2.3',
+        latestVersion: '2.0.0',
+        lifecycle: 'managed',
+        resolvedBinaryPath: '/opt/test/bin/test-bin',
+        sourceLabel: 'managed via bun (test-package)',
+        updateLabel: 'managed update',
+      },
+      name: 'conflicting',
+      result: resolved(present({ kind: 'conflicting-source' }), trackedState),
+    },
+    {
+      expected: {
+        binaryPath: '/usr/local/bin/test-bin',
+        inPath: true,
+        installedVersion: '1.2.3',
+        latestVersion: '2.0.0',
+        lifecycle: 'unmanaged',
+        resolvedBinaryPath: '/opt/test/bin/test-bin',
+        sourceLabel: 'detected in PATH',
+        updateLabel: 'manual update',
+      },
+      name: 'indeterminate',
+      result: resolved(indeterminate(), undefined),
+    },
+  ])('preserves historical inspection meanings for $name observations', ({ expected, result }) => {
+    const inspection = projectObservationToV1Inspection(result)
+
+    expect(inspection).toEqual({ agent, methods, ...expected, installedState: result.installedState })
+    expect(Object.keys(inspection).sort()).toEqual(
+      [
+        'agent',
+        'binaryPath',
+        'inPath',
+        'installedState',
+        'installedVersion',
+        'latestVersion',
+        'lifecycle',
+        'methods',
+        'resolvedBinaryPath',
+        'sourceLabel',
+        'updateLabel',
+      ].sort(),
+    )
+    expect(inspection).not.toHaveProperty('observation')
+    expect(inspection).not.toHaveProperty('drift')
+    expect(inspection).not.toHaveProperty('receipt')
+    expect(inspection).not.toHaveProperty('binding')
+    expect(inspection).not.toHaveProperty('capabilities')
+  })
+})
+
+function resolved(
+  observation: LifecycleObservation,
+  installedState?: InstalledAgentState,
+  executable: ResolvedAgentObservation['executable'] = {
+    path: '/usr/local/bin/test-bin',
+    present: true,
+    version: '1.2.3',
+  },
+): ResolvedAgentObservation {
+  return {
+    agent,
+    capabilities: ['observe', 'update'],
+    catalogMethods: [],
+    executable,
+    installedState,
+    latestVersion: '2.0.0',
+    methods,
+    observation,
+    pathExecutable: executable,
+    receipt: installedState
+      ? {
+          kind: 'lifecycle-receipt',
+          providerId: 'bun',
+          providerTargetId: 'test-package',
+          providerTargetKind: 'package',
+          schemaVersion: 1,
+          targetId: 'test-agent',
+          verifiedAt: '2026-07-12T08:00:00.000Z',
+        }
+      : undefined,
+    resolvedBinaryPath: executable.path ? '/opt/test/bin/test-bin' : undefined,
+  }
+}
+
+function present(drift: LifecycleObservation['drift']): LifecycleObservation {
+  return {
+    drift,
+    executablePath: '/usr/local/bin/test-bin',
+    kind: 'present',
+    observedAt: '2026-07-12T08:00:00.000Z',
+    targetId: 'test-agent',
+    version: '1.2.3',
+  }
+}
+
+function absent(drift: LifecycleObservation['drift']): LifecycleObservation {
+  return {
+    drift,
+    kind: 'absent',
+    observedAt: '2026-07-12T08:00:00.000Z',
+    targetId: 'test-agent',
+  }
+}
+
+function indeterminate(): LifecycleObservation {
+  return {
+    drift: { kind: 'indeterminate', reason: 'provider unavailable' },
+    kind: 'indeterminate',
+    observedAt: '2026-07-12T08:00:00.000Z',
+    reason: 'provider unavailable',
+    targetId: 'test-agent',
+  }
+}

--- a/test/compatibility/v1-baseline.test.ts
+++ b/test/compatibility/v1-baseline.test.ts
@@ -6,7 +6,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setCliContext } from '../../src/cli-context'
 import { executeCommandWithRuntime } from '../../src/command-runtime'
 import { commandsCommand } from '../../src/commands/commands'
+import { infoCommand } from '../../src/commands/info'
+import { inspectCommand } from '../../src/commands/inspect'
+import { listCommand } from '../../src/commands/list'
+import { resolveCommand } from '../../src/commands/resolve'
 import { cliErrorCodes, getExitCodeForResult } from '../../src/errors'
+import * as legacyAgentsService from '../../src/services/agents'
+import * as lifecycleObservations from '../../src/services/lifecycle-observations'
 import { loadState, StateFileError } from '../../src/state'
 
 interface CompatibilitySurface {
@@ -116,7 +122,481 @@ describe('v1 compatibility baseline', () => {
       logSpy.mockRestore()
     }
   })
+
+  it('locks list and info to strict v1 projections at the observation route boundary', async () => {
+    const spies = installObservationRouteSpies()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      setCliContext({ interactive: false, outputMode: 'json', runId: 'v1-list-info-json' })
+      await listCommand()
+      await infoCommand('ta')
+
+      const [listPayload, infoPayload] = logSpy.mock.calls.map(call => JSON.parse(call[0]))
+      expect(listPayload).toEqual(expectedListResult('json', 'v1-list-info-json'))
+      expect(infoPayload).toEqual(expectedInfoResult('json', 'v1-list-info-json'))
+      expectNoInternalObservationFields(listPayload)
+      expectNoInternalObservationFields(infoPayload)
+      expectRouteSpies(spies)
+    } finally {
+      logSpy.mockRestore()
+      restoreRouteSpies(spies)
+    }
+  })
+
+  it('locks list and info NDJSON result events to strict v1 projections', async () => {
+    const spies = installObservationRouteSpies()
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      setCliContext({ interactive: false, outputMode: 'ndjson', runId: 'v1-list-info-ndjson' })
+      await listCommand()
+      await infoCommand('ta')
+
+      const [listEvent, infoEvent] = logSpy.mock.calls.map(call => JSON.parse(call[0]))
+      expect(listEvent).toEqual(
+        expectedResultEvent(
+          expectedListResult('ndjson', 'v1-list-info-ndjson'),
+          { kind: 'system', name: 'agents' },
+          'v1-list-info-ndjson',
+        ),
+      )
+      expect(infoEvent).toEqual(
+        expectedResultEvent(
+          expectedInfoResult('ndjson', 'v1-list-info-ndjson'),
+          { kind: 'agent', name: 'test-agent' },
+          'v1-list-info-ndjson',
+        ),
+      )
+      expectNoInternalObservationFields(listEvent)
+      expectNoInternalObservationFields(infoEvent)
+      expectRouteSpies(spies)
+    } finally {
+      logSpy.mockRestore()
+      restoreRouteSpies(spies)
+    }
+  })
+
+  it('locks inspect and resolve JSON results to strict v1 observation projections', async () => {
+    const observation = v1Observation()
+    const spies = installInspectResolveRouteSpies(
+      observation,
+      observation,
+      v1MissingObservation(),
+      undefined,
+      undefined,
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      setCliContext({ interactive: false, outputMode: 'json', runId: 'v1-inspect-resolve-json' })
+      await inspectCommand('ta')
+      await resolveCommand('ta')
+      await resolveCommand('ta')
+      await inspectCommand('unknown')
+      await resolveCommand('unknown')
+
+      const [inspectPayload, resolvePayload, guidancePayload, inspectUnknownPayload, resolveUnknownPayload] =
+        logSpy.mock.calls.map(call => JSON.parse(call[0]))
+      expect(inspectPayload).toEqual(expectedInspectResult('json', 'v1-inspect-resolve-json'))
+      expect(resolvePayload).toEqual(expectedResolveResult('json', 'v1-inspect-resolve-json'))
+      expect(guidancePayload).toEqual(expectedResolveGuidanceResult('json', 'v1-inspect-resolve-json'))
+      expect(inspectUnknownPayload).toEqual(expectedAgentNotFoundResult('inspect', 'json', 'v1-inspect-resolve-json'))
+      expect(resolveUnknownPayload).toEqual(expectedAgentNotFoundResult('resolve', 'json', 'v1-inspect-resolve-json'))
+      expectNoInspectInternalObservationFields(inspectPayload)
+      expectNoInternalObservationFields(resolvePayload)
+      expectNoInternalObservationFields(guidancePayload)
+      expectNoInternalObservationFields(inspectUnknownPayload)
+      expectNoInternalObservationFields(resolveUnknownPayload)
+      expectInspectResolveRouteSpies(spies, ['ta', 'ta', 'ta', 'unknown', 'unknown'])
+    } finally {
+      logSpy.mockRestore()
+      restoreInspectResolveRouteSpies(spies)
+    }
+  })
+
+  it('locks inspect and resolve NDJSON result events to strict v1 observation projections', async () => {
+    const observation = v1Observation()
+    const spies = installInspectResolveRouteSpies(
+      observation,
+      observation,
+      undefined,
+      undefined,
+      v1MissingObservation(),
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    try {
+      setCliContext({ interactive: false, outputMode: 'ndjson', runId: 'v1-inspect-resolve-ndjson' })
+      await inspectCommand('ta')
+      await resolveCommand('ta')
+      await inspectCommand('unknown')
+      await resolveCommand('unknown')
+      await resolveCommand('ta')
+
+      const [inspectEvent, resolveEvent, inspectUnknownEvent, resolveUnknownEvent, guidanceEvent] =
+        logSpy.mock.calls.map(call => JSON.parse(call[0]))
+      expect(inspectEvent).toEqual(
+        expectedResultEvent(
+          expectedInspectResult('ndjson', 'v1-inspect-resolve-ndjson'),
+          { kind: 'agent', name: 'test-agent' },
+          'v1-inspect-resolve-ndjson',
+        ),
+      )
+      expect(resolveEvent).toEqual(
+        expectedResultEvent(
+          expectedResolveResult('ndjson', 'v1-inspect-resolve-ndjson'),
+          { kind: 'agent', name: 'test-agent' },
+          'v1-inspect-resolve-ndjson',
+        ),
+      )
+      expect(inspectUnknownEvent).toEqual(
+        expectedResultEvent(
+          expectedAgentNotFoundResult('inspect', 'ndjson', 'v1-inspect-resolve-ndjson'),
+          { kind: 'agent', name: 'unknown' },
+          'v1-inspect-resolve-ndjson',
+        ),
+      )
+      expect(resolveUnknownEvent).toEqual(
+        expectedResultEvent(
+          expectedAgentNotFoundResult('resolve', 'ndjson', 'v1-inspect-resolve-ndjson'),
+          { kind: 'agent', name: 'unknown' },
+          'v1-inspect-resolve-ndjson',
+        ),
+      )
+      expect(guidanceEvent).toEqual(
+        expectedResultEvent(
+          expectedResolveGuidanceResult('ndjson', 'v1-inspect-resolve-ndjson'),
+          { kind: 'agent', name: 'test-agent' },
+          'v1-inspect-resolve-ndjson',
+        ),
+      )
+      expectNoInspectInternalObservationFields(inspectEvent)
+      expectNoInternalObservationFields(resolveEvent)
+      expectNoInternalObservationFields(inspectUnknownEvent)
+      expectNoInternalObservationFields(resolveUnknownEvent)
+      expectNoInternalObservationFields(guidanceEvent)
+      expectInspectResolveRouteSpies(spies, ['ta', 'ta', 'unknown', 'unknown', 'ta'])
+    } finally {
+      logSpy.mockRestore()
+      restoreInspectResolveRouteSpies(spies)
+    }
+  })
 })
+
+function installInspectResolveRouteSpies(
+  ...observations: Array<Awaited<ReturnType<typeof lifecycleObservations.resolveAgentObservation>>>
+) {
+  const queue = [...observations]
+  return {
+    legacy: vi
+      .spyOn(legacyAgentsService, 'resolveAgentInspection')
+      .mockRejectedValue(new Error('legacy inspect/resolve inspection must not run')),
+    resolve: vi.spyOn(lifecycleObservations, 'resolveAgentObservation').mockImplementation(async () => queue.shift()),
+  }
+}
+
+function restoreInspectResolveRouteSpies(spies: ReturnType<typeof installInspectResolveRouteSpies>): void {
+  spies.legacy.mockRestore()
+  spies.resolve.mockRestore()
+}
+
+function expectInspectResolveRouteSpies(
+  spies: ReturnType<typeof installInspectResolveRouteSpies>,
+  inputs: string[],
+): void {
+  expect(spies.resolve.mock.calls.map(([input]) => input)).toEqual(inputs)
+  expect(spies.legacy).not.toHaveBeenCalled()
+}
+
+function installObservationRouteSpies() {
+  const observation = v1Observation()
+  return {
+    legacyInfo: vi
+      .spyOn(legacyAgentsService, 'resolveAgentInspection')
+      .mockRejectedValueOnce(new Error('legacy info inspection must not run')),
+    legacyList: vi
+      .spyOn(legacyAgentsService, 'inspectRegisteredAgents')
+      .mockRejectedValueOnce(new Error('legacy list inspection must not run')),
+    observe: vi.spyOn(lifecycleObservations, 'observeRegisteredAgents').mockResolvedValueOnce([observation]),
+    resolve: vi.spyOn(lifecycleObservations, 'resolveAgentObservation').mockResolvedValueOnce(observation),
+  }
+}
+
+function restoreRouteSpies(spies: ReturnType<typeof installObservationRouteSpies>): void {
+  spies.legacyInfo.mockRestore()
+  spies.legacyList.mockRestore()
+  spies.resolve.mockRestore()
+  spies.observe.mockRestore()
+}
+
+function expectRouteSpies(spies: ReturnType<typeof installObservationRouteSpies>): void {
+  expect(spies.observe).toHaveBeenCalledOnce()
+  expect(spies.resolve).toHaveBeenCalledWith('ta')
+  expect(spies.legacyList).not.toHaveBeenCalled()
+  expect(spies.legacyInfo).not.toHaveBeenCalled()
+}
+
+function v1Observation() {
+  const agent = {
+    binaryName: 'test-bin',
+    displayName: 'Test Agent',
+    homepage: 'https://example.com',
+    lookupAliases: ['ta'],
+    name: 'test-agent',
+    packages: { npm: 'test-pkg' },
+    platforms: { linux: [{ packageName: 'test-pkg', type: 'bun' as const }] },
+    selfUpdate: { command: ['test-bin', 'update'] },
+  }
+  return {
+    agent,
+    capabilities: ['observe', 'update'] as const,
+    catalogMethods: [],
+    executable: { path: '/usr/bin/test-bin', present: true as const, version: '1.2.3' },
+    installedState: { agentName: 'test-agent', installType: 'bun' as const, packageName: 'test-pkg' },
+    latestVersion: '2.0.0',
+    methods: [{ packageName: 'test-pkg', type: 'bun' as const }],
+    observation: {
+      drift: { kind: 'none' as const },
+      executablePath: '/usr/bin/test-bin',
+      kind: 'present' as const,
+      targetId: 'test-agent',
+      version: '1.2.3',
+    },
+    pathExecutable: { path: '/usr/bin/test-bin', present: true as const, version: '1.2.3' },
+    receipt: {
+      kind: 'lifecycle-receipt' as const,
+      providerId: 'bun' as const,
+      providerTargetId: 'test-pkg',
+      providerTargetKind: 'package' as const,
+      schemaVersion: 1 as const,
+      targetId: 'test-agent',
+      verifiedAt: '2026-07-12T08:00:00.000Z',
+    },
+    resolvedBinaryPath: '/usr/bin/test-bin',
+  }
+}
+
+function v1MissingObservation() {
+  return {
+    ...v1Observation(),
+    executable: { present: false as const },
+    observation: {
+      drift: { kind: 'recorded-absent' as const },
+      kind: 'absent' as const,
+      targetId: 'test-agent',
+    },
+    pathExecutable: { present: false as const },
+    resolvedBinaryPath: undefined,
+  }
+}
+
+function expectedListResult(mode: 'json' | 'ndjson', runId: string) {
+  return {
+    action: 'list',
+    data: {
+      agents: [
+        {
+          binaryName: 'test-bin',
+          displayName: 'Test Agent',
+          installed: true,
+          installedVersion: '1.2.3',
+          latestVersion: '2.0.0',
+          lifecycle: 'managed',
+          name: 'test-agent',
+          sourceLabel: 'managed via bun (test-pkg)',
+          updateLabel: 'managed update',
+        },
+      ],
+    },
+    error: null,
+    meta: expectedMeta(mode, runId),
+    ok: true,
+    target: { kind: 'system', name: 'agents' },
+    warnings: [],
+  }
+}
+
+function expectedInfoResult(mode: 'json' | 'ndjson', runId: string) {
+  return {
+    action: 'info',
+    data: {
+      agent: {
+        aliases: ['ta'],
+        binaryName: 'test-bin',
+        displayName: 'Test Agent',
+        installMethods: [{ command: 'bun add -g test-pkg', label: 'managed/bun (test-pkg)', type: 'bun' }],
+        name: 'test-agent',
+        packageName: 'test-pkg',
+        selfUpdateCommands: ['test-bin update'],
+      },
+      inspection: {
+        binaryPath: '/usr/bin/test-bin',
+        installed: true,
+        installedVersion: '1.2.3',
+        latestVersion: '2.0.0',
+        lifecycle: 'managed',
+        sourceLabel: 'managed via bun (test-pkg)',
+      },
+    },
+    error: null,
+    meta: expectedMeta(mode, runId),
+    ok: true,
+    target: { kind: 'agent', name: 'test-agent' },
+    warnings: [],
+  }
+}
+
+function expectedInspectResult(mode: 'json' | 'ndjson', runId: string) {
+  return {
+    action: 'inspect',
+    data: {
+      agent: {
+        aliases: ['ta'],
+        binaryName: 'test-bin',
+        displayName: 'Test Agent',
+        installMethods: [{ command: 'bun add -g test-pkg', label: 'managed/bun (test-pkg)', type: 'bun' }],
+        name: 'test-agent',
+        packageName: 'test-pkg',
+        selfUpdateCommands: ['test-bin update'],
+      },
+      capabilities: {
+        canAutoInstall: true,
+        canAutoUninstall: true,
+        canRun: true,
+        canSelfUpdate: true,
+      },
+      inspection: {
+        binaryPath: '/usr/bin/test-bin',
+        installed: true,
+        installedVersion: '1.2.3',
+        latestVersion: '2.0.0',
+        lifecycle: 'managed',
+        sourceLabel: 'managed via bun (test-pkg)',
+        updateLabel: 'managed update',
+      },
+    },
+    error: null,
+    meta: expectedMeta(mode, runId),
+    ok: true,
+    target: { kind: 'agent', name: 'test-agent' },
+    warnings: [],
+  }
+}
+
+function expectedResolveResult(mode: 'json' | 'ndjson', runId: string) {
+  return {
+    action: 'resolve',
+    data: {
+      agent: { binaryName: 'test-bin', displayName: 'Test Agent', name: 'test-agent' },
+      resolution: {
+        binaryPath: '/usr/bin/test-bin',
+        installed: true,
+        installSource: 'bun',
+        installedVersion: '1.2.3',
+        lifecycle: 'managed',
+        sourceLabel: 'managed via bun (test-pkg)',
+        suggestedLaunchCommand: ['/usr/bin/test-bin'],
+      },
+    },
+    error: null,
+    meta: expectedMeta(mode, runId),
+    ok: true,
+    target: { kind: 'agent', name: 'test-agent' },
+    warnings: [],
+  }
+}
+
+function expectedResolveGuidanceResult(mode: 'json' | 'ndjson', runId: string) {
+  const installGuidance = {
+    docsRef: 'skills/quantex-cli/references/command-recipes.md',
+    installMethods: [{ command: 'bun add -g test-pkg', label: 'managed/bun (test-pkg)', type: 'bun' }],
+    suggestedAction: 'ensure-agent-installed',
+    suggestedEnsureCommand: 'quantex ensure test-agent',
+  }
+  return {
+    action: 'resolve',
+    data: {
+      agent: { binaryName: 'test-bin', displayName: 'Test Agent', name: 'test-agent' },
+      resolution: {
+        binaryPath: '',
+        installGuidance,
+        installed: false,
+        installSource: 'not-installed',
+        lifecycle: 'unmanaged',
+        sourceLabel: 'not installed',
+        suggestedLaunchCommand: [],
+      },
+    },
+    error: {
+      code: 'AGENT_NOT_INSTALLED',
+      details: installGuidance,
+      message: 'Test Agent is not installed.',
+    },
+    meta: expectedMeta(mode, runId),
+    ok: false,
+    target: { kind: 'agent', name: 'test-agent' },
+    warnings: [],
+  }
+}
+
+function expectedAgentNotFoundResult(action: 'inspect' | 'resolve', mode: 'json' | 'ndjson', runId: string) {
+  return {
+    action,
+    error: {
+      code: 'AGENT_NOT_FOUND',
+      details: { input: 'unknown' },
+      message: 'Unknown agent: unknown',
+    },
+    meta: expectedMeta(mode, runId),
+    ok: false,
+    target: { kind: 'agent', name: 'unknown' },
+    warnings: [],
+  }
+}
+
+function expectedResultEvent(
+  result:
+    | ReturnType<typeof expectedListResult>
+    | ReturnType<typeof expectedInfoResult>
+    | ReturnType<typeof expectedInspectResult>
+    | ReturnType<typeof expectedResolveResult>
+    | ReturnType<typeof expectedResolveGuidanceResult>
+    | ReturnType<typeof expectedAgentNotFoundResult>,
+  target: { kind: string; name: string },
+  runId: string,
+) {
+  return {
+    action: result.action,
+    data: result,
+    meta: expectedMeta('ndjson', runId),
+    target,
+    type: 'result',
+  }
+}
+
+function expectedMeta(mode: 'json' | 'ndjson', runId: string) {
+  return {
+    mode,
+    runId,
+    schemaVersion: '1',
+    timestamp: expect.any(String),
+    version: expect.any(String),
+  }
+}
+
+function expectNoInternalObservationFields(value: unknown): void {
+  expect(JSON.stringify(value)).not.toMatch(
+    /"(?:binding|capabilities|drift|providerTarget|providerTargetId|providerTargetKind|receipt)"/,
+  )
+}
+
+function expectNoInspectInternalObservationFields(value: unknown): void {
+  expect(JSON.stringify(value)).not.toMatch(
+    /"(?:binding|drift|providerTarget|providerTargetId|providerTargetKind|receipt)"/,
+  )
+  expect(JSON.stringify(value)).not.toMatch(/"capabilities":\[/)
+}
 
 async function readFixture<T>(fixturePath: string): Promise<T> {
   return JSON.parse(await readFixtureText(fixturePath)) as T

--- a/test/lifecycle/agent-observation.test.ts
+++ b/test/lifecycle/agent-observation.test.ts
@@ -1,0 +1,428 @@
+import type { AgentDefinition } from '../../src/agents'
+import type { LifecycleReceipt } from '../../src/lifecycle'
+import type { ProviderAdapter, ProviderObservation, ProviderOutcome, ProviderRegistry } from '../../src/providers'
+import type { InstalledAgentState } from '../../src/state'
+import { describe, expect, it, vi } from 'vitest'
+import { type AgentLifecycleObservationPorts, observeAgentLifecycle } from '../../src/lifecycle/agent-observation'
+
+type ObservationOutcome = ProviderOutcome<ProviderObservation>
+
+interface Scenario {
+  readonly expected: {
+    readonly binding?: { providerId: string; target: { id: string; kind: string } }
+    readonly capabilities?: readonly string[]
+    readonly drift: string
+    readonly kind: string
+    readonly path?: string
+    readonly pathExecutable?: Scenario['executable']
+    readonly providerId?: string
+    readonly providerOutcomeKind?: ObservationOutcome['kind']
+    readonly version?: string
+  }
+  readonly executable?: { readonly path?: string; readonly present: boolean; readonly version?: string }
+  readonly name: string
+  readonly outcomes?: Partial<Record<'bun' | 'cargo' | 'npm', ObservationOutcome>>
+  readonly receipt?: LifecycleReceipt
+  readonly rejectingProviders?: readonly ('bun' | 'cargo' | 'npm')[]
+  readonly state?: InstalledAgentState
+}
+
+const absent = (providerId: 'bun' | 'cargo' | 'npm'): ObservationOutcome => ({
+  kind: 'success',
+  value: {
+    kind: 'absent',
+    target: { id: providerId === 'cargo' ? 'test-cargo' : 'test-pkg', kind: 'package' },
+  },
+})
+
+const present = (providerId: 'bun' | 'cargo' | 'npm', path = '/bin/test-bin'): ObservationOutcome => ({
+  kind: 'success',
+  value: {
+    executablePath: path,
+    kind: 'present',
+    target: { id: providerId === 'cargo' ? 'test-cargo' : 'test-pkg', kind: 'package' },
+    version: providerId === 'bun' ? '1.2.3' : '2.0.0',
+  },
+})
+
+const legacyState: InstalledAgentState = {
+  agentName: 'test-agent',
+  installType: 'bun',
+}
+
+const receipt: LifecycleReceipt = {
+  executableName: 'test-bin',
+  executablePath: '/bin/test-bin',
+  kind: 'lifecycle-receipt',
+  providerId: 'bun',
+  providerTargetId: 'test-pkg',
+  providerTargetKind: 'package',
+  schemaVersion: 1,
+  targetId: 'test-agent',
+  verifiedAt: '2026-07-12T03:00:00.000Z',
+  version: '1.2.3',
+}
+
+const scenarios: readonly Scenario[] = [
+  {
+    expected: { drift: 'none', kind: 'absent' },
+    name: 'reports absent when PATH and every catalog provider are conclusively absent',
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true, version: '1.2.3' },
+    expected: {
+      drift: 'untracked',
+      kind: 'present',
+      path: '/bin/test-bin',
+      version: '1.2.3',
+    },
+    name: 'reports a PATH-only executable as untracked without inventing provider ownership',
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true, version: '1.2.3' },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'untracked',
+      kind: 'present',
+      path: '/bin/test-bin',
+      providerId: 'bun',
+      version: '1.2.3',
+    },
+    name: 'uses exactly one live catalog candidate as untracked provider ownership',
+    outcomes: { bun: present('bun') },
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: { drift: 'conflicting-source', kind: 'present', path: '/bin/test-bin' },
+    name: 'reports multiple live catalog candidates as conflicting source evidence',
+    outcomes: { bun: present('bun'), npm: present('npm') },
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: { drift: 'conflicting-source', kind: 'present', path: '/bin/test-bin' },
+    name: 'keeps conclusive multiple-live conflict ahead of another candidate failure',
+    outcomes: {
+      bun: present('bun'),
+      cargo: { kind: 'failed', reason: 'cargo probe failed', retryable: true },
+      npm: present('npm'),
+    },
+  },
+  {
+    expected: { drift: 'conflicting-source', kind: 'indeterminate' },
+    name: 'reports multiple live candidates as conflicting even when PATH is absent',
+    outcomes: { bun: present('bun'), npm: present('npm') },
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: { drift: 'indeterminate', kind: 'indeterminate', path: '/bin/test-bin' },
+    name: 'fails closed when a candidate probe is unresolved while PATH is present',
+    outcomes: {
+      bun: {
+        kind: 'failed',
+        reason: 'probe failed',
+        retryable: true,
+      },
+    },
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true, version: '1.2.3' },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'none',
+      kind: 'present',
+      path: '/bin/test-bin',
+      providerId: 'bun',
+      version: '1.2.3',
+    },
+    name: 'verifies matching installed state and receipt against live evidence',
+    outcomes: { bun: present('bun') },
+    receipt: receipt,
+    state: legacyState,
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: { drift: 'indeterminate', kind: 'indeterminate', path: '/bin/test-bin' },
+    name: 'fails closed when persisted receipt binding cannot be resolved',
+    receipt: { ...receipt, providerId: 'unknown-provider' },
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true, version: '1.2.3' },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'conflicting-source',
+      kind: 'present',
+      path: '/bin/test-bin',
+      providerId: 'bun',
+      version: '1.2.3',
+    },
+    name: 'reports a changed executable path against recorded receipt identity',
+    outcomes: { bun: present('bun') },
+    receipt: { ...receipt, executablePath: '/old/test-bin' },
+    state: legacyState,
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'conflicting-source',
+      kind: 'present',
+      path: '/bin/test-bin',
+    },
+    name: 'rejects provider evidence for a different target identity',
+    outcomes: {
+      bun: {
+        kind: 'success',
+        value: {
+          kind: 'present',
+          target: { id: 'other-package', kind: 'package' },
+        },
+      },
+    },
+    receipt,
+    state: legacyState,
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'indeterminate',
+      kind: 'indeterminate',
+      path: '/bin/test-bin',
+      providerOutcomeKind: 'failed',
+    },
+    name: 'normalizes a persisted provider adapter rejection to indeterminate',
+    receipt,
+    rejectingProviders: ['bun'],
+    state: legacyState,
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: {
+      drift: 'indeterminate',
+      kind: 'indeterminate',
+      path: '/bin/test-bin',
+      providerOutcomeKind: 'failed',
+    },
+    name: 'normalizes a catalog candidate adapter rejection to indeterminate',
+    rejectingProviders: ['bun'],
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true, version: '1.2.3' },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'none',
+      kind: 'present',
+      path: '/bin/test-bin',
+      providerId: 'bun',
+      version: '1.2.3',
+    },
+    name: 'verifies legacy installed state without requiring a receipt',
+    outcomes: { bun: present('bun') },
+    state: legacyState,
+  },
+  {
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'recorded-absent',
+      kind: 'absent',
+    },
+    name: 'reports a conclusive ghost when recorded and live evidence are absent',
+    receipt,
+    state: legacyState,
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: { drift: 'conflicting-source', kind: 'present', path: '/bin/test-bin' },
+    name: 'reports conflicting state and receipt provider bindings',
+    receipt: { ...receipt, providerId: 'npm' },
+    state: legacyState,
+  },
+  {
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'conflicting-source',
+      kind: 'present',
+      path: '/bin/test-bin',
+      pathExecutable: { present: false },
+      providerId: 'bun',
+      version: '1.2.3',
+    },
+    name: 'reports provider-present and PATH-absent evidence as conflicting',
+    outcomes: { bun: present('bun') },
+    receipt,
+    state: legacyState,
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true, version: '1.2.3' },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'conflicting-source',
+      kind: 'present',
+      path: '/bin/test-bin',
+      version: '1.2.3',
+    },
+    name: 'reports provider-absent and PATH-present evidence as conflicting',
+    receipt,
+    state: legacyState,
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'indeterminate',
+      kind: 'indeterminate',
+      path: '/bin/test-bin',
+    },
+    name: 'maps a typed unsupported provider observation to indeterminate drift',
+    outcomes: { bun: { kind: 'unsupported', operation: 'observe' } },
+    receipt,
+    state: legacyState,
+  },
+  {
+    executable: { path: '/bin/test-bin', present: true },
+    expected: {
+      binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+      capabilities: ['availability', 'observe', 'update'],
+      drift: 'indeterminate',
+      kind: 'indeterminate',
+      path: '/bin/test-bin',
+    },
+    name: 'preserves a typed indeterminate provider outcome',
+    outcomes: { bun: { kind: 'indeterminate', reason: 'ambiguous provider state' } },
+    receipt,
+    state: legacyState,
+  },
+]
+
+describe('observeAgentLifecycle', () => {
+  for (const scenario of scenarios) {
+    it(scenario.name, async () => {
+      const mutateState = vi.fn(() => {
+        throw new Error('observer must not mutate state')
+      })
+      const readInstalledState = vi.fn(async () => scenario.state)
+      const readReceipt = vi.fn(async () => scenario.receipt)
+      const registry = createRegistry(scenario.outcomes, scenario.rejectingProviders)
+      const ports: AgentLifecycleObservationPorts & { mutateState: typeof mutateState } = {
+        clock: () => '2026-07-12T04:00:00.000Z',
+        inspectExecutable: vi.fn(async () => scenario.executable ?? { present: false }),
+        mutateState,
+        platform: 'linux',
+        providerRegistry: registry,
+        readInstalledState,
+        readReceipt,
+        signal: new AbortController().signal,
+      }
+
+      const result = await observeAgentLifecycle(agent, ports)
+
+      expect(result.observation.kind).toBe(scenario.expected.kind)
+      expect(result.observation.drift.kind).toBe(scenario.expected.drift)
+      expect(result.binding).toMatchObject(scenario.expected.binding ?? {})
+      if (!scenario.expected.binding) expect(result.binding).toBeUndefined()
+      expect(result.capabilities).toEqual(scenario.expected.capabilities ?? [])
+      expect(result.executable.path).toBe(scenario.expected.path)
+      expect(result.executable.version).toBe(scenario.expected.version)
+      if (scenario.expected.pathExecutable) {
+        expect(result.pathExecutable).toEqual(scenario.expected.pathExecutable)
+      }
+      if (scenario.expected.providerOutcomeKind) {
+        expect(result.providerOutcome?.kind).toBe(scenario.expected.providerOutcomeKind)
+      }
+      if (result.observation.kind === 'present') {
+        expect(result.observation.providerId).toBe(scenario.expected.providerId)
+        expect(result.observation.executablePath).toBe(scenario.expected.path)
+        expect(result.observation.version).toBe(scenario.expected.version)
+      }
+      expect(result.installedState).toBe(scenario.state)
+      expect(result.receipt).toBe(scenario.receipt)
+      expect(result.catalogMethods).toEqual([
+        { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
+        { providerId: 'npm', target: { id: 'test-pkg', kind: 'package' } },
+        { providerId: 'cargo', target: { id: 'test-cargo', kind: 'package' } },
+      ])
+      expect(readInstalledState).toHaveBeenCalledWith('test-agent')
+      expect(readReceipt).toHaveBeenCalledWith('test-agent')
+      expect(mutateState).not.toHaveBeenCalled()
+    })
+  }
+
+  for (const providerId of ['brew', 'winget'] as const) {
+    it(`fails closed for an unresolved ${providerId} catalog candidate`, async () => {
+      const unresolvedAgent: AgentDefinition = {
+        ...agent,
+        packages: undefined,
+        platforms: { linux: [{ type: providerId }] },
+      }
+      const result = await observeAgentLifecycle(unresolvedAgent, {
+        clock: () => '2026-07-12T04:00:00.000Z',
+        inspectExecutable: async () => ({ path: '/bin/test-bin', present: true }),
+        platform: 'linux',
+        providerRegistry: createRegistry(),
+        readInstalledState: async () => undefined,
+        readReceipt: async () => undefined,
+        signal: new AbortController().signal,
+      })
+
+      expect(result.observation.kind).toBe('indeterminate')
+      expect(result.observation.drift.kind).toBe('indeterminate')
+      expect(result.binding).toBeUndefined()
+    })
+  }
+})
+
+function createRegistry(
+  outcomes: Scenario['outcomes'] = {},
+  rejectingProviders: Scenario['rejectingProviders'] = [],
+): ProviderRegistry {
+  const adapters = (['bun', 'npm', 'cargo'] as const).map(providerId => {
+    const adapter: ProviderAdapter = {
+      availability: async () => ({ kind: 'success', value: { executable: providerId } }),
+      id: providerId,
+      observe: async request => {
+        if (rejectingProviders.includes(providerId)) throw new Error(`${providerId} adapter rejected`)
+        return outcomes[providerId] ?? absent(providerId)
+      },
+      ...(providerId === 'bun'
+        ? {
+            update: async request => ({
+              kind: 'success' as const,
+              value: { evidence: [], target: request.target },
+            }),
+          }
+        : {}),
+    }
+    return adapter
+  })
+
+  return {
+    get: id => adapters.find(adapter => adapter.id === id),
+    getCapabilities: id => (id === 'bun' ? ['availability', 'observe', 'update'] : ['availability', 'observe']),
+    list: () => adapters,
+  }
+}
+
+const agent: AgentDefinition = {
+  binaryName: 'test-bin',
+  displayName: 'Test Agent',
+  homepage: 'https://example.com',
+  name: 'test-agent',
+  packages: { npm: 'test-pkg' },
+  platforms: {
+    linux: [
+      { packageName: 'test-pkg', type: 'bun' },
+      { packageName: 'test-pkg', type: 'npm' },
+      { packageName: 'test-cargo', type: 'cargo' },
+    ],
+  },
+}

--- a/test/lifecycle/mutation-planner.test.ts
+++ b/test/lifecycle/mutation-planner.test.ts
@@ -1,4 +1,5 @@
 import type { LifecycleIntent, LifecycleObservation } from '../../src/lifecycle'
+import type { LifecyclePlanningProvider } from '../../src/lifecycle/model'
 import { describe, expect, it } from 'vitest'
 import { planLifecycleMutation } from '../../src/lifecycle/mutation-planner'
 
@@ -57,6 +58,151 @@ describe('planLifecycleMutation', () => {
         ],
       }),
     ])
+  })
+
+  it('returns unsupported instead of inventing a missing provider mutation capability', () => {
+    const result = planLifecycleMutation({
+      intent: intent('install'),
+      observation: absent(),
+      provider: { capabilities: [], providerId: 'bun', targetId: '@openai/codex', targetKind: 'package' },
+    })
+
+    expect(result).toMatchObject({
+      decision: 'unsupported',
+      plan: { id: 'install-codex', steps: [] },
+    })
+  })
+
+  it('returns unsupported when tracked uninstall lacks the provider capability', () => {
+    const result = planLifecycleMutation({
+      intent: intent('uninstall'),
+      observation: present({
+        drift: { kind: 'none' },
+        providerId: 'bun',
+        providerTargetId: '@openai/codex',
+      }),
+      provider: {
+        capabilities: ['observe'],
+        providerId: 'bun',
+        targetId: '@openai/codex',
+        targetKind: 'package',
+      },
+    })
+
+    expect(result).toMatchObject({
+      decision: 'unsupported',
+      plan: { id: 'uninstall-codex', steps: [] },
+    })
+  })
+
+  it.each([
+    present({
+      drift: { kind: 'conflicting-source', observedProviderId: 'npm', recordedProviderId: 'bun' },
+      providerId: 'npm',
+      providerTargetId: '@openai/codex',
+    }),
+    indeterminate(),
+  ])('blocks contradictory or incomplete observations without planning effects', observation => {
+    const result = planLifecycleMutation({
+      intent: intent('install'),
+      observation,
+      provider: {
+        capabilities: ['install'],
+        providerId: 'bun',
+        targetId: '@openai/codex',
+        targetKind: 'package',
+      },
+    })
+
+    expect(result).toMatchObject({
+      decision: 'blocked',
+      plan: { id: 'install-codex', steps: [] },
+    })
+  })
+
+  it('blocks a capability snapshot bound to a different observed provider target', () => {
+    const result = planLifecycleMutation({
+      intent: intent('uninstall'),
+      observation: present({
+        drift: { kind: 'none' },
+        providerId: 'npm',
+        providerTargetId: '@openai/codex',
+      }),
+      provider: {
+        capabilities: ['uninstall'],
+        providerId: 'bun',
+        targetId: '@openai/codex',
+        targetKind: 'package',
+      },
+    })
+
+    expect(result).toMatchObject({
+      decision: 'blocked',
+      plan: { id: 'uninstall-codex', steps: [] },
+    })
+  })
+
+  it('requires target kind on new planning snapshots and blocks malformed runtime input that omits it', () => {
+    // @ts-expect-error Exact planning snapshots must include their provider target kind.
+    const missingKindProvider: LifecyclePlanningProvider = {
+      capabilities: ['uninstall'],
+      providerId: 'brew',
+      targetId: 'demo',
+    }
+    const result = planLifecycleMutation({
+      intent: intent('uninstall'),
+      observation: present({
+        drift: { kind: 'none' },
+        providerId: 'brew',
+        providerTargetId: 'demo',
+        providerTargetKind: 'cask',
+      }),
+      provider: missingKindProvider,
+    })
+
+    expect(result).toMatchObject({
+      decision: 'blocked',
+      plan: { id: 'uninstall-codex', steps: [] },
+    })
+  })
+
+  it('blocks a planning snapshot with a different provider target kind', () => {
+    const result = planLifecycleMutation({
+      intent: intent('uninstall'),
+      observation: present({
+        drift: { kind: 'none' },
+        providerId: 'brew',
+        providerTargetId: 'demo',
+        providerTargetKind: 'cask',
+      }),
+      provider: {
+        capabilities: ['uninstall'],
+        providerId: 'brew',
+        targetId: 'demo',
+        targetKind: 'formula',
+      },
+    })
+
+    expect(result).toMatchObject({
+      decision: 'blocked',
+      plan: { id: 'uninstall-codex', steps: [] },
+    })
+  })
+
+  it('keeps legacy provider fields compatible without requiring a planning target kind', () => {
+    const result = planLifecycleMutation({
+      intent: intent('uninstall'),
+      observation: present({
+        drift: { kind: 'none' },
+        providerId: 'brew',
+        providerTargetId: 'demo',
+        providerTargetKind: 'cask',
+      }),
+      providerId: 'brew',
+      providerTargetId: 'demo',
+    })
+
+    expect(result.decision).toBe('uninstall')
   })
 })
 

--- a/test/lifecycle/observation-planning.test.ts
+++ b/test/lifecycle/observation-planning.test.ts
@@ -1,0 +1,183 @@
+import type { LifecycleIntent, LifecycleObservation, LifecycleStep } from '../../src/lifecycle'
+import { describe, expect, it } from 'vitest'
+import { planLifecycleMutation } from '../../src/lifecycle/mutation-planner'
+
+describe('observation-driven lifecycle planning', () => {
+  it.each([
+    {
+      capabilities: ['install', 'uninstall'],
+      decision: 'satisfied',
+      intent: intent('ensure'),
+      name: 'already-satisfied',
+      observation: present({ drift: { kind: 'none' }, providerId: 'bun', providerTargetId: packageId }),
+      steps: [],
+    },
+    {
+      capabilities: ['install'],
+      decision: 'install',
+      intent: intent('install'),
+      name: 'absent',
+      observation: absent(),
+      steps: [providerStep('install', 'package-present')],
+    },
+    {
+      capabilities: ['uninstall'],
+      decision: 'uninstall',
+      intent: intent('uninstall'),
+      name: 'tracked',
+      observation: present({ drift: { kind: 'none' }, providerId: 'bun', providerTargetId: packageId }),
+      steps: [providerStep('uninstall', 'package-absent')],
+    },
+    {
+      capabilities: [],
+      decision: 'adopt',
+      intent: intent('ensure'),
+      name: 'untracked with exact provider evidence',
+      observation: present({
+        drift: { kind: 'untracked' },
+        executablePath: '/opt/homebrew/bin/codex',
+        providerId: 'bun',
+        providerTargetId: packageId,
+      }),
+      steps: [
+        {
+          dependsOn: [],
+          effects: [],
+          id: 'adopt-codex',
+          kind: 'operation',
+          postconditions: [{ executable: '/opt/homebrew/bin/codex', kind: 'executable-present' }],
+          preconditions: [],
+        },
+      ],
+    },
+    {
+      capabilities: ['uninstall'],
+      decision: 'clear-ghost',
+      intent: intent('uninstall'),
+      name: 'ghost',
+      observation: absent({ drift: { kind: 'recorded-absent' } }),
+      steps: [emptyStep('clear-ghost-codex')],
+    },
+    {
+      capabilities: ['install', 'uninstall'],
+      decision: 'blocked',
+      intent: intent('ensure'),
+      name: 'conflicting',
+      observation: present({ drift: { kind: 'conflicting-source' } }),
+      steps: [],
+    },
+    {
+      capabilities: [],
+      decision: 'unsupported',
+      intent: intent('install'),
+      name: 'unsupported',
+      observation: absent(),
+      steps: [],
+    },
+    {
+      capabilities: ['install'],
+      decision: 'blocked',
+      intent: intent('ensure'),
+      name: 'indeterminate',
+      observation: indeterminate(),
+      steps: [],
+    },
+    {
+      capabilities: [],
+      decision: 'preserve-unmanaged',
+      intent: intent('uninstall'),
+      name: 'untracked without provider evidence',
+      observation: present({ drift: { kind: 'untracked' } }),
+      steps: [],
+    },
+  ] as const)(
+    'produces a stable $name decision, id, step order, effects, and postconditions',
+    ({ capabilities, decision, intent: lifecycleIntent, observation, steps }) => {
+      const input = {
+        intent: lifecycleIntent,
+        observation,
+        provider: { capabilities, providerId: 'bun', targetId: packageId, targetKind: 'package' as const },
+      }
+
+      const first = planLifecycleMutation(input)
+      const second = planLifecycleMutation(input)
+
+      expect(first).toEqual(second)
+      expect(first).toEqual({
+        decision,
+        plan: {
+          id: `${lifecycleIntent.kind}-codex`,
+          intent: lifecycleIntent,
+          kind: 'lifecycle-plan',
+          observation,
+          steps,
+        },
+      })
+    },
+  )
+})
+
+const packageId = '@openai/codex'
+
+function intent(kind: LifecycleIntent['kind']): LifecycleIntent {
+  return { kind, targetId: 'codex' }
+}
+
+function present(input: Partial<Extract<LifecycleObservation, { kind: 'present' }>> = {}): LifecycleObservation {
+  return {
+    drift: input.drift ?? { kind: 'none' },
+    kind: 'present',
+    targetId: 'codex',
+    ...input,
+  }
+}
+
+function absent(input: Partial<Extract<LifecycleObservation, { kind: 'absent' }>> = {}): LifecycleObservation {
+  return {
+    drift: input.drift ?? { kind: 'none' },
+    kind: 'absent',
+    targetId: 'codex',
+    ...input,
+  }
+}
+
+function indeterminate(): LifecycleObservation {
+  return {
+    drift: { kind: 'indeterminate', reason: 'provider-timeout' },
+    kind: 'indeterminate',
+    reason: 'provider-timeout',
+    targetId: 'codex',
+  }
+}
+
+function providerStep(
+  operation: 'install' | 'uninstall',
+  postcondition: 'package-absent' | 'package-present',
+): LifecycleStep {
+  return {
+    dependsOn: [],
+    effects: [
+      {
+        capability: `bun-${operation}`,
+        kind: 'provider-mutation',
+        providerId: 'bun',
+        targetId: packageId,
+      },
+    ],
+    id: `${operation}-codex`,
+    kind: 'operation',
+    postconditions: [{ kind: postcondition, providerId: 'bun', targetId: packageId }],
+    preconditions: [],
+  }
+}
+
+function emptyStep(id: string): LifecycleStep {
+  return {
+    dependsOn: [],
+    effects: [],
+    id,
+    kind: 'operation',
+    postconditions: [],
+    preconditions: [],
+  }
+}

--- a/test/lifecycle/provider-evidence.test.ts
+++ b/test/lifecycle/provider-evidence.test.ts
@@ -5,6 +5,7 @@ import type { InstalledAgentState } from '../../src/state'
 import { describe, expect, it, vi } from 'vitest'
 import {
   observeLifecycleProvider,
+  resolveCatalogProviderEvidence,
   resolveReceiptProviderBinding,
   resolveStateProviderBinding,
 } from '../../src/lifecycle/provider-evidence'
@@ -71,6 +72,26 @@ describe('lifecycle provider evidence', () => {
     ).toEqual({
       providerId: 'brew',
       target: { id: 'test-cask', kind: 'cask' },
+    })
+  })
+
+  it('deduplicates equivalent catalog bindings without reporting an unresolved candidate', () => {
+    const evidence = resolveCatalogProviderEvidence(
+      {
+        ...agent,
+        platforms: {
+          linux: [
+            { packageName: 'test-pkg', type: 'bun' },
+            { packageName: 'test-pkg', type: 'bun' },
+          ],
+        },
+      },
+      'linux',
+    )
+
+    expect(evidence).toEqual({
+      bindings: [{ providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } }],
+      unresolvedCandidates: [],
     })
   })
 

--- a/test/providers/first-party-interruption.test.ts
+++ b/test/providers/first-party-interruption.test.ts
@@ -1,0 +1,195 @@
+import type { ProviderId, ProviderTarget } from '../../src/providers'
+import { existsSync } from 'node:fs'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import process from 'node:process'
+import { afterEach, describe, expect, it } from 'vitest'
+import { firstPartyProviderRegistry } from '../../src/providers'
+
+const availabilityProviders = [
+  ['brew', 'brew'],
+  ['bun', 'bun'],
+  ['cargo', 'cargo'],
+  ['deno', 'deno'],
+  ['mise', 'mise'],
+  ['npm', 'npm'],
+  ['pip', 'pip'],
+  ['uv', 'uv'],
+  ['winget', 'winget'],
+] as const satisfies readonly (readonly [ProviderId, string])[]
+
+const observationProviders = [
+  ['bun', 'bun', 'demo@1.0.0'],
+  ['mise', 'mise', '{"demo":[{"version":"1.0.0"}]}'],
+  ['npm', 'npm', '{"dependencies":{"demo":{"version":"1.0.0"}}}'],
+  ['uv', 'uv', 'demo v1.0.0'],
+] as const satisfies readonly (readonly [ProviderId, string, string])[]
+
+const roots: string[] = []
+const originalPath = process.env.PATH
+
+afterEach(async () => {
+  process.env.PATH = originalPath
+  await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+}, 15_000)
+
+describe('first-party provider interruption', () => {
+  it('preserves typed timeouts and joins all availability process trees', async () => {
+    const fixture = await createProviderFixtures(
+      availabilityProviders.map(([id, executable]) => ({ executable, id, mode: 'hang' as const })),
+    )
+
+    const outcomes = await Promise.all(
+      availabilityProviders.map(([id]) =>
+        firstPartyProviderRegistry.get(id)!.availability({
+          signal: new AbortController().signal,
+          timeoutMs: 10_000,
+        }),
+      ),
+    )
+
+    expect(outcomes).toEqual(availabilityProviders.map(() => ({ kind: 'timed-out', timeoutMs: 10_000 })))
+    await expectAllTreesStopped(fixture)
+  }, 30_000)
+
+  it('preserves typed cancellation and joins all availability process trees', async () => {
+    const fixture = await createProviderFixtures(
+      availabilityProviders.map(([id, executable]) => ({ executable, id, mode: 'hang' as const })),
+    )
+    const controllers = availabilityProviders.map(() => new AbortController())
+    const pending = availabilityProviders.map(([id], index) =>
+      firstPartyProviderRegistry.get(id)!.availability({ signal: controllers[index]!.signal }),
+    )
+    await fixture.waitForAllTrees()
+    controllers.forEach(controller => controller.abort('test cancellation'))
+
+    expect(await Promise.all(pending)).toEqual(
+      availabilityProviders.map(() => ({ kind: 'cancelled', reason: 'test cancellation' })),
+    )
+    await expectAllTreesStopped(fixture)
+  }, 15_000)
+
+  it('preserves typed timeouts through npm, Bun, mise, and uv presence/version probes', async () => {
+    const fixture = await createProviderFixtures(
+      observationProviders.map(([id, executable, firstOutput]) => ({
+        executable,
+        firstOutput,
+        id,
+        mode: 'version-then-hang' as const,
+      })),
+    )
+    const target: ProviderTarget = { id: 'demo', kind: 'package' }
+
+    const outcomes = await Promise.all(
+      observationProviders.map(([id]) =>
+        firstPartyProviderRegistry.get(id)!.observe!({
+          context: { signal: new AbortController().signal, timeoutMs: 10_000 },
+          target: id === 'mise' || id === 'uv' ? { ...target, kind: 'tool' } : target,
+        }),
+      ),
+    )
+
+    expect(outcomes).toEqual(observationProviders.map(() => ({ kind: 'timed-out', timeoutMs: 10_000 })))
+    await expectAllTreesStopped(fixture)
+  }, 30_000)
+
+  it('preserves typed cancellation through npm, Bun, mise, and uv presence/version probes', async () => {
+    const fixture = await createProviderFixtures(
+      observationProviders.map(([id, executable, firstOutput]) => ({
+        executable,
+        firstOutput,
+        id,
+        mode: 'version-then-hang' as const,
+      })),
+    )
+    const controllers = observationProviders.map(() => new AbortController())
+    const target: ProviderTarget = { id: 'demo', kind: 'package' }
+    const pending = observationProviders.map(([id], index) =>
+      firstPartyProviderRegistry.get(id)!.observe!({
+        context: { signal: controllers[index]!.signal },
+        target: id === 'mise' || id === 'uv' ? { ...target, kind: 'tool' } : target,
+      }),
+    )
+    await fixture.waitForAllTrees()
+    controllers.forEach(controller => controller.abort('test cancellation'))
+
+    expect(await Promise.all(pending)).toEqual(
+      observationProviders.map(() => ({ kind: 'cancelled', reason: 'test cancellation' })),
+    )
+    await expectAllTreesStopped(fixture)
+  }, 20_000)
+})
+
+interface FixtureInput {
+  executable: string
+  firstOutput?: string
+  id: ProviderId
+  mode: 'hang' | 'version-then-hang'
+}
+
+async function createProviderFixtures(inputs: FixtureInput[]) {
+  const root = await mkdtemp(join(tmpdir(), 'quantex-first-party-interruption-'))
+  roots.push(root)
+  const bun = resolveExecutable('bun')
+  const pidLogs: string[] = []
+
+  for (const input of inputs) {
+    const pidLog = join(root, `${input.id}.pids`)
+    const countFile = join(root, `${input.id}.count`)
+    pidLogs.push(pidLog)
+    await writeFile(
+      join(root, input.executable),
+      `#!${bun}\nconst mode = ${JSON.stringify(input.mode)}\nconst countFile = ${JSON.stringify(countFile)}\nlet count = 0\ntry { count = Number(await Bun.file(countFile).text()) } catch {}\nawait Bun.write(countFile, String(count + 1))\nif (mode === 'version-then-hang' && count === 0) { console.log(${JSON.stringify(input.firstOutput ?? '')}); process.exit(0) }\nprocess.on('SIGTERM', () => undefined)\nprocess.on('SIGINT', () => undefined)\nconst child = Bun.spawn([process.execPath, '-e', "process.on('SIGTERM', () => undefined); process.on('SIGINT', () => undefined); await new Promise(() => undefined)"], { stdin: 'ignore', stdout: 'ignore', stderr: 'ignore' })\nawait Bun.write(${JSON.stringify(pidLog)}, \`\${process.pid} \${child.pid}\\n\`)\nawait child.exited\n`,
+    )
+    await chmod(join(root, input.executable), 0o755)
+  }
+
+  process.env.PATH = `${root}${delimiter}${originalPath ?? ''}`
+  return {
+    pidLogs,
+    waitForAllTrees: () => waitForFiles(pidLogs, 10_000),
+  }
+}
+
+async function expectAllTreesStopped(fixture: { pidLogs: string[] }): Promise<void> {
+  await waitForFiles(fixture.pidLogs, 10_000)
+  const pids = (await Promise.all(fixture.pidLogs.map(readPids))).flat()
+  expect(pids.length).toBe(fixture.pidLogs.length * 2)
+  await waitForProcessesStopped(pids, 1_000)
+  expect(pids.filter(isProcessAlive)).toEqual([])
+}
+
+async function waitForProcessesStopped(pids: number[], timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (pids.some(isProcessAlive) && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 5))
+}
+
+async function waitForFiles(paths: string[], timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (paths.some(path => !existsSync(path)) && Date.now() < deadline)
+    await new Promise(resolve => setTimeout(resolve, 5))
+  const missing = paths.filter(path => !existsSync(path))
+  if (missing.length > 0) throw new Error(`Provider processes did not start: ${missing.join(', ')}`)
+}
+
+async function readPids(path: string): Promise<number[]> {
+  return (await readFile(path, 'utf8')).trim().split(/\s+/).map(Number).filter(Number.isFinite)
+}
+
+function resolveExecutable(name: string): string {
+  for (const directory of (originalPath ?? '').split(delimiter)) {
+    const candidate = join(directory, name)
+    if (existsSync(candidate)) return candidate
+  }
+  throw new Error(`Unable to find ${name}.`)
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/test/read-only-lifecycle-provider-signal.test.ts
+++ b/test/read-only-lifecycle-provider-signal.test.ts
@@ -1,0 +1,158 @@
+import type { CommandResult } from '../src/output/types'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const CLI_PATH = join(ROOT, 'src', 'cli.ts')
+
+describe('read-only lifecycle mixed signal cancellation', () => {
+  it.each(['SIGINT', 'SIGTERM'] as const)(
+    'cancels %s and terminates provider and agent process trees',
+    async signal => {
+      if (process.platform === 'win32') return
+      const root = await mkdtemp(join(tmpdir(), 'quantex-readonly-signal-'))
+      const home = join(root, 'home')
+      const bin = join(root, 'bin')
+      const providerPidLog = join(root, 'provider.pids.log')
+      const agentPidLog = join(root, 'agent.pids.log')
+      const bun = resolveExecutable('bun')
+      await mkdir(join(home, '.quantex'), { recursive: true })
+      await mkdir(bin, { recursive: true })
+      await writeFile(
+        join(home, '.quantex', 'state.json'),
+        `${JSON.stringify({ installedAgents: {}, lifecycleReceipts: {}, schemaVersion: 2, self: {} })}\n`,
+      )
+      await writeFile(join(bin, 'npm'), hangingTreeScript(bun, providerPidLog))
+      await chmod(join(bin, 'npm'), 0o755)
+      await writeFile(join(bin, 'codex'), hangingTreeScript(bun, agentPidLog))
+      await chmod(join(bin, 'codex'), 0o755)
+      const child = spawn(bun, [CLI_PATH, '--output', 'ndjson', '--non-interactive', 'doctor'], {
+        cwd: ROOT,
+        env: {
+          ...process.env,
+          HOME: home,
+          NO_COLOR: '1',
+          PATH: `${bin}:/usr/bin:/bin`,
+          USERPROFILE: home,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+
+      try {
+        await Promise.all([waitForFile(providerPidLog, 10_000), waitForFile(agentPidLog, 10_000)])
+        const pids = [...(await readPids(providerPidLog)), ...(await readPids(agentPidLog))]
+        expect(pids.length).toBe(4)
+        const startedAt = Date.now()
+        child.kill(signal)
+        const [exitCode, stdout, stderr] = await Promise.all([
+          waitForExit(child, 3_000),
+          readStream(child.stdout),
+          readStream(child.stderr),
+        ])
+        const result = parseJsonDocuments(`${stdout}\n${stderr}`).findLast(
+          entry => (entry.data ?? entry).error?.code === 'CANCELLED',
+        )
+
+        expect(exitCode).toBe(11)
+        expect(result?.data ?? result).toMatchObject({ error: { code: 'CANCELLED', details: { signal } }, ok: false })
+        await waitForProcessesStopped(pids, 1_000)
+        expect(Date.now() - startedAt).toBeLessThan(3_000)
+        expect(pids.filter(isProcessAlive)).toEqual([])
+      } finally {
+        if (child.pid && isProcessAlive(child.pid)) child.kill('SIGKILL')
+        await rm(root, { force: true, recursive: true })
+      }
+    },
+    20_000,
+  )
+})
+
+function hangingTreeScript(bun: string, pidLog: string): string {
+  return `#!${bun}\nprocess.on('SIGTERM', () => undefined)\nprocess.on('SIGINT', () => undefined)\nconst child = Bun.spawn([process.execPath, '-e', "process.on('SIGTERM', () => undefined); process.on('SIGINT', () => undefined); await new Promise(() => undefined)"], { stdin: 'ignore', stdout: 'ignore', stderr: 'ignore' })\nawait Bun.write(${JSON.stringify(pidLog)}, \`\${process.pid} \${child.pid}\\n\`)\nawait child.exited\n`
+}
+
+function resolveExecutable(name: string): string {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    const candidate = join(directory, name)
+    if (existsSync(candidate)) return candidate
+  }
+  throw new Error(`Unable to find ${name}.`)
+}
+
+async function waitForFile(path: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (!existsSync(path) && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 5))
+  if (!existsSync(path)) throw new Error(`Timed out waiting for ${path}.`)
+}
+
+async function readPids(path: string): Promise<number[]> {
+  return (await readFile(path, 'utf8')).trim().split(/\s+/).map(Number).filter(Number.isFinite)
+}
+
+async function waitForProcessesStopped(pids: number[], timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (pids.some(isProcessAlive) && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 5))
+}
+
+function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`CLI did not exit within ${timeoutMs}ms.`)), timeoutMs)
+    child.once('error', reject)
+    child.once('close', code => {
+      clearTimeout(timeout)
+      resolve(code ?? 1)
+    })
+  })
+}
+
+async function readStream(stream: NodeJS.ReadableStream | null): Promise<string> {
+  if (!stream) return ''
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+interface JsonDocument extends Partial<CommandResult> {
+  data?: CommandResult
+}
+
+function parseJsonDocuments(stdout: string): JsonDocument[] {
+  const documents: JsonDocument[] = []
+  let depth = 0
+  let start = -1
+  let escaped = false
+  let quoted = false
+  for (let index = 0; index < stdout.length; index += 1) {
+    const character = stdout[index]!
+    if (quoted) {
+      if (escaped) escaped = false
+      else if (character === '\\') escaped = true
+      else if (character === '"') quoted = false
+      continue
+    }
+    if (character === '"') quoted = true
+    else if (character === '{') {
+      if (depth === 0) start = index
+      depth += 1
+    } else if (character === '}') {
+      depth -= 1
+      if (depth === 0 && start >= 0) documents.push(JSON.parse(stdout.slice(start, index + 1)))
+    }
+  }
+  return documents
+}

--- a/test/read-only-lifecycle-provider-timeout.test.ts
+++ b/test/read-only-lifecycle-provider-timeout.test.ts
@@ -1,0 +1,230 @@
+import type { CommandResult } from '../src/output/types'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { readProcessOutputWithContext, spawnCommand } from '../src/utils/child-process'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const CLI_PATH = join(ROOT, 'src', 'cli.ts')
+
+describe('read-only lifecycle provider timeout', { timeout: 20_000 }, () => {
+  it.each([{ assertTree: false, timeoutMs: 100 }])(
+    'returns TIMEOUT for $timeoutMs ms and terminates the npm tree when observable',
+    async ({ assertTree, timeoutMs }) => {
+      if (process.platform === 'win32') return
+
+      const root = await mkdtemp(join(tmpdir(), 'quantex-readonly-timeout-'))
+      const home = join(root, 'home')
+      const bin = join(root, 'bin')
+      const pidLog = join(root, 'npm-pids.log')
+      const bun = resolveExecutable('bun')
+      await mkdir(join(home, '.quantex'), { recursive: true })
+      await mkdir(bin, { recursive: true })
+      await writeFile(
+        join(home, '.quantex', 'state.json'),
+        `${JSON.stringify({
+          installedAgents: {
+            copilot: {
+              agentName: 'copilot',
+              binaryName: 'copilot',
+              installType: 'npm',
+              packageName: '@github/copilot',
+              packageTargetKind: 'package',
+            },
+          },
+          lifecycleReceipts: {},
+          schemaVersion: 2,
+          self: {},
+        })}\n`,
+      )
+      await mkdir(join(home, '.quantex', 'cache'), { recursive: true })
+      await writeFile(
+        join(home, '.quantex', 'cache', 'versions.json'),
+        JSON.stringify({
+          entries: {
+            'npm:https://registry.npmjs.org:quantex-cli:latest': {
+              body: JSON.stringify({ version: '0.29.0' }),
+              expiresAt: Date.now() + 60_000,
+              fetchedAt: Date.now(),
+            },
+          },
+        }),
+      )
+      await writeFile(
+        join(bin, 'npm'),
+        `#!/bin/sh\nprintf 'invoked %s %s\\n' "$$" "$*" >> '${pidLog}'\nsh -c 'trap "" TERM; sleep 30' &\nchild=$!\nprintf '%s %s\\n' "$$" "$child" >> '${pidLog}'\ntrap '' TERM\nwait\n`,
+      )
+      await chmod(join(bin, 'npm'), 0o755)
+      await writeFile(join(bin, 'copilot'), '#!/bin/sh\n[ "$1" = "--version" ] && echo "copilot 1.0.0"\n')
+      await chmod(join(bin, 'copilot'), 0o755)
+
+      const startedAt = Date.now()
+      const child = spawn(
+        bun,
+        [CLI_PATH, '--output', 'ndjson', '--non-interactive', '--timeout', `${timeoutMs}ms`, 'info', 'copilot'],
+        {
+          cwd: ROOT,
+          detached: true,
+          env: {
+            ...process.env,
+            HOME: home,
+            LANG: 'C',
+            LC_ALL: 'C',
+            NO_COLOR: '1',
+            PATH: `${bin}:/usr/bin:/bin`,
+            USERPROFILE: home,
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      )
+
+      try {
+        const [exitCode, stdout, stderr] = await Promise.all([
+          waitForExit(child, timeoutMs + 3_000),
+          readStream(child.stdout),
+          readStream(child.stderr),
+        ])
+        const timeoutDocument = parseJsonDocuments(stdout).findLast(
+          entry => (entry.result ?? entry.data ?? entry).error?.code === 'TIMEOUT',
+        )
+        const result = timeoutDocument?.result ?? timeoutDocument?.data ?? timeoutDocument
+        const pidLogText = await readFile(pidLog, 'utf8').catch(() => '<missing>')
+        expect(result, `stdout=${stdout}\nstderr=${stderr}\npidLog=${pidLogText}`).toMatchObject({
+          error: { code: 'TIMEOUT', details: { timeoutMs } },
+          ok: false,
+        })
+        expect(exitCode).toBe(10)
+        expect(Date.now() - startedAt).toBeLessThan(assertTree ? 5_000 : 3_000)
+
+        if (assertTree) {
+          const pids = (await readFile(pidLog, 'utf8')).trim().split(/\s+/).map(Number).filter(Number.isFinite)
+          expect(pids.length).toBeGreaterThan(1)
+          await new Promise(resolve => setTimeout(resolve, 100))
+          expect(pids.filter(isProcessAlive)).toEqual([])
+        }
+      } finally {
+        if (child.pid && isProcessAlive(child.pid)) process.kill(-child.pid, 'SIGKILL')
+        await rm(root, { force: true, recursive: true })
+      }
+    },
+    10_000,
+  )
+
+  it('terminates a hanging npm probe process tree at a 100ms provider deadline', async () => {
+    if (process.platform === 'win32') return
+    const root = await mkdtemp(join(tmpdir(), 'quantex-provider-tree-'))
+    const npm = join(root, 'npm')
+    const pidLog = join(root, 'pids.log')
+    await writeFile(
+      npm,
+      `#!${resolveExecutable('bun')}\nprocess.on('SIGTERM', () => undefined)\nconst child = Bun.spawn([process.execPath, '-e', "process.on('SIGTERM', () => undefined); await new Promise(() => undefined)"], { stdin: 'ignore', stdout: 'ignore', stderr: 'ignore' })\nawait Bun.write(${JSON.stringify(pidLog)}, \`\${process.pid} \${child.pid}\\n\`)\nawait child.exited\n`,
+    )
+    await chmod(npm, 0o755)
+    const proc = spawnCommand([npm, 'list', '-g', '@github/copilot', '--depth=0', '--json'], {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    try {
+      await waitForFile(pidLog, 10_000)
+      await expect(
+        readProcessOutputWithContext(proc, {
+          signal: new AbortController().signal,
+          timeoutMs: 100,
+        }),
+      ).rejects.toMatchObject({ kind: 'timed-out', timeoutMs: 100 })
+      const pids = (await readFile(pidLog, 'utf8')).trim().split(/\s+/).map(Number).filter(Number.isFinite)
+      expect(pids.length).toBe(2)
+      await waitForProcessesStopped(pids, 1_000)
+      expect(pids.filter(isProcessAlive)).toEqual([])
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  }, 20_000)
+})
+
+function resolveExecutable(name: string): string {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    const path = join(directory, name)
+    if (existsSync(path)) return path
+  }
+  throw new Error(`Unable to find ${name}.`)
+}
+
+function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`CLI did not exit within ${timeoutMs}ms.`)), timeoutMs)
+    child.once('error', reject)
+    child.once('close', code => {
+      clearTimeout(timeout)
+      resolve(code ?? 1)
+    })
+  })
+}
+
+async function readStream(stream: NodeJS.ReadableStream | null): Promise<string> {
+  if (!stream) return ''
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function waitForProcessesStopped(pids: number[], timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (pids.some(isProcessAlive) && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 5))
+}
+
+async function waitForFile(path: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    if (existsSync(path)) return
+    await new Promise(resolve => setTimeout(resolve, 5))
+  }
+  throw new Error(`Timed out waiting for ${path}.`)
+}
+
+interface JsonDocument extends Partial<CommandResult> {
+  data?: CommandResult
+  result?: CommandResult
+  type?: string
+}
+
+function parseJsonDocuments(stdout: string): JsonDocument[] {
+  const documents: JsonDocument[] = []
+  let depth = 0
+  let start = -1
+  let escaped = false
+  let quoted = false
+  for (let index = 0; index < stdout.length; index += 1) {
+    const character = stdout[index]!
+    if (quoted) {
+      if (escaped) escaped = false
+      else if (character === '\\') escaped = true
+      else if (character === '"') quoted = false
+      continue
+    }
+    if (character === '"') quoted = true
+    else if (character === '{') {
+      if (depth === 0) start = index
+      depth += 1
+    } else if (character === '}') {
+      depth -= 1
+      if (depth === 0 && start >= 0) documents.push(JSON.parse(stdout.slice(start, index + 1)))
+    }
+  }
+  return documents
+}

--- a/test/read-only-lifecycle-smoke.test.ts
+++ b/test/read-only-lifecycle-smoke.test.ts
@@ -1,0 +1,66 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import * as smoke from '../scripts/read-only-lifecycle-smoke'
+
+type SmokeModule = typeof smoke & {
+  READ_ONLY_LIFECYCLE_BASELINE?: unknown
+  assertReadOnlyLifecycleBaseline?: (value: unknown) => void
+  formatReadOnlyLifecycleSummary?: (value: unknown) => string
+}
+
+let summary: Awaited<ReturnType<typeof smoke.runReadOnlyLifecycleSmoke>>
+
+describe('read-only lifecycle real-environment smoke', () => {
+  beforeAll(async () => {
+    summary = await smoke.runReadOnlyLifecycleSmoke()
+  }, 120_000)
+
+  it('keeps all migrated command projections read-only across compatibility fixtures', async () => {
+    expect(summary).toMatchObject({
+      commands: ['list', 'info', 'inspect', 'resolve', 'capabilities', 'doctor'],
+      fixtures: ['absent', 'tracked', 'untracked', 'ghost'],
+      invocations: 48,
+      modes: ['human', 'json'],
+    })
+  })
+
+  it('consumes a deterministic normalized compatibility baseline', () => {
+    const module = smoke as SmokeModule
+    expect(module.READ_ONLY_LIFECYCLE_BASELINE).toBeDefined()
+    expect(module.assertReadOnlyLifecycleBaseline).toBeTypeOf('function')
+    expect(summary).toHaveProperty('normalizedEvidence')
+
+    const normalizedEvidence = (summary as unknown as { normalizedEvidence?: unknown }).normalizedEvidence
+    expect(normalizedEvidence).toEqual(module.READ_ONLY_LIFECYCLE_BASELINE)
+    module.assertReadOnlyLifecycleBaseline?.(normalizedEvidence)
+  })
+
+  it('formats the normalized evidence as deterministic portable JSON', () => {
+    const module = smoke as SmokeModule
+    expect(module.formatReadOnlyLifecycleSummary).toBeTypeOf('function')
+    const normalizedEvidence = (summary as unknown as { normalizedEvidence?: unknown }).normalizedEvidence
+    const formatted = module.formatReadOnlyLifecycleSummary?.(normalizedEvidence)
+
+    expect(JSON.parse(formatted ?? '')).toEqual({
+      kind: 'read-only-lifecycle-smoke',
+      normalizedEvidence: module.READ_ONLY_LIFECYCLE_BASELINE,
+    })
+    expect(formatted).toBe(module.formatReadOnlyLifecycleSummary?.(structuredClone(normalizedEvidence)))
+  })
+
+  it.each([
+    ['tracked/untracked', 'tracked', 'untracked'],
+    ['absent/ghost', 'absent', 'ghost'],
+  ] as const)('rejects a %s fixture interchange', (_label, left, right) => {
+    const module = smoke as SmokeModule
+    expect(module.assertReadOnlyLifecycleBaseline).toBeTypeOf('function')
+    const normalizedEvidence = structuredClone(
+      (summary as unknown as { normalizedEvidence?: Record<string, unknown> }).normalizedEvidence,
+    )
+    expect(normalizedEvidence).toBeDefined()
+    const leftEvidence = normalizedEvidence?.[left]
+    normalizedEvidence![left] = normalizedEvidence![right]!
+    normalizedEvidence![right] = leftEvidence!
+
+    expect(() => module.assertReadOnlyLifecycleBaseline?.(normalizedEvidence)).toThrow(/compatibility baseline/i)
+  })
+})

--- a/test/read-only-lifecycle-timeout.test.ts
+++ b/test/read-only-lifecycle-timeout.test.ts
@@ -1,0 +1,45 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it } from 'vitest'
+import * as smoke from '../scripts/read-only-lifecycle-smoke'
+
+type WaitForChildExit = (
+  child: EventEmitter & { kill(signal: NodeJS.Signals): boolean },
+  options: { commandLabel: string; graceMs: number; timeoutMs: number },
+) => Promise<number>
+
+describe('read-only lifecycle child timeout', () => {
+  it('resolves a normal child exit without sending a signal', async () => {
+    const waitForChildExit = getWaitForChildExit()
+    const child = new FakeChild()
+    const result = waitForChildExit(child, { commandLabel: 'normal probe', graceMs: 5, timeoutMs: 50 })
+    child.emit('close', 0)
+
+    await expect(result).resolves.toBe(0)
+    expect(child.signals).toEqual([])
+  })
+
+  it('escalates from SIGTERM to SIGKILL and rejects a hung child', async () => {
+    const waitForChildExit = getWaitForChildExit()
+    const child = new FakeChild()
+
+    await expect(waitForChildExit(child, { commandLabel: 'hung probe', graceMs: 5, timeoutMs: 5 })).rejects.toThrow(
+      /hung probe.*timed out/i,
+    )
+    expect(child.signals).toEqual(['SIGTERM', 'SIGKILL'])
+  })
+})
+
+class FakeChild extends EventEmitter {
+  readonly signals: NodeJS.Signals[] = []
+
+  kill(signal: NodeJS.Signals): boolean {
+    this.signals.push(signal)
+    return true
+  }
+}
+
+function getWaitForChildExit(): WaitForChildExit {
+  const candidate = (smoke as typeof smoke & { waitForChildExit?: unknown }).waitForChildExit
+  expect(candidate).toBeTypeOf('function')
+  return candidate as WaitForChildExit
+}

--- a/test/read-only-network-header-timeout.test.ts
+++ b/test/read-only-network-header-timeout.test.ts
@@ -1,0 +1,151 @@
+import type { CommandResult } from '../src/output/types'
+import { spawn } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join, relative } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const CLI_PATH = join(ROOT, 'src', 'cli.ts')
+
+describe('read-only network request timeout', () => {
+  it('returns the established TIMEOUT envelope when transport rejects on abort before headers', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'quantex-header-timeout-'))
+    const home = join(root, 'home')
+    const configDir = join(home, '.quantex')
+    const preload = join(root, 'headerless-fetch.mjs')
+    const bun = resolveExecutable('bun')
+    await mkdir(configDir, { recursive: true })
+    await writeFile(
+      join(configDir, 'state.json'),
+      `${JSON.stringify({ installedAgents: {}, lifecycleReceipts: {}, schemaVersion: 2, self: {} })}\n`,
+    )
+    await writeFile(
+      preload,
+      `globalThis.fetch = (_input, init = {}) => new Promise((_resolve, reject) => { init.signal?.addEventListener('abort', () => reject(new Error('transport aborted')), { once: true }) })\n`,
+    )
+    const before = await snapshotTree(configDir)
+    const child = spawn(
+      bun,
+      ['--preload', preload, CLI_PATH, '--output', 'ndjson', '--non-interactive', '--timeout', '100ms', 'capabilities'],
+      {
+        cwd: ROOT,
+        env: {
+          ...process.env,
+          HOME: home,
+          NO_COLOR: '1',
+          PATH: `/usr/bin:/bin${delimiter}${dirname(bun)}`,
+          USERPROFILE: home,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    )
+
+    try {
+      const [exitCode, stdout, stderr] = await Promise.all([
+        waitForExit(child, 3_000),
+        readStream(child.stdout),
+        readStream(child.stderr),
+      ])
+      const documents = parseJsonDocuments(`${stdout}\n${stderr}`)
+      const timeout = documents.findLast(entry => (entry.data ?? entry).error?.code === 'TIMEOUT')
+
+      expect(exitCode).toBe(10)
+      expect(timeout?.data ?? timeout).toMatchObject({
+        error: { code: 'TIMEOUT', details: { timeoutMs: 100 } },
+        ok: false,
+      })
+      expect(documents.some(entry => (entry.data ?? entry).ok === true)).toBe(false)
+      expect(await snapshotTree(configDir)).toEqual(before)
+    } finally {
+      if (child.pid && isProcessAlive(child.pid)) child.kill('SIGKILL')
+      await rm(root, { force: true, recursive: true })
+    }
+  }, 10_000)
+})
+
+function resolveExecutable(name: string): string {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    const candidate = join(directory, name)
+    if (existsSync(candidate)) return candidate
+  }
+  throw new Error(`Unable to find ${name}.`)
+}
+
+function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`CLI did not exit within ${timeoutMs}ms.`)), timeoutMs)
+    child.once('error', reject)
+    child.once('close', code => {
+      clearTimeout(timeout)
+      resolve(code ?? 1)
+    })
+  })
+}
+
+async function readStream(stream: NodeJS.ReadableStream | null): Promise<string> {
+  if (!stream) return ''
+  const chunks: Buffer[] = []
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk))
+  return Buffer.concat(chunks).toString('utf8')
+}
+
+async function snapshotTree(root: string): Promise<Array<{ body?: string; path: string; type: 'directory' | 'file' }>> {
+  const snapshot: Array<{ body?: string; path: string; type: 'directory' | 'file' }> = []
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name)
+      const relativePath = relative(root, path)
+      if (entry.isDirectory()) {
+        snapshot.push({ path: relativePath, type: 'directory' })
+        await visit(path)
+      } else {
+        snapshot.push({ body: (await readFile(path)).toString('base64'), path: relativePath, type: 'file' })
+      }
+    }
+  }
+  await visit(root)
+  return snapshot.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+interface JsonDocument extends Partial<CommandResult> {
+  data?: CommandResult
+}
+
+function parseJsonDocuments(output: string): JsonDocument[] {
+  const documents: JsonDocument[] = []
+  let depth = 0
+  let start = -1
+  let escaped = false
+  let quoted = false
+  for (let index = 0; index < output.length; index += 1) {
+    const character = output[index]!
+    if (quoted) {
+      if (escaped) escaped = false
+      else if (character === '\\') escaped = true
+      else if (character === '"') quoted = false
+      continue
+    }
+    if (character === '"') quoted = true
+    else if (character === '{') {
+      if (depth === 0) start = index
+      depth += 1
+    } else if (character === '}') {
+      depth -= 1
+      if (depth === 0 && start >= 0) documents.push(JSON.parse(output.slice(start, index + 1)))
+    }
+  }
+  return documents
+}

--- a/test/read-only-network-timeout-compat.test.ts
+++ b/test/read-only-network-timeout-compat.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { setCliContext } from '../src/cli-context'
+import { capabilitiesCommand } from '../src/commands/capabilities'
+import { doctorCommand } from '../src/commands/doctor'
+import { infoCommand } from '../src/commands/info'
+import { listCommand } from '../src/commands/list'
+import * as config from '../src/config'
+
+const originalFetch = globalThis.fetch
+const getConfigDirSpy = vi.spyOn(config, 'getConfigDir')
+const loadConfigSpy = vi.spyOn(config, 'loadConfig')
+let root: string
+let cancelledBodies = 0
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), 'quantex-network-timeout-compat-'))
+  getConfigDirSpy.mockReturnValue(root)
+  loadConfigSpy.mockResolvedValue({
+    defaultPackageManager: 'bun',
+    networkRetries: 0,
+    networkTimeoutMs: 100,
+    npmBunUpdateStrategy: 'latest-major',
+    selfUpdateChannel: 'stable',
+    versionCacheTtlHours: 6,
+  })
+  setCliContext({ cacheMode: 'default', interactive: false, outputMode: 'json', runId: 'network-timeout-compat' })
+  globalThis.fetch = vi.fn(() =>
+    Promise.resolve(
+      new Response(
+        new ReadableStream({
+          cancel() {
+            cancelledBodies += 1
+          },
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode('{"version":"'))
+          },
+        }),
+        { headers: { 'content-type': 'application/json' }, status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+})
+
+afterAll(async () => {
+  globalThis.fetch = originalFetch
+  getConfigDirSpy.mockRestore()
+  loadConfigSpy.mockRestore()
+  await rm(root, { force: true, recursive: true })
+})
+
+describe('read-only internal network timeout compatibility', () => {
+  it('keeps no-timeout v1 command projections successful and cancels every exhausted body', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    try {
+      const [list, info, capabilities, doctor] = await Promise.all([
+        listCommand(),
+        infoCommand('codex'),
+        capabilitiesCommand(),
+        doctorCommand(),
+      ])
+
+      expect([list.ok, info.ok, capabilities.ok, doctor.ok]).toEqual([true, true, true, true])
+      expect(list.data?.agents.every(agent => agent.latestVersion === undefined)).toBe(true)
+      expect(info.data?.inspection.latestVersion).toBeUndefined()
+      expect(cancelledBodies).toBeGreaterThan(0)
+    } finally {
+      log.mockRestore()
+    }
+  }, 30_000)
+})

--- a/test/read-only-spawn-guard.test.ts
+++ b/test/read-only-spawn-guard.test.ts
@@ -1,0 +1,93 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, dirname, join } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..')
+const GUARD_PATH = join(ROOT, 'scripts', 'read-only-spawn-guard.ts')
+const BUN_PATH = resolveExecutable('bun')
+const SAFE_COMMANDS = ['bash', 'brew', 'bun', 'cargo', 'curl', 'deno', 'mise', 'npm', 'pip', 'sh', 'uv', 'winget']
+
+let sentinelDir: string
+
+beforeAll(async () => {
+  sentinelDir = await mkdtemp(join(tmpdir(), 'quantex-readonly-guard-'))
+  for (const command of SAFE_COMMANDS) {
+    const path = join(sentinelDir, command)
+    await writeFile(path, '#!/bin/sh\nexit 0\n')
+    await chmod(path, 0o755)
+  }
+})
+
+afterAll(async () => {
+  await rm(sentinelDir, { force: true, recursive: true })
+})
+
+describe('read-only child-process guard preload', () => {
+  it.each([
+    ['npm install', ['npm', 'install', '--global', '@openai/codex']],
+    ['bun add', ['bun', 'add', '--global', '@openai/codex']],
+    ['bun trust with a probe-shaped package name', ['bun', 'pm', 'trust', 'ls']],
+    ['brew upgrade', ['brew', 'upgrade', 'codex']],
+    ['cargo uninstall', ['cargo', 'uninstall', 'codex']],
+    ['deno install', ['deno', 'install', '--global', 'codex']],
+    ['pip uninstall', ['pip', 'uninstall', '-y', 'codex']],
+    ['uv upgrade', ['uv', 'tool', 'upgrade', 'codex']],
+    ['winget uninstall', ['winget', 'uninstall', '--id', 'OpenAI.Codex']],
+    ['mise use', ['mise', 'use', '--global', 'codex@latest']],
+    ['mise unuse', ['mise', 'unuse', '--global', 'codex']],
+    ['shell script', ['sh', '-c', 'exit 0 # curl https://example.invalid/install | bash']],
+    ['curl script', ['curl', 'https://example.invalid/install']],
+    ['bash script', ['bash', '-c', 'exit 0']],
+    ['binary effect', ['/missing/custom-agent-installer', '--apply']],
+  ] as const)('rejects %s before it can execute', (_label, command) => {
+    const result = runProbe([...command])
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('READ_ONLY_MUTATION_BLOCKED')
+  })
+
+  it.each([
+    ['bun version', ['bun', '--version']],
+    ['mise version', ['mise', '--version']],
+  ] as const)(
+    'allows the %s observation probe',
+    (_label, command) => {
+      const result = runProbe([...command])
+
+      expect(result.status).toBe(0)
+      expect(result.stderr).not.toContain('READ_ONLY_MUTATION_BLOCKED')
+    },
+    15_000,
+  )
+})
+
+function runProbe(command: string[]): { status: number; stderr: string } {
+  const script = `const child = Bun.spawn(${JSON.stringify(command)}, { stdout: 'ignore', stderr: 'ignore' }); await child.exited; process.exit(child.exitCode ?? 1)`
+  const result = spawnSync(BUN_PATH, ['--preload', GUARD_PATH, '-e', script], {
+    cwd: ROOT,
+    env: {
+      HOME: sentinelDir,
+      PATH: sentinelDir,
+      QUANTEX_READ_ONLY_GUARD: '1',
+    },
+    encoding: 'utf8',
+  })
+
+  return {
+    status: result.status ?? 1,
+    stderr: result.stderr,
+  }
+}
+
+function resolveExecutable(command: string): string {
+  for (const directory of (process.env.PATH ?? '').split(delimiter)) {
+    const candidate = join(directory, command)
+    if (existsSync(candidate)) return candidate
+  }
+  throw new Error(`Unable to resolve ${command}.`)
+}

--- a/test/runtime/cli-operation-context.test.ts
+++ b/test/runtime/cli-operation-context.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { cancelCliContextOperations, clearCliContextCancelled } from '../../src/cli-context'
+import { createCliOperationContext } from '../../src/runtime/cli-operation-context'
+
+describe('CLI operation context', () => {
+  it('aborts and joins live operations before cancellation completes', async () => {
+    clearCliContextCancelled()
+    const operation = createCliOperationContext()
+    let cleanupFinished = false
+    operation.context.registerCleanup?.({
+      cleanup: () =>
+        new Promise<void>(resolve => {
+          setTimeout(() => {
+            cleanupFinished = true
+            resolve()
+          }, 10)
+        }),
+    })
+
+    await cancelCliContextOperations()
+
+    expect(operation.context.signal.aborted).toBe(true)
+    expect(cleanupFinished).toBe(true)
+    operation.dispose()
+  })
+
+  it('unregisters its cancellation handler on dispose', async () => {
+    clearCliContextCancelled()
+    const operation = createCliOperationContext()
+    operation.dispose()
+
+    await cancelCliContextOperations()
+
+    expect(operation.context.signal.aborted).toBe(false)
+  })
+
+  it('returns typed cancellation without joining an unresponsive application promise', async () => {
+    clearCliContextCancelled()
+    const operation = createCliOperationContext()
+    const pending = operation.run(() => new Promise<never>(() => undefined))
+    const startedAt = Date.now()
+
+    await expect(
+      Promise.race([
+        cancelCliContextOperations().then(() => 'cancelled'),
+        new Promise<string>(resolve => setTimeout(() => resolve('still-pending'), 100)),
+      ]),
+    ).resolves.toBe('cancelled')
+    await expect(pending).rejects.toMatchObject({ kind: 'cancelled' })
+    expect(Date.now() - startedAt).toBeLessThan(100)
+    operation.dispose()
+  })
+
+  it('bounds cleanup joins and forces resources that miss the grace period', async () => {
+    clearCliContextCancelled()
+    const operation = createCliOperationContext()
+    let forced = false
+    operation.context.registerCleanup?.({
+      cleanup: () => new Promise<void>(() => undefined),
+      force: () => {
+        forced = true
+      },
+    })
+    const startedAt = Date.now()
+
+    await cancelCliContextOperations()
+
+    expect(forced).toBe(true)
+    expect(Date.now() - startedAt).toBeLessThan(1_000)
+    operation.dispose()
+  })
+})

--- a/test/self-update-notice.test.ts
+++ b/test/self-update-notice.test.ts
@@ -4,20 +4,21 @@ import * as selfModule from '../src/self'
 import { maybeRenderSelfUpdateNotice } from '../src/self/update-notice'
 import * as state from '../src/state'
 
-const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelf')
+const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelfReadOnly')
 const getSelfStateSpy = vi.spyOn(state, 'getSelfState')
 const setSelfUpdateNoticeStateSpy = vi.spyOn(state, 'setSelfUpdateNoticeState')
 
 describe('maybeRenderSelfUpdateNotice', () => {
-  let logSpy: ReturnType<typeof vi.spyOn>
+  let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
     inspectSelfSpy.mockClear()
     getSelfStateSpy.mockClear()
     setSelfUpdateNoticeStateSpy.mockClear()
     getSelfStateSpy.mockResolvedValue({})
     setCliContext({
+      colorMode: 'never',
       interactive: true,
       outputMode: 'human',
       runId: 'notice-run-id',
@@ -25,7 +26,7 @@ describe('maybeRenderSelfUpdateNotice', () => {
   })
 
   afterEach(() => {
-    logSpy.mockRestore()
+    stdoutWriteSpy.mockRestore()
   })
 
   it('suppresses passive notices when latest version is lower than current', async () => {
@@ -42,7 +43,28 @@ describe('maybeRenderSelfUpdateNotice', () => {
 
     await maybeRenderSelfUpdateNotice({ action: 'list', ok: true })
 
-    expect(logSpy).not.toHaveBeenCalled()
+    expect(stdoutWriteSpy).not.toHaveBeenCalled()
+    expect(setSelfUpdateNoticeStateSpy).not.toHaveBeenCalled()
+  })
+
+  it('renders the exact latest-version notice without persisting notice state', async () => {
+    inspectSelfSpy.mockResolvedValue({
+      canAutoUpdate: true,
+      currentVersion: '0.15.0',
+      executablePath: '/Users/test/.bun/bin/qtx',
+      installSource: 'bun',
+      latestVersion: '0.16.0',
+      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
+      recommendedUpgradeCommand: 'quantex upgrade',
+      updateChannel: 'stable',
+    })
+
+    await maybeRenderSelfUpdateNotice({ action: 'list', ok: true })
+
+    expect(stdoutWriteSpy).toHaveBeenCalledOnce()
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(
+      'Quantex CLI 0.16.0 is available (current 0.15.0). Run `quantex upgrade`.\n',
+    )
     expect(setSelfUpdateNoticeStateSpy).not.toHaveBeenCalled()
   })
 })

--- a/test/services/lifecycle-observations.test.ts
+++ b/test/services/lifecycle-observations.test.ts
@@ -1,0 +1,221 @@
+import type { AgentDefinition, InstallMethod } from '../../src/agents'
+import type { AgentLifecycleObservationPorts, AgentLifecycleObservationResult } from '../../src/lifecycle'
+import type { InstalledAgentState } from '../../src/state'
+import { readFile } from 'node:fs/promises'
+import { describe, expect, it, vi } from 'vitest'
+import * as legacyAgentsService from '../../src/services/agents'
+import {
+  createLifecycleObservationService,
+  observeRegisteredAgents,
+  resolveAgentObservation,
+} from '../../src/services/lifecycle-observations'
+
+const firstAgent = agent('alpha', ['a'])
+const secondAgent = agent('beta', ['b'])
+
+describe('lifecycle observation application service', () => {
+  it('resolves aliases to the canonical agent and observes it once', async () => {
+    const observe = vi.fn(async (target: AgentDefinition) => observation(target))
+    const service = createLifecycleObservationService(
+      ports({
+        getAgentByNameOrAlias: name => (name === 'a' ? firstAgent : undefined),
+        observeAgentLifecycle: observe,
+      }),
+    )
+
+    const result = await service.resolveAgentObservation('a')
+
+    expect(result?.agent).toBe(firstAgent)
+    expect(result?.observation.targetId).toBe('alpha')
+    expect(observe).toHaveBeenCalledTimes(1)
+    expect(observe).toHaveBeenCalledWith(firstAgent, expect.objectContaining({ providerRegistry: expect.anything() }))
+  })
+
+  it('returns undefined for an unknown agent without observing providers or state', async () => {
+    const observe = vi.fn(async (target: AgentDefinition) => observation(target))
+    const readInstalledState = vi.fn(async () => undefined)
+    const readReceipt = vi.fn(async () => undefined)
+    const service = createLifecycleObservationService(
+      ports({
+        getAgentByNameOrAlias: () => undefined,
+        observeAgentLifecycle: observe,
+        readInstalledState,
+        readReceipt,
+      }),
+    )
+
+    await expect(service.resolveAgentObservation('unknown')).resolves.toBeUndefined()
+    expect(observe).not.toHaveBeenCalled()
+    expect(readInstalledState).not.toHaveBeenCalled()
+    expect(readReceipt).not.toHaveBeenCalled()
+  })
+
+  it('observes every registered agent once in canonical registry order', async () => {
+    const observed: string[] = []
+    const service = createLifecycleObservationService(
+      ports({
+        getAllAgents: () => [secondAgent, firstAgent],
+        observeAgentLifecycle: async target => {
+          observed.push(target.name)
+          return observation(target)
+        },
+      }),
+    )
+
+    const results = await service.observeRegisteredAgents()
+
+    expect(results.map(result => result.agent.name)).toEqual(['beta', 'alpha'])
+    expect(observed).toEqual(['beta', 'alpha'])
+  })
+
+  it('shares one installed-state read with executable inspection', async () => {
+    const installedState = { agentName: 'alpha', installType: 'bun' as const, packageName: 'alpha-package' }
+    const readInstalledState = vi.fn(async () => installedState)
+    const inspectExecutable = vi.fn(async (_target: AgentDefinition, state: InstalledAgentState | undefined) => ({
+      present: true,
+      version: state?.packageName,
+    }))
+    const service = createLifecycleObservationService(
+      ports({
+        getAgentByNameOrAlias: () => firstAgent,
+        inspectExecutable,
+        observeAgentLifecycle: async (target, observationPorts) => {
+          const [executable, state] = await Promise.all([
+            observationPorts.inspectExecutable(target),
+            observationPorts.readInstalledState(target.name),
+          ])
+          return { ...observation(target), executable, installedState: state }
+        },
+        readInstalledState,
+      }),
+    )
+
+    const result = await service.resolveAgentObservation('alpha')
+
+    expect(result?.executable.version).toBe('alpha-package')
+    expect(inspectExecutable).toHaveBeenCalledWith(firstAgent, installedState)
+    expect(readInstalledState).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves the v1 binary path from raw PATH evidence instead of merged provider evidence', async () => {
+    const getResolvedBinaryPath = vi.fn(async (path?: string) => path)
+    const service = createLifecycleObservationService(
+      ports({
+        getAgentByNameOrAlias: () => firstAgent,
+        getResolvedBinaryPath,
+        observeAgentLifecycle: async target => ({
+          ...observation(target),
+          executable: { path: '/provider/alpha-bin', present: true, version: '2.0.0' },
+          pathExecutable: { path: '/path/alpha-bin', present: true, version: '1.0.0' },
+        }),
+      }),
+    )
+
+    const result = await service.resolveAgentObservation('alpha')
+
+    expect(getResolvedBinaryPath).toHaveBeenCalledWith('/path/alpha-bin')
+    expect(result?.resolvedBinaryPath).toBe('/path/alpha-bin')
+  })
+
+  it('exposes production entry points without routing through legacy inspection', async () => {
+    expect(typeof resolveAgentObservation).toBe('function')
+    expect(typeof observeRegisteredAgents).toBe('function')
+    expect(legacyAgentsService.resolveAgentInspection).toBeTypeOf('function')
+    expect(legacyAgentsService.inspectRegisteredAgents).toBeTypeOf('function')
+  })
+})
+
+describe('legacy mutation and execution boundary', () => {
+  it('keeps legacy exports and callers on services/agents', async () => {
+    const agentsSource = await source('src/services/agents.ts')
+    expect(agentsSource).toContain('export async function resolveAgentInspection')
+    expect(agentsSource).toContain('export async function inspectRegisteredAgents')
+    expect(agentsSource).not.toContain("from './lifecycle-observations'")
+
+    const expectedRoutes = {
+      'src/commands/ensure.ts': { exports: ['resolveAgent', 'resolveAgentInspection'], route: '../services/agents' },
+      'src/commands/install.ts': { exports: ['resolveAgent', 'resolveAgentInspection'], route: '../services/agents' },
+      'src/commands/run.ts': { exports: ['resolveAgentInspection'], route: '../services/agents' },
+      'src/commands/update.ts': { exports: ['resolveAgent'], route: '../services/agents' },
+      'src/services/update.ts': { exports: ['inspectRegisteredAgents'], route: './agents' },
+    }
+
+    for (const [path, expected] of Object.entries(expectedRoutes)) {
+      const contents = await source(path)
+      expect(contents).toContain(`from '${expected.route}'`)
+      expect(contents).not.toContain('lifecycle-observations')
+      for (const exportName of expected.exports) expect(contents).toContain(exportName)
+    }
+  })
+
+  it('keeps the new application boundary read-only and presenter-independent', async () => {
+    const serviceSource = await source('src/services/lifecycle-observations.ts')
+    const projectionSource = await source('src/compatibility/agent-inspection.ts')
+
+    for (const contents of [serviceSource, projectionSource]) {
+      expect(contents).not.toMatch(/from ['"]\.\.\/output/)
+      expect(contents).not.toMatch(/from ['"]\.\.\/commands/)
+    }
+    expect(serviceSource).not.toMatch(/\b(?:saveState|setInstalledAgentState|removeInstalledAgentState)\b/)
+    expect(serviceSource).not.toContain('withAgentLifecycleLock')
+  })
+})
+
+function ports(
+  overrides: Partial<Parameters<typeof createLifecycleObservationService>[0]> = {},
+): Parameters<typeof createLifecycleObservationService>[0] {
+  return {
+    clock: () => '2026-07-12T08:00:00.000Z',
+    getAllAgents: () => [firstAgent, secondAgent],
+    getAgentByNameOrAlias: name => [firstAgent, secondAgent].find(target => target.name === name),
+    getLatestVersion: async () => '2.0.0',
+    getOrderedInstallMethods: async target => [...(target.platforms.linux ?? [])],
+    getPlatform: () => 'linux',
+    getResolvedBinaryPath: async path => path,
+    inspectExecutable: async target => ({ path: `/bin/${target.binaryName}`, present: true, version: '1.0.0' }),
+    observeAgentLifecycle: async target => observation(target),
+    providerRegistry: {
+      get: () => undefined,
+      getCapabilities: () => [],
+      list: () => [],
+    },
+    readInstalledState: async () => undefined,
+    readReceipt: async () => undefined,
+    signal: new AbortController().signal,
+    ...overrides,
+  }
+}
+
+function observation(target: AgentDefinition): AgentLifecycleObservationResult {
+  const executable = { path: `/bin/${target.binaryName}`, present: true, version: '1.0.0' }
+
+  return {
+    capabilities: [],
+    catalogMethods: [],
+    executable,
+    observation: {
+      drift: { kind: 'untracked' },
+      executablePath: `/bin/${target.binaryName}`,
+      kind: 'present',
+      targetId: target.name,
+      version: '1.0.0',
+    },
+    pathExecutable: executable,
+  }
+}
+
+function agent(name: string, lookupAliases: string[]): AgentDefinition {
+  return {
+    binaryName: `${name}-bin`,
+    displayName: name.toUpperCase(),
+    homepage: 'https://example.com',
+    lookupAliases,
+    name,
+    packages: { npm: `${name}-package` },
+    platforms: { linux: [{ packageName: `${name}-package`, type: 'bun' } satisfies InstallMethod] },
+  }
+}
+
+async function source(path: string): Promise<string> {
+  return readFile(new URL(`../../${path}`, import.meta.url), 'utf8')
+}

--- a/test/services/provider-observations.test.ts
+++ b/test/services/provider-observations.test.ts
@@ -1,0 +1,127 @@
+import type { ProviderAdapter, ProviderOutcome, ProviderRegistry } from '../../src/providers'
+import { describe, expect, it, vi } from 'vitest'
+import { getCommandContracts } from '../../src/command-contract/registry'
+import { createProviderRegistry } from '../../src/providers'
+import {
+  getCommandCapabilitySnapshot,
+  projectCommandCapabilitiesToV1Features,
+} from '../../src/services/command-capabilities'
+import {
+  observeProviderSnapshot,
+  projectProviderSnapshotToV1Installers,
+} from '../../src/services/provider-observations'
+
+describe('provider observation snapshot', () => {
+  it('queries every registered adapter once and derives capabilities from the registry', async () => {
+    const adapters = [
+      adapter('bun', { kind: 'success', value: { executable: 'bun' } }, { update: true }),
+      adapter('script'),
+    ]
+    const baseRegistry = createProviderRegistry(adapters)
+    const registry: ProviderRegistry = {
+      get: vi.fn(id => baseRegistry.get(id)),
+      getCapabilities: vi.fn(id => baseRegistry.getCapabilities(id)),
+      list: vi.fn(() => baseRegistry.list()),
+    }
+
+    const snapshot = await observeProviderSnapshot({
+      context: { signal: new AbortController().signal },
+      registry,
+    })
+
+    expect(registry.list).toHaveBeenCalledTimes(1)
+    expect(registry.getCapabilities).toHaveBeenCalledTimes(2)
+    expect(adapters[0].availability).toHaveBeenCalledTimes(1)
+    expect(adapters[1].availability).toHaveBeenCalledTimes(1)
+    expect(snapshot.map(entry => [entry.id, entry.capabilities])).toEqual([
+      ['bun', ['availability', 'observe', 'update']],
+      ['script', ['availability', 'observe']],
+    ])
+  })
+
+  it.each([
+    [{ kind: 'cancelled', reason: 'stop' }],
+    [{ kind: 'timed-out', timeoutMs: 25 }],
+    [{ kind: 'unavailable', reason: 'missing provider', retryable: true }],
+  ] as const)('preserves typed availability outcome %o', async outcome => {
+    const snapshot = await observeProviderSnapshot({
+      context: { signal: new AbortController().signal, timeoutMs: 25 },
+      registry: createProviderRegistry([adapter('npm', outcome)]),
+    })
+
+    expect(snapshot[0].availability).toEqual(outcome)
+  })
+
+  it('projects exactly the nine strict v1 installers without script or binary providers', async () => {
+    const providers = [
+      'bun',
+      'npm',
+      'brew',
+      'cargo',
+      'deno',
+      'mise',
+      'pip',
+      'uv',
+      'winget',
+      'script',
+      'binary',
+    ] as const
+    const snapshot = await observeProviderSnapshot({
+      context: { signal: new AbortController().signal },
+      registry: createProviderRegistry(providers.map(id => adapter(id))),
+    })
+
+    const projection = projectProviderSnapshotToV1Installers(snapshot, entry => entry.id)
+
+    expect(Object.keys(projection)).toEqual(['brew', 'bun', 'cargo', 'deno', 'mise', 'npm', 'pip', 'uv', 'winget'])
+    expect(projection).not.toHaveProperty('script')
+    expect(projection).not.toHaveProperty('binary')
+  })
+})
+
+describe('command capability snapshot', () => {
+  it('derives the unchanged v1 feature projection from registered flags and effects', () => {
+    const snapshot = getCommandCapabilitySnapshot(getCommandContracts())
+
+    expect(snapshot.flagsByCommand.get('exec')).toContain('--install')
+    expect(snapshot.effectsByCommand.get('upgrade')).toEqual(new Set(['filesystem', 'mutation', 'network', 'process']))
+    expect(projectCommandCapabilitiesToV1Features(snapshot, { canAutoUpdateSelf: true })).toEqual({
+      assumeYes: true,
+      cacheBypass: true,
+      cacheRefresh: true,
+      channels: ['stable', 'beta'],
+      colorModes: ['auto', 'always', 'never'],
+      dryRun: true,
+      execInstallPolicies: ['never', 'if-missing', 'always'],
+      freshnessMetadata: true,
+      idempotencyKey: true,
+      logLevels: ['silent', 'error', 'warn', 'info', 'debug'],
+      quietLogs: true,
+      selfUpgrade: true,
+      timeout: true,
+    })
+  })
+})
+
+function adapter(
+  id: ProviderAdapter['id'],
+  availability: ProviderOutcome<{ readonly executable?: string }> = {
+    kind: 'unavailable',
+    reason: `${id} unavailable`,
+  },
+  operations: { readonly update?: boolean } = {},
+): ProviderAdapter {
+  return {
+    availability: vi.fn(async () => availability),
+    id,
+    observe: vi.fn(async request => ({ kind: 'success', value: { kind: 'absent', target: request.target } }) as const),
+    ...(operations.update
+      ? {
+          update: vi.fn(async request => ({
+            kind: 'success' as const,
+            value: { evidence: [], target: request.target },
+          })),
+        }
+      : {}),
+  }
+}

--- a/test/utils/child-process.test.ts
+++ b/test/utils/child-process.test.ts
@@ -1,7 +1,13 @@
+import { EventEmitter } from 'node:events'
 import process from 'node:process'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { cancelCliContextOperations, setCliContext } from '../../src/cli-context'
-import { spawnWithQuantexStdio, waitForSpawnedCommand } from '../../src/utils/child-process'
+import {
+  readProcessOutputWithContext,
+  spawnWithQuantexStdio,
+  terminateWindowsProcessTree,
+  waitForSpawnedCommand,
+} from '../../src/utils/child-process'
 
 const mockSpawn = vi.fn()
 let originalSpawn: typeof Bun.spawn
@@ -122,5 +128,47 @@ describe('spawnWithQuantexStdio', () => {
 
     expect(exitCode).toBe(1)
     expect(kill).toHaveBeenCalledWith('SIGTERM')
+  })
+})
+
+describe('context-aware process observations', () => {
+  it('escalates a timed-out observation from TERM to KILL', async () => {
+    const signals: NodeJS.Signals[] = []
+    const never = new Promise<number>(() => {})
+    const proc = {
+      exitCode: null,
+      exited: never,
+      kill: (signal: NodeJS.Signals) => {
+        signals.push(signal)
+        return true
+      },
+      stderr: null,
+      stdout: null,
+      unref: () => undefined,
+    }
+
+    await expect(
+      readProcessOutputWithContext(proc, {
+        signal: new AbortController().signal,
+        timeoutMs: 5,
+      }),
+    ).rejects.toMatchObject({ kind: 'timed-out', timeoutMs: 5 })
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL'])
+  })
+
+  it('uses taskkill tree force flags for Windows cleanup', async () => {
+    const calls: unknown[][] = []
+    const spawnProcess = ((...args: unknown[]) => {
+      calls.push(args)
+      const child = new EventEmitter()
+      queueMicrotask(() => child.emit('close', 0))
+      return child
+    }) as unknown as typeof import('node:child_process').spawn
+
+    await terminateWindowsProcessTree(42, spawnProcess)
+
+    expect(calls).toEqual([
+      ['taskkill.exe', ['/PID', '42', '/T', '/F'], { stdio: ['ignore', 'ignore', 'ignore'], windowsHide: true }],
+    ])
   })
 })

--- a/test/utils/network-lifecycle.test.ts
+++ b/test/utils/network-lifecycle.test.ts
@@ -1,0 +1,388 @@
+import type { Server } from 'node:http'
+import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join, relative } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cancelCliContextOperations, resetCliContext, setCliContext } from '../../src/cli-context'
+import * as config from '../../src/config'
+import { createCliOperationContext } from '../../src/runtime/cli-operation-context'
+import { resolveSelfUpdateTarget } from '../../src/self/planning'
+import { getLatestVersion } from '../../src/utils/version'
+
+const originalFetch = globalThis.fetch
+const roots: string[] = []
+const getConfigDirSpy = vi.spyOn(config, 'getConfigDir')
+const loadConfigSpy = vi.spyOn(config, 'loadConfig')
+
+beforeEach(() => {
+  resetCliContext()
+  setCliContext({ cacheMode: 'default', interactive: false, outputMode: 'json', runId: 'network-lifecycle' })
+  loadConfigSpy.mockResolvedValue({
+    defaultPackageManager: 'bun',
+    networkRetries: 0,
+    networkTimeoutMs: 10_000,
+    npmBunUpdateStrategy: 'latest-major',
+    selfUpdateChannel: 'stable',
+    versionCacheTtlHours: 6,
+  })
+})
+
+afterEach(async () => {
+  globalThis.fetch = originalFetch
+  resetCliContext()
+  await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+})
+
+describe('network response lifecycle', () => {
+  it('prioritizes an explicit invocation timeout over request transport rejection before headers', async () => {
+    const fixture = await createFixture()
+    const before = await snapshotTree(fixture)
+    installHeaderlessAbortFetch()
+
+    await expect(
+      getLatestVersion('headerless-timeout-package', 'latest', {
+        context: { signal: new AbortController().signal, timeoutMs: 20 },
+      }),
+    ).rejects.toMatchObject({ kind: 'timed-out', timeoutMs: 20 })
+    expect(await snapshotTree(fixture)).toEqual(before)
+  })
+
+  it('prioritizes external cancellation over request transport rejection before headers', async () => {
+    const fixture = await createFixture()
+    const before = await snapshotTree(fixture)
+    const controller = new AbortController()
+    installHeaderlessAbortFetch()
+    const pending = getLatestVersion('headerless-cancel-package', 'latest', {
+      context: { signal: controller.signal },
+    })
+
+    controller.abort('test cancellation')
+
+    await expect(pending).rejects.toMatchObject({ kind: 'cancelled', reason: 'test cancellation' })
+    expect(await snapshotTree(fixture)).toEqual(before)
+  })
+
+  it('keeps request-before-headers internal timeout exhaustion on the legacy fallback path', async () => {
+    const fixture = await createFixture()
+    const before = await snapshotTree(fixture)
+    installHeaderlessAbortFetch()
+    loadConfigSpy.mockResolvedValue({
+      defaultPackageManager: 'bun',
+      networkRetries: 0,
+      networkTimeoutMs: 20,
+      npmBunUpdateStrategy: 'latest-major',
+      selfUpdateChannel: 'stable',
+      versionCacheTtlHours: 6,
+    })
+
+    await expect(getLatestVersion('headerless-internal-package')).resolves.toBeUndefined()
+    expect(await snapshotTree(fixture)).toEqual(before)
+  })
+
+  it('cancels a slow version body through the shared invocation cleanup without changing cache state', async () => {
+    const fixture = await createFixture()
+    const server = await startSlowBodyServer('{"version":"')
+    const operation = createCliOperationContext()
+    const before = await snapshotTree(fixture)
+
+    try {
+      const pending = operation.run(() =>
+        getLatestVersion('slow-package', 'latest', {
+          context: operation.context,
+          registry: server.url,
+        }),
+      )
+      await server.requested
+      setTimeout(() => void cancelCliContextOperations(), 100)
+
+      await expect(withDeadline(pending, 1_000)).rejects.toMatchObject({ kind: 'cancelled' })
+      await expect(withDeadline(server.cancelled, 1_000)).resolves.toBeUndefined()
+      expect(await snapshotTree(fixture)).toEqual(before)
+    } finally {
+      operation.dispose()
+      await server.close()
+    }
+  })
+
+  it('cancels a slow self-release body and preserves the complete cache tree', async () => {
+    const fixture = await createFixture()
+    const server = await startSlowBodyServer('{"version":"')
+    const controller = new AbortController()
+    const before = await snapshotTree(fixture)
+    globalThis.fetch = ((_input, init) => originalFetch(server.url, init)) as typeof fetch
+
+    try {
+      const pending = resolveSelfUpdateTarget(
+        {
+          canAutoUpdate: true,
+          currentVersion: '1.0.0',
+          executablePath: '/tmp/quantex',
+          installSource: 'binary',
+          packageRoot: '/tmp',
+          updateChannel: 'stable',
+        },
+        { signal: controller.signal },
+      )
+      await server.requested
+      setTimeout(() => controller.abort('test cancellation'), 100)
+
+      await expect(withDeadline(pending, 1_000)).rejects.toMatchObject({
+        kind: 'cancelled',
+        reason: 'test cancellation',
+      })
+      await expect(withDeadline(server.cancelled, 1_000)).resolves.toBeUndefined()
+      expect(await snapshotTree(fixture)).toEqual(before)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('preserves typed timeout only when the invocation context has an explicit deadline', async () => {
+    const fixture = await createFixture()
+    const server = await startSlowBodyServer('{"version":"')
+    const before = await snapshotTree(fixture)
+
+    try {
+      await expect(
+        getLatestVersion('invocation-timeout-package', 'latest', {
+          context: { signal: new AbortController().signal, timeoutMs: 100 },
+          registry: server.url,
+        }),
+      ).rejects.toMatchObject({ kind: 'timed-out', timeoutMs: 100 })
+      await expect(withDeadline(server.cancelled, 1_000)).resolves.toBeUndefined()
+      expect(await snapshotTree(fixture)).toEqual(before)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('falls back after an internal slow-body timeout without committing cache or freshness metadata', async () => {
+    const fixture = await createFixture()
+    const server = await startSlowBodyServer('{"version":"')
+    const before = await snapshotTree(fixture)
+    loadConfigSpy.mockResolvedValue({
+      defaultPackageManager: 'bun',
+      networkRetries: 0,
+      networkTimeoutMs: 100,
+      npmBunUpdateStrategy: 'latest-major',
+      selfUpdateChannel: 'stable',
+      versionCacheTtlHours: 6,
+    })
+
+    try {
+      const pending = getLatestVersion('slow-timeout-package', 'latest', { registry: server.url })
+
+      await expect(withDeadline(pending, 1_000)).resolves.toBeUndefined()
+      await expect(withDeadline(server.cancelled, 1_000)).resolves.toBeUndefined()
+      expect(await snapshotTree(fixture)).toEqual(before)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('keeps the per-attempt deadline active through response validation', async () => {
+    const fixture = await createFixture()
+    const server = await startBodyServer('{"version":"2.0.0"}')
+    const before = await snapshotTree(fixture)
+    const parse = JSON.parse.bind(JSON)
+    const parseSpy = vi.spyOn(JSON, 'parse').mockImplementationOnce(value => {
+      const deadline = Date.now() + 150
+      while (Date.now() < deadline) {
+        // Hold synchronous validation past the attempt deadline.
+      }
+      return parse(value)
+    })
+    loadConfigSpy.mockResolvedValue({
+      defaultPackageManager: 'bun',
+      networkRetries: 0,
+      networkTimeoutMs: 100,
+      npmBunUpdateStrategy: 'latest-major',
+      selfUpdateChannel: 'stable',
+      versionCacheTtlHours: 6,
+    })
+
+    try {
+      await expect(
+        getLatestVersion('slow-validation-package', 'latest', { registry: server.url }),
+      ).resolves.toBeUndefined()
+      expect(await snapshotTree(fixture)).toEqual(before)
+    } finally {
+      parseSpy.mockRestore()
+      await server.close()
+    }
+  })
+
+  it('returns stale cached version data after internal timeout without rewriting the cache', async () => {
+    const fixture = await createFixture()
+    const server = await startSlowBodyServer('{"version":"')
+    const cacheDir = join(fixture, 'cache')
+    await mkdir(cacheDir, { recursive: true })
+    await writeFile(
+      join(cacheDir, 'versions.json'),
+      `${JSON.stringify({
+        entries: {
+          [`npm:${server.url}:stale-package:latest`]: {
+            body: JSON.stringify({ version: '7.7.7' }),
+            expiresAt: Date.now() - 1,
+            fetchedAt: Date.now() - 10_000,
+          },
+        },
+      })}\n`,
+    )
+    const before = await snapshotTree(fixture)
+    loadConfigSpy.mockResolvedValue({
+      defaultPackageManager: 'bun',
+      networkRetries: 0,
+      networkTimeoutMs: 100,
+      npmBunUpdateStrategy: 'latest-major',
+      selfUpdateChannel: 'stable',
+      versionCacheTtlHours: 6,
+    })
+
+    try {
+      await expect(getLatestVersion('stale-package', 'latest', { registry: server.url })).resolves.toBe('7.7.7')
+      await expect(withDeadline(server.cancelled, 1_000)).resolves.toBeUndefined()
+      expect(await snapshotTree(fixture)).toEqual(before)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it('maps an internal self-release timeout to the legacy network resolution result', async () => {
+    const fixture = await createFixture()
+    const server = await startSlowBodyServer('{"version":"')
+    const before = await snapshotTree(fixture)
+    globalThis.fetch = ((_input, init) => originalFetch(server.url, init)) as typeof fetch
+    loadConfigSpy.mockResolvedValue({
+      defaultPackageManager: 'bun',
+      networkRetries: 0,
+      networkTimeoutMs: 100,
+      npmBunUpdateStrategy: 'latest-major',
+      selfUpdateChannel: 'stable',
+      versionCacheTtlHours: 6,
+    })
+
+    try {
+      await expect(
+        resolveSelfUpdateTarget({
+          canAutoUpdate: true,
+          currentVersion: '1.0.0',
+          executablePath: '/tmp/quantex',
+          installSource: 'binary',
+          packageRoot: '/tmp',
+          updateChannel: 'stable',
+        }),
+      ).resolves.toMatchObject({ resolutionError: { kind: 'network' } })
+      await expect(withDeadline(server.cancelled, 1_000)).resolves.toBeUndefined()
+      expect(await snapshotTree(fixture)).toEqual(before)
+    } finally {
+      await server.close()
+    }
+  })
+})
+
+function installHeaderlessAbortFetch(): void {
+  globalThis.fetch = vi.fn(
+    (_input, init: RequestInit = {}) =>
+      new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => reject(new Error('transport aborted')), { once: true })
+      }),
+  ) as unknown as typeof fetch
+}
+
+async function createFixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'quantex-network-lifecycle-'))
+  roots.push(root)
+  await mkdir(root, { recursive: true })
+  await writeFile(join(root, 'sentinel.txt'), 'unchanged\n')
+  getConfigDirSpy.mockReturnValue(root)
+  return root
+}
+
+async function startSlowBodyServer(prefix: string): Promise<{
+  cancelled: Promise<void>
+  close(): Promise<void>
+  requested: Promise<void>
+  url: string
+}> {
+  let markCancelled!: () => void
+  let markRequested!: () => void
+  const cancelled = new Promise<void>(resolve => (markCancelled = resolve))
+  const requested = new Promise<void>(resolve => (markRequested = resolve))
+  const server = createServer((request, response) => {
+    request.once('close', markCancelled)
+    response.writeHead(200, { 'content-type': 'application/json' })
+    response.write(prefix)
+    markRequested()
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('Failed to start slow-body test server.')
+  return {
+    cancelled,
+    close: () => closeServer(server),
+    requested,
+    url: `http://127.0.0.1:${address.port}`,
+  }
+}
+
+async function startBodyServer(body: string): Promise<{ close(): Promise<void>; url: string }> {
+  const server = createServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' })
+    response.end(body)
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('Failed to start body test server.')
+  return {
+    close: () => closeServer(server),
+    url: `http://127.0.0.1:${address.port}`,
+  }
+}
+
+async function closeServer(server: Server): Promise<void> {
+  server.closeAllConnections()
+  await new Promise<void>(resolve => server.close(() => resolve()))
+}
+
+async function snapshotTree(root: string): Promise<Array<{ body?: string; path: string; type: 'directory' | 'file' }>> {
+  const snapshot: Array<{ body?: string; path: string; type: 'directory' | 'file' }> = []
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = join(directory, entry.name)
+      const relativePath = relative(root, path)
+      if (entry.isDirectory()) {
+        snapshot.push({ path: relativePath, type: 'directory' })
+        await visit(path)
+      } else {
+        snapshot.push({ body: (await readFile(path)).toString('base64'), path: relativePath, type: 'file' })
+      }
+    }
+  }
+  await visit(root)
+  return snapshot.sort((left, right) => left.path.localeCompare(right.path))
+}
+
+async function withDeadline<T>(work: Promise<T>, timeoutMs: number): Promise<T> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Network lifecycle did not settle within ${timeoutMs}ms.`)),
+          timeoutMs,
+        )
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}

--- a/test/utils/version.test.ts
+++ b/test/utils/version.test.ts
@@ -176,6 +176,24 @@ describe('compareVersions', () => {
 })
 
 describe('getLatestVersion', () => {
+  it('cancels an unresponsive cache-miss network request with the operation signal', async () => {
+    const { getLatestVersion } = await import('../../src/utils/version')
+    const controller = new AbortController()
+    mockFetch.mockImplementation(
+      (_url, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => reject(new Error('aborted')), { once: true })
+        }),
+    )
+    const pending = getLatestVersion('unresponsive-package', 'latest', {
+      context: { signal: controller.signal },
+    })
+
+    controller.abort('test cancellation')
+
+    await expect(pending).rejects.toMatchObject({ kind: 'cancelled', reason: 'test cancellation' })
+  })
+
   it('returns version from npm registry on success', async () => {
     const { getLatestVersion } = await import('../../src/utils/version')
     mockFetch.mockResolvedValue(new Response(JSON.stringify({ version: '2.0.0' }), { status: 200 }))


### PR DESCRIPTION
## Summary

Complete the observation/read-only milestone of the lifecycle redesign while preserving the v1 CLI contract.

- combine PATH, provider, state, receipt, version, and capability evidence behind one fail-closed lifecycle observer
- keep planning pure and retain the Phase 6 mutation compatibility boundary
- migrate `list`, `info`, `inspect`, `resolve`, `capabilities`, and `doctor` through a one-way v1 projection
- make provider observations side-effect-free, invocation-cancellable, process-tree-safe, and cache-safe across request/header/body/validation phases
- add real CLI local/container compatibility smoke coverage and advance the active umbrella change from 30/74 to 37/74

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/redesign-lifecycle-engine` tasks 5.1-5.7
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (105 files / 1086 tests)
- [ ] Not run, explained below

Additional validation:

- `bun run test:readonly-smoke` (5 files / 28 tests)
- Bun 1.3.11 container smoke (5 files / 28 tests)
- `bun run openspec:validate` (16/16)
- `bun run build`
- independent whole-branch review: no Critical, Important, or Minor findings
- normalized delivery branch: one commit; reviewed tree preserved exactly

## Release Intent

- Release: not applicable - integration milestone; final release intent is deferred to the integration to main closure

## Docs Updated

- [ ] Not needed
- [x] `docs/superpowers/plans/2026-07-12-observation-readonly-milestone.md`
- [x] `openspec/changes/redesign-lifecycle-engine/tasks.md`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is active across milestone merges by design and remains active at 37/74.
- [x] Release is not applicable for this integration-targeted milestone PR.

## Notes

- Base branch: `codex/redesign-lifecycle-integration`
- No Release workflow or npm publication is expected or permitted for this PR.
- Keep `redesign-lifecycle-engine` active; do not sync current specs or archive it after this milestone merge.
- Merge policy: rebase preferred, squash fallback, no merge commit or auto-merge.
