### PR TITLE
refactor: migrate agent execution lifecycle

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,18 +1,17 @@
-# Update and Idempotency Milestone Progress
+# Agent Execution Milestone Progress
 
-Base: `origin/codex/redesign-lifecycle-integration@d2d2275fbc631962414ebfccabfc30746ba1a727`
+Base: `origin/codex/redesign-lifecycle-integration@9213bd92cc555e2625067625cc05b2cce994f09d`
 
-Plan: `docs/superpowers/plans/2026-07-13-update-idempotency-milestone.md`
+Plan: `docs/superpowers/plans/2026-07-15-agent-execution-milestone.md`
 
 | Task | State | Checkpoint | Evidence |
 | --- | --- | --- | --- |
-| 1. Pure semantic update planning | complete | `54c456b`, `41ce213`, `ba36b88`, `bd33df7` | v1 goldens preserved; controller gate 103/103; final spec and quality review clean |
-| 2. Verified single-agent update service | complete | `76fd58e`..`c9a6389` | controller gate 56/56; final spec and quality review clean; known unrelated flakes pass exact isolation |
-| 3. Deterministic update-all composition | complete | `acd7659`..`3d17be0` | controller gate 117/117; v1 goldens unchanged; final spec and quality review clean |
-| 4. Versioned idempotency records | complete | `997b882`..`7301343` | controller gate 68/68; legacy runtime 21/21; canonical/schema/storage durability reviews clean |
-| 5. Command-specific replay validation | complete | `24934f6`..`2d05fad` (5A), `cb9274b`..`9b66549` (5B), `181f3e4`..`73d9acc` (5C single), `adfda05`..`9c83c75` (5C batch install), `e9c1628`..`099dcc4` (single update), `5ceee0a`..`d04aef0` (batch update), `4a739e8`..`b88bdae` (legacy removal and deterministic gates) | all command policies and legacy runtime removal approved; focused matrix 258/258 and full suite 1430/1430 pass |
-| 6. Contract and delivery closure | in progress | `bd1917d` | OpenSpec 44/74; full local gate 1434/1434, Docker managed/deno/uv smoke, and whole-branch re-review pass; Modal is unavailable locally, so base normalization, PR delivery, and trusted remote sandbox remain |
+| 1. Pure execution preflight planning | complete | `b642ee5` | 15/15 decision-table tests; lint, format, typecheck pass |
+| 2. Observation-driven execution service | complete | `f4e20ef` | 18 service tests plus 15 planner tests; no launch before fresh verified observation |
+| 3. Production process port and unified surface | complete | task-3 commit | explicit exec and shortcut share the lifecycle execution service; 48 focused tests plus full static validation pass |
+| 4. Cross-platform execution verification | complete | PR #459 first head | 1494/1494 local tests, managed/deno/uv container, macOS/Ubuntu/Windows CI, and trusted sandbox pass; independent review approved |
+| 5. PR delivery to integration | in progress | PR #459 | OpenSpec 48/74 update and refreshed CI/governance/final rebase CAS pending |
 
-Plan review: Ready Yes; no remaining Critical or Important findings.
+Baseline: lint, format, typecheck, and 329/329 suites with 1434/1434 tests pass on integration tip `9213bd9`. CodeGraph initialized with 450 files, 3923 nodes, and 10203 edges.
 
-Recovery rule: resume the first row that is not `complete`; inspect its brief/report, `git log`, and `git status` before dispatching work. Preserve granular commits on a recovery ref and normalize only after the refreshed integration-base gate.
+Recovery rule: resume the first row that is not `complete`; inspect its tests, `git log`, `git status`, and CodeGraph pending-sync banner before editing. Commit each reviewed task, preserve the granular head on `refs/quantex/recovery/redesign-agent-execution-granular`, and normalize only after the refreshed integration-base gate.

--- a/docs/superpowers/plans/2026-07-15-agent-execution-milestone.md
+++ b/docs/superpowers/plans/2026-07-15-agent-execution-milestone.md
@@ -1,0 +1,314 @@
+# Agent Execution Milestone Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete OpenSpec tasks 8.1–8.4 by routing explicit `exec` and shortcut launches through one observation-driven execution use case while preserving every v1 install-policy, standard-I/O, exit-code, timeout, and cancellation contract.
+
+**Architecture:** Add a pure execution-preflight planner over live lifecycle observations, then coordinate observation, optional verified installation, re-observation, and child launch in an injected application service. Keep `src/commands/run.ts` and `src/cli.ts` as compatibility adapters and presenters. A narrow production process port retains the existing terminal and process-tree behavior without moving command parsing or human output into the lifecycle domain.
+
+**Tech Stack:** Bun 1.3.x, strict TypeScript, Commander 14, Vitest, existing lifecycle observation/install reconciliation, existing child-process infrastructure, OpenSpec.
+
+## Global Constraints
+
+- Preserve explicit `exec <agent>` syntax, passthrough arguments, and default `--install never`; preserve shortcut launch with its current prompt policy.
+- Preserve `never`, `if-missing`, `always`, and shortcut `prompt` behavior. For compatibility, `always` does not reinstall an already runnable agent.
+- An executable present in `PATH` remains runnable even when provider or receipt evidence has drift; installation reconciliation remains responsible for deciding whether an absent executable can be installed safely.
+- Execution preflight MUST use live lifecycle observation without resolving a remote latest version or introducing an implicit self-update/network request.
+- Human launches inherit stdin/stdout/stderr. Structured explicit `exec` keeps stdout reserved for Quantex protocol output and routes child output to stderr. Shortcut structured output remains rejected before launch.
+- Return the child agent's exact exit code when it exits normally. Preserve exit code `10` for timeout, `11` for cancellation, existing preflight/error mappings, and exit code `1` for install/launch failure.
+- Timeout and cancellation MUST terminate the managed process tree on Unix and Windows-capable paths and MUST clean up signal handlers after every outcome.
+- Reuse verified installation reconciliation; do not invoke `ensure` or `install` as a nested CLI command and do not duplicate receipt persistence in the execution service.
+- Do not implement Phase 3 command-registry generation, Phase 9 self-upgrade integration, Phase 10 compatibility-facade removal, or any workflow-orchestration feature in this milestone.
+- Keep `redesign-lifecycle-engine` active. Check only tasks 8.1–8.4 after their full wording is implemented and verified; do not sync current specs or archive either active change.
+- Create granular recovery commits, retain them on a recovery ref, and normalize the PR branch to one commit before delivery to `codex/redesign-lifecycle-integration`.
+
+---
+
+### Task 1: Pure Execution Preflight Planning
+
+**Files:**
+- Create: `src/lifecycle/agent-execution.ts`
+- Modify: `src/lifecycle/index.ts`
+- Test: `test/lifecycle/agent-execution.test.ts`
+
+**Interfaces:**
+- Consumes: `LifecycleObservation`, `AgentExecutableObservation`, install policy, interaction state, and dry-run state.
+- Produces: `AgentExecutionPreflightInput`, `AgentExecutionPreflightPlan`, and `planAgentExecutionPreflight(input)`.
+- `AgentExecutionPreflightPlan` decisions are exactly `launch`, `install-and-launch`, `prompt-install`, `dry-run`, or `reject`; rejected plans carry `AGENT_NOT_INSTALLED` or `INTERACTION_REQUIRED` without CLI-formatted text.
+
+- [ ] **Step 1: Add failing table-driven preflight tests**
+
+  Cover executable present with every policy, executable absent with `never`, `if-missing`, `always`, interactive `prompt`, non-interactive `prompt`, and dry run. Add provider-drift and indeterminate-provider observations with an executable still present and assert they remain launchable. Assert repeated planning returns deep-equal plans and does not mutate the input.
+
+- [ ] **Step 2: Run the planner test to verify RED**
+
+  Run: `bun run test -- test/lifecycle/agent-execution.test.ts`
+
+  Expected: FAIL because `planAgentExecutionPreflight` and its typed decisions do not exist.
+
+- [ ] **Step 3: Implement the minimal pure decision table**
+
+  Implement this decision order without I/O:
+
+  ```typescript
+  export function planAgentExecutionPreflight(input: AgentExecutionPreflightInput): AgentExecutionPreflightPlan {
+    if (input.executable.present) return { decision: input.dryRun ? 'dry-run' : 'launch' }
+    if (input.installPolicy === 'never') {
+      return { decision: 'reject', errorCode: 'AGENT_NOT_INSTALLED' }
+    }
+    if (input.installPolicy === 'prompt' && !input.interactive) {
+      return { decision: 'reject', errorCode: 'INTERACTION_REQUIRED' }
+    }
+    if (input.dryRun) return { decision: 'dry-run' }
+    return { decision: input.installPolicy === 'prompt' ? 'prompt-install' : 'install-and-launch' }
+  }
+  ```
+
+  The concrete types may carry the observation and normalized intent for later diagnostics, but MUST NOT import command presenters, Commander, prompts, state stores, providers, or process utilities.
+
+- [ ] **Step 4: Verify GREEN and domain isolation**
+
+  Run: `bun run test -- test/lifecycle/agent-execution.test.ts && bun run typecheck`
+
+  Expected: PASS; `src/lifecycle/agent-execution.ts` has no CLI or infrastructure imports.
+
+- [ ] **Step 5: Review and checkpoint**
+
+  Review decision completeness and v1 policy compatibility, then commit:
+
+  ```bash
+  git add src/lifecycle/agent-execution.ts src/lifecycle/index.ts test/lifecycle/agent-execution.test.ts
+  git commit -m "refactor(exec): add lifecycle preflight planning"
+  ```
+
+### Task 2: Observation-Driven Execution Application Service
+
+**Files:**
+- Create: `src/services/lifecycle-execution.ts`
+- Modify: `src/services/index.ts`
+- Test: `test/services/lifecycle-execution.test.ts`
+
+**Interfaces:**
+- Produces `LifecycleExecutionServicePorts` with injected `observe`, `install`, `confirmInstall`, and `launch` functions plus interaction, dry-run, signal, timeout, and output-mode values.
+- Produces `executeAgentLifecycle(input, ports): Promise<AgentExecutionOutcome>`.
+- `AgentExecutionOutcome` is a discriminated union for `not-found`, `not-installed`, `interaction-required`, `install-declined`, `install-failed`, `dry-run`, `launch-failed`, `cancelled`, `timed-out`, and `exited`.
+- The service passes a canonical launch request containing `[binaryName, ...args]`, selected stdio mode, the invocation signal, and timeout. It returns typed data only and never prints or calls `process.exit`.
+
+- [ ] **Step 1: Add failing application-service tests**
+
+  Cover unknown agents, installed launch, every install policy, declined prompt, verified install followed by launch, install success followed by absent re-observation, dry run, launch failure, child exit codes `0`, `2`, and `42`, cancellation, and timeout. Assert launch never occurs before a post-install observation reports the executable present.
+
+- [ ] **Step 2: Run service tests to verify RED**
+
+  Run: `bun run test -- test/services/lifecycle-execution.test.ts`
+
+  Expected: FAIL because the execution application service does not exist.
+
+- [ ] **Step 3: Implement plan/execute orchestration**
+
+  Resolve one live observation, call `planAgentExecutionPreflight`, request confirmation only for `prompt-install`, and invoke the injected verified-install port only for an accepted install decision. Re-observe after successful installation and reject launch if the executable is still absent. Do not resolve latest versions, persist receipts, or select providers inside this service.
+
+- [ ] **Step 4: Implement typed launch mapping**
+
+  Map process-port success with a numeric exit code to `exited`, null exit plus a termination signal to `launch-failed`, and runtime failure kinds `cancelled`/`timed-out` to their matching execution outcomes. Preserve any other typed runtime failure as `launch-failed` with its stable diagnostic fields.
+
+- [ ] **Step 5: Verify GREEN and service boundaries**
+
+  Run: `bun run test -- test/services/lifecycle-execution.test.ts test/lifecycle/agent-execution.test.ts && bun run typecheck`
+
+  Expected: PASS; the service imports lifecycle/runtime types but no concrete catalog, provider, state, prompts, child-process, or presenter module.
+
+- [ ] **Step 6: Review and checkpoint**
+
+  Review ordering, no-launch-on-unverified-install, cancellation mapping, and boundary purity, then commit:
+
+  ```bash
+  git add src/services/lifecycle-execution.ts src/services/index.ts test/services/lifecycle-execution.test.ts
+  git commit -m "refactor(exec): add lifecycle execution service"
+  ```
+
+### Task 3: Production Process Port and Unified `exec`/Shortcut Surface
+
+**Files:**
+- Create: `src/runtime/agent-process.ts`
+- Modify: `src/runtime/index.ts`
+- Create: `src/services/lifecycle-execution-production.ts`
+- Modify: `src/services/lifecycle-observations.ts`
+- Modify: `src/commands/run.ts`
+- Create: `src/commands/shortcut.ts`
+- Modify: `src/cli.ts`
+- Test: `test/runtime/agent-process.test.ts`
+- Test: `test/commands/shortcut.test.ts`
+- Modify: `test/commands/run.test.ts`
+- Modify: `test/services/lifecycle-observations.test.ts`
+
+**Interfaces:**
+- `createAgentProcessPort()` implements the execution service's launch port with existing `spawnCommand` and `terminateProcessTree` primitives while owning timeout, abort-listener, output draining, and listener cleanup.
+- `createProductionLifecycleExecutionService()` binds catalog lookup, a no-latest-version lifecycle observation, verified `reconcileAgentInstallation`, prompts, and the process port.
+- `resolveShortcutInvocation(argv, knownCommands, { agentFriendly })` is a pure compatibility parser exported from `src/commands/shortcut.ts`.
+- `runCommand` becomes a v1 presenter over `AgentExecutionOutcome`; explicit `exec` and shortcut routing both call this same function.
+
+- [ ] **Step 1: Add failing production process tests**
+
+  Using controlled spawn handles, assert inherited stdio for human mode, ignored stdin plus child stdout/stderr forwarding to stderr for structured mode, exact child exit propagation, spawn failure, timeout termination, abort termination, Unix detached process-group termination, Windows tree-termination delegation, and cleanup of abort/signal listeners.
+
+- [ ] **Step 2: Add failing shortcut parser and shared-route tests**
+
+  Cover all currently accepted shortcut globals, passthrough argument order, known-command exclusion, unknown leading option fallback, missing global option values, structured/agent-friendly rejection, and the fact that both explicit `exec` and shortcut call the same `runCommand` compatibility adapter with their distinct default policies.
+
+- [ ] **Step 3: Run the focused surface tests to verify RED**
+
+  Run: `bun run test -- test/runtime/agent-process.test.ts test/commands/shortcut.test.ts test/commands/run.test.ts test/services/lifecycle-observations.test.ts`
+
+  Expected: FAIL because the process port, pure shortcut parser, no-latest execution observation, and production composition root do not exist.
+
+- [ ] **Step 4: Implement the process port**
+
+  Spawn direct argv with `detached: true` on non-Windows platforms. Register one abort listener before awaiting the child, race the child with timeout when configured, terminate the entire managed process tree on abort/timeout, await output drains, and remove every listener/timer in `finally`. Never translate a normal non-zero child exit into a Quantex failure.
+
+- [ ] **Step 5: Add a no-network execution observation composition**
+
+  Extend `createProductionLifecycleObservationService` with an explicit option that disables latest-version resolution while preserving its current default. Bind execution preflight with that option and assert the latest-version/network port is not called. Do not change read-only command behavior.
+
+- [ ] **Step 6: Bind verified installation and process launch**
+
+  The production installation port may adapt the already migrated `reconcileAgentInstallation` path after preflight chooses installation. It MUST use the reconciler's verified result, then let the application service re-observe before launch. It MUST NOT call `installAgent` directly from `runCommand` or write lifecycle receipts itself.
+
+- [ ] **Step 7: Convert `runCommand` into a compatibility presenter**
+
+  Map typed outcomes to the existing human text, JSON v1 data/error fields, install guidance, and established exit codes. Retain explicit `exec` default `never`, shortcut default `prompt`, passthrough argument handling, dry-run messages, and prompt copy. Remove legacy timeout/signal/install policy control flow from the command after equivalent tests pass.
+
+- [ ] **Step 8: Extract and route the shortcut parser**
+
+  Move `ShortcutInvocation` and `resolveShortcutInvocation` out of `src/cli.ts`. Pass TTY-derived `agentFriendly` as input, keep structured shortcut rejection unchanged, and call the same `runCommand` facade used by explicit `exec`.
+
+- [ ] **Step 9: Verify GREEN and v1 compatibility**
+
+  Run: `bun run test -- test/runtime/agent-process.test.ts test/commands/shortcut.test.ts test/commands/run.test.ts test/commands/state-read-error.test.ts test/compatibility/v1-baseline.test.ts test/services/lifecycle-observations.test.ts`
+
+  Expected: PASS with exact child exit codes, stream routing, preflight errors, dry-run output, and existing v1 fixtures unchanged.
+
+- [ ] **Step 10: Review and checkpoint**
+
+  Review stdio ownership, signal races, process-tree cleanup, no-network preflight, and compatibility mapping, then commit:
+
+  ```bash
+  git add src/runtime/agent-process.ts src/runtime/index.ts src/services/lifecycle-execution-production.ts src/services/lifecycle-observations.ts src/commands/run.ts src/commands/shortcut.ts src/cli.ts test/runtime/agent-process.test.ts test/commands/shortcut.test.ts test/commands/run.test.ts test/services/lifecycle-observations.test.ts
+  git commit -m "refactor(exec): unify explicit and shortcut execution"
+  ```
+
+### Task 4: Cross-Platform Execution and Cancellation Verification
+
+**Files:**
+- Modify: `scripts/lifecycle-smoke.ts`
+- Modify: `test/managed-installer-cancellation.e2e.test.ts`
+- Modify: `openspec/changes/redesign-lifecycle-engine/tasks.md`
+- Replace: `.superpowers/sdd/progress.md`
+
+**Interfaces:**
+- The lifecycle smoke runs an installed sandbox agent through explicit `exec -- --version` and shortcut `<agent> --version`, in addition to the existing exec dry run.
+- Cross-platform tests exercise the same production process/cancellation adapter used by the command surface.
+
+- [ ] **Step 1: Add failing smoke assertions for real execution**
+
+  After the managed sandbox agent is installed and verified, run explicit exec and shortcut version commands. Assert exit code `0`, non-empty version output on the expected terminal stream, and no mutation of lifecycle receipts during execution.
+
+- [ ] **Step 2: Harden managed-installer cancellation coverage**
+
+  Keep the existing natural-completion deadline and add assertions that cancellation leaves no successful receipt, no running child process, and no later state write. Use platform-specific path delimiters and process termination behavior so the test runs under Windows CI as well as Unix.
+
+- [ ] **Step 3: Run focused and cross-platform-capable local suites**
+
+  Run: `bun run test -- test/lifecycle/agent-execution.test.ts test/services/lifecycle-execution.test.ts test/runtime/agent-process.test.ts test/commands/shortcut.test.ts test/commands/run.test.ts test/managed-installer-cancellation.e2e.test.ts`
+
+  Expected: PASS with no leaked processes or timers.
+
+- [ ] **Step 4: Run trusted container execution smoke**
+
+  Run: `QTX_ISOLATION_AGENTS=codex QTX_ISOLATION_SCENARIOS=managed,deno-managed,uv-managed bun run test:container`
+
+  Expected: PASS including explicit exec, shortcut execution, and existing install/ensure/update/uninstall lifecycle scenarios.
+
+- [ ] **Step 5: Complete OpenSpec task accounting**
+
+  Check tasks 8.1–8.4 only after focused, full, three-platform CI, and sandbox evidence exists. Update progress to record exact commit/test evidence. The active count becomes 48/74; the change remains active and unarchived.
+
+- [ ] **Step 6: Run the complete milestone gate**
+
+  Run:
+
+  ```bash
+  bun run lint
+  bun run format:check
+  bun run typecheck
+  bun run test
+  bun run openspec:validate
+  bun run memory:check
+  bun run build
+  ```
+
+  Expected: all commands pass; no release artifact or npm publication is produced.
+
+- [ ] **Step 7: Whole-branch review and recovery checkpoint**
+
+  Request independent spec and code-quality review over `origin/codex/redesign-lifecycle-integration...HEAD`, fix every Critical/Important finding, rerun affected gates, then commit:
+
+  ```bash
+  git add scripts/lifecycle-smoke.ts test/managed-installer-cancellation.e2e.test.ts openspec/changes/redesign-lifecycle-engine/tasks.md .superpowers/sdd/progress.md
+  git commit -m "test(exec): verify cross-platform lifecycle execution"
+  git update-ref refs/quantex/recovery/redesign-agent-execution-granular HEAD
+  ```
+
+### Task 5: PR Delivery to Integration
+
+**Files:**
+- Modify as needed: `.superpowers/sdd/progress.md`
+- Create outside the repository: `/tmp/quantex-agent-execution-pr.md`
+
+**Interfaces:**
+- Produces one reviewed milestone commit and one ready PR from `codex/redesign-agent-execution` to `codex/redesign-lifecycle-integration`.
+- Preserves granular recovery history under `refs/quantex/recovery/redesign-agent-execution-granular`.
+
+- [ ] **Step 1: Refresh integration and normalize with CAS**
+
+  Fetch both refs, require the approved integration tip to remain the milestone base or rebase/revalidate first, preserve the granular head under the recovery ref, and normalize the feature branch to one commit with title:
+
+  ```text
+  refactor: migrate agent execution lifecycle
+  ```
+
+- [ ] **Step 2: Re-run final-tree validation**
+
+  Repeat lint, format check, typecheck, full test, OpenSpec validation, memory check, build, and trusted container smoke on the normalized tree. Verify the normalized tree hash equals the reviewed granular tree hash.
+
+- [ ] **Step 3: Validate the PR body**
+
+  Build the body from `.github/pull_request_template.md`, record OpenSpec `48/74`, local/container evidence, compatibility impact, release state, and archive state, then run:
+
+  ```bash
+  bun run pr:body:check -- --body-file /tmp/quantex-agent-execution-pr.md --title "refactor: migrate agent execution lifecycle"
+  ```
+
+- [ ] **Step 4: Push and create the ready PR**
+
+  Push `codex/redesign-agent-execution`, create a ready PR with base `codex/redesign-lifecycle-integration`, and confirm `autoMergeRequest` is null.
+
+- [ ] **Step 5: Monitor required and review checks**
+
+  Require lint, format/typecheck, macOS/Ubuntu/Windows tests, OpenSpec, memory, sandbox tests, PR body validation, and independent governance review to pass. Confirm no Release workflow runs for the branch or PR.
+
+- [ ] **Step 6: Rebase-merge only after final CAS**
+
+  Persist approved base tip, feature head, and expected merge tree under the worktree Git path. Reload them in a fresh process, fetch both refs again, verify exact equality, and merge with:
+
+  ```bash
+  pr_number=$(gh pr view --json number --jq .number)
+  approved_feature_head=$(git rev-parse origin/codex/redesign-agent-execution)
+  gh pr merge "$pr_number" --rebase --match-head-commit "$approved_feature_head"
+  ```
+
+  Do not enable auto-merge, create a merge commit, or squash unless rebase is unavailable and the user explicitly authorizes the fallback.
+
+- [ ] **Step 7: Verify post-merge closure**
+
+  Fetch integration, require its tree to equal the approved expected tree, confirm it still contains latest `main`, confirm no release ran, and leave `redesign-lifecycle-engine` active at 48/74 with no spec sync or archive closure.

--- a/openspec/changes/redesign-lifecycle-engine/tasks.md
+++ b/openspec/changes/redesign-lifecycle-engine/tasks.md
@@ -74,10 +74,10 @@
 
 ## 8. Agent Execution Migration
 
-- [ ] 8.1 Migrate explicit `exec` preflight and install policies to the new observer/planner/application boundary.
-- [ ] 8.2 Migrate shortcut launch to the same execution use case without duplicating lifecycle or option parsing.
-- [ ] 8.3 Preserve inherited stdin/stdout/stderr, child exit codes, interaction guidance, timeout, and process-tree cancellation.
-- [ ] 8.4 Run execution and managed-installer cancellation tests on Unix and Windows-capable CI/sandbox paths.
+- [x] 8.1 Migrate explicit `exec` preflight and install policies to the new observer/planner/application boundary.
+- [x] 8.2 Migrate shortcut launch to the same execution use case without duplicating lifecycle or option parsing.
+- [x] 8.3 Preserve inherited stdin/stdout/stderr, child exit codes, interaction guidance, timeout, and process-tree cancellation.
+- [x] 8.4 Run execution and managed-installer cancellation tests on Unix and Windows-capable CI/sandbox paths.
 
 ## 9. Self-Upgrade Integration
 

--- a/scripts/lifecycle-smoke.ts
+++ b/scripts/lifecycle-smoke.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import process from 'node:process'
 import { loadConfig } from '../src/config'
 import { resolveManagedSelfUpdateRegistry } from '../src/self'
+import { getStateFilePath } from '../src/state'
 import {
   buildSelfManagedRegistryMetadata,
   parsePackedTarballName,
@@ -113,6 +114,35 @@ async function smokeManagedAgentLifecycle(agent: string): Promise<void> {
 
   console.log(`[${agent}] exec dry run`)
   await runText(`exec ${agent} dry run`, [...cli, '--dry-run', 'exec', agent, '--', '--version'])
+
+  const stateBeforeExecution = await readFile(getStateFilePath())
+
+  console.log(`[${agent}] explicit exec`)
+  const explicitExecution = await runText(`exec ${agent}`, [...cli, 'exec', agent, '--', '--version'])
+  if (!explicitExecution.stderr.trim()) {
+    throw new Error(`${agent} structured exec should forward child version output to stderr`)
+  }
+
+  console.log(`[${agent}] shortcut exec`)
+  const shortcutExecution = await runText(`shortcut ${agent}`, [
+    'bun',
+    'run',
+    'src/cli.ts',
+    '--output',
+    'human',
+    '--non-interactive',
+    '--yes',
+    '--color',
+    'never',
+    agent,
+    '--version',
+  ])
+  if (!shortcutExecution.stdout.trim()) {
+    throw new Error(`${agent} shortcut should inherit child version output on stdout`)
+  }
+
+  const stateAfterExecution = await readFile(getStateFilePath())
+  assertBytesEqual(stateAfterExecution, stateBeforeExecution, `${agent} explicit and shortcut execution`)
 
   console.log(`[${agent}] update`)
   const update = await runJson(`update ${agent}`, [...cli, 'update', agent])
@@ -932,6 +962,13 @@ async function assertFileExists(path: string, message: string, debugRoot: string
 async function dumpDirectoryTree(root: string): Promise<void> {
   const output = await runCommand('debug self-managed sandbox tree', ['find', root, '-maxdepth', '5', '-print'])
   process.stderr.write(`[self-managed sandbox tree]\n${output.stdout}`)
+}
+
+function assertBytesEqual(actual: Uint8Array, expected: Uint8Array, label: string): void {
+  if (actual.byteLength !== expected.byteLength) throw new Error(`State file size changed during ${label}.`)
+  for (let index = 0; index < actual.byteLength; index += 1) {
+    if (actual[index] !== expected[index]) throw new Error(`State file bytes changed during ${label}.`)
+  }
 }
 
 async function resolveSelfManagedDependencyRegistry(): Promise<string> {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,7 @@ import {
   type CommandIdempotencyPolicyFactory,
 } from './command-runtime'
 import { runCommand } from './commands/run'
+import { resolveShortcutInvocation } from './commands/shortcut'
 import { getExitCodeForResult } from './errors'
 import {
   createAgentAbsenceIdempotencyPolicy,
@@ -281,7 +282,9 @@ const knownCommands = new Set([
   '-v',
 ])
 
-const shortcutInvocation = resolveShortcutInvocation(process.argv.slice(2), knownCommands)
+const shortcutInvocation = resolveShortcutInvocation(process.argv.slice(2), knownCommands, {
+  agentFriendly: process.stdin.isTTY === false || process.stdout.isTTY === false,
+})
 
 if (shortcutInvocation?.error) {
   console.log(pc.red(shortcutInvocation.error))
@@ -326,174 +329,11 @@ if (shortcutInvocation) {
 
 program.parse()
 
-interface ShortcutInvocation {
-  agentArgs: string[]
-  agentName: string
-  color?: string
-  dryRun?: boolean
-  error?: string
-  idempotencyKey?: string
-  logLevel?: string
-  noCache?: boolean
-  nonInteractive?: boolean
-  quiet?: boolean
-  refresh?: boolean
-  runId?: string
-  timeout?: string
-  yes?: boolean
-}
-
 function extractExecPassthroughArgs(command: { args: string[]; processedArgs: string[] }): string[] {
   const rawArgs = command.processedArgs.at(-1)
   if (Array.isArray(rawArgs)) return rawArgs
 
   return command.args.slice(1)
-}
-
-function resolveShortcutInvocation(argv: string[], knownCommandNames: Set<string>): ShortcutInvocation | undefined {
-  const autoAgentFriendly = process.stdin.isTTY === false || process.stdout.isTTY === false
-  let color: string | undefined
-  let dryRun = false
-  let index = 0
-  let idempotencyKey: string | undefined
-  let jsonOutputRequested = false
-  let logLevel: string | undefined
-  let noCache = false
-  let nonInteractive = false
-  let outputMode: string | undefined
-  let quiet = false
-  let refresh = false
-  let runId: string | undefined
-  let timeout: string | undefined
-  let yes = false
-
-  while (index < argv.length) {
-    const arg = argv[index]
-
-    if (arg === '--json') {
-      jsonOutputRequested = true
-      index += 1
-      continue
-    }
-
-    if (arg === '--output') {
-      const value = argv[index + 1]
-      if (!value) return { agentArgs: [], agentName: '', error: '--output requires a value' }
-      outputMode = value
-      index += 2
-      continue
-    }
-
-    if (arg === '--non-interactive') {
-      nonInteractive = true
-      index += 1
-      continue
-    }
-
-    if (arg === '--yes') {
-      yes = true
-      index += 1
-      continue
-    }
-
-    if (arg === '--quiet') {
-      quiet = true
-      index += 1
-      continue
-    }
-
-    if (arg === '--color') {
-      const value = argv[index + 1]
-      if (!value) return { agentArgs: [], agentName: '', error: '--color requires a value' }
-      color = value
-      index += 2
-      continue
-    }
-
-    if (arg === '--log-level') {
-      const value = argv[index + 1]
-      if (!value) return { agentArgs: [], agentName: '', error: '--log-level requires a value' }
-      logLevel = value
-      index += 2
-      continue
-    }
-
-    if (arg === '--dry-run') {
-      dryRun = true
-      index += 1
-      continue
-    }
-
-    if (arg === '--refresh') {
-      refresh = true
-      index += 1
-      continue
-    }
-
-    if (arg === '--no-cache') {
-      noCache = true
-      index += 1
-      continue
-    }
-
-    if (arg === '--idempotency-key') {
-      const value = argv[index + 1]
-      if (!value) return { agentArgs: [], agentName: '', error: '--idempotency-key requires a value' }
-      idempotencyKey = value
-      index += 2
-      continue
-    }
-
-    if (arg === '--run-id') {
-      const value = argv[index + 1]
-      if (!value) return { agentArgs: [], agentName: '', error: '--run-id requires a value' }
-      runId = value
-      index += 2
-      continue
-    }
-
-    if (arg === '--timeout') {
-      const value = argv[index + 1]
-      if (!value) return { agentArgs: [], agentName: '', error: '--timeout requires a value' }
-      timeout = value
-      index += 2
-      continue
-    }
-
-    if (arg.startsWith('-')) return undefined
-
-    if (knownCommandNames.has(arg)) return undefined
-
-    if (
-      jsonOutputRequested ||
-      outputMode === 'json' ||
-      outputMode === 'ndjson' ||
-      (autoAgentFriendly && outputMode !== 'human')
-    )
-      return {
-        agentArgs: [],
-        agentName: '',
-        error: 'Structured output is not supported for shortcut agent execution yet. Use a management command instead.',
-      }
-
-    return {
-      agentArgs: argv.slice(index + 1),
-      agentName: arg,
-      color,
-      dryRun,
-      idempotencyKey,
-      logLevel,
-      noCache,
-      nonInteractive,
-      quiet,
-      refresh,
-      runId,
-      timeout,
-      yes,
-    }
-  }
-
-  return undefined
 }
 
 async function executeCliCommand<T>(options: {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,19 +1,16 @@
 import type { AgentDefinition, InstallMethod } from '../agents/types'
-import type { SpawnHandle } from '../utils/child-process'
+import type { CliErrorCode } from '../errors'
+import type { RuntimeFailure } from '../runtime'
+import type { AgentExecutionOutcome } from '../services'
 import type { ExecInstallPolicy } from './exec'
 import process from 'node:process'
 import prompts from 'prompts'
-import { cancelCliContextOperations, clearCliContextCancelled, getCliContext } from '../cli-context'
-import { getExitCodeForError } from '../errors'
+import { cancelCliContextOperations, getCliContext } from '../cli-context'
+import { cliErrorCodes, getExitCodeForError } from '../errors'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
-import { installAgent } from '../package-manager'
-import { resolveAgentInspection } from '../services/agents'
-import { getStateFilePath, StateFileError } from '../state'
-import { spawnWithQuantexStdio, waitForSpawnedCommand } from '../utils/child-process'
+import { createProductionLifecycleExecutionService } from '../services'
 import { pc } from '../utils/color'
 import { formatInstallMethodCommand, formatInstallMethodLabel } from '../utils/install'
-import { createStateReadError } from '../utils/lifecycle-errors'
-import { isResourceLockError } from '../utils/lock'
 import {
   isAssumeYesEnabled,
   isDryRunEnabled,
@@ -49,160 +46,193 @@ interface ExecPreflightData {
   }
 }
 
+export interface RunCommandOptions {
+  readonly assumeYes?: boolean
+  readonly dryRun?: boolean
+  readonly install?: ExecInstallPolicy | 'prompt'
+  readonly nonInteractive?: boolean
+}
+
+export interface RunCommandDependencies {
+  readonly cancelOperations: typeof cancelCliContextOperations
+  readonly createExecutionService: typeof createProductionLifecycleExecutionService
+}
+
+const defaultDependencies: RunCommandDependencies = {
+  cancelOperations: cancelCliContextOperations,
+  createExecutionService: createProductionLifecycleExecutionService,
+}
+
 export async function runCommand(
   agentName: string,
   args: string[],
-  options: {
-    assumeYes?: boolean
-    dryRun?: boolean
-    install?: ExecInstallPolicy | 'prompt'
-    nonInteractive?: boolean
-  } = {},
+  options: RunCommandOptions = {},
+  dependencies: RunCommandDependencies = defaultDependencies,
 ): Promise<number> {
-  let resolved
-  try {
-    resolved = await resolveAgentInspection(agentName)
-  } catch (error) {
-    if (error instanceof StateFileError) {
-      emitStateReadError(agentName, error)
-      return getExitCodeForError('STATE_READ_ERROR')
-    }
+  const context = getCliContext()
+  const interactive = options.nonInteractive ? false : context.interactive
+  const assumeYes = options.assumeYes ?? isAssumeYesEnabled()
+  const dryRun = options.dryRun ?? isDryRunEnabled()
+  const installPolicy = options.install ?? 'prompt'
+  let cancellationSignal: NodeJS.Signals | undefined
 
-    throw error
+  const service = dependencies.createExecutionService({
+    confirmInstall: async observed => {
+      if (assumeYes) return true
+      const response = await prompts({
+        initial: true,
+        message: `${observed.agent.displayName} is not installed. Would you like to install it?`,
+        name: 'install',
+        type: 'confirm',
+      })
+      return Boolean(response.install)
+    },
+    dryRun,
+    interactive,
+    onInstallStart: observed => {
+      printInfo(pc.cyan(`Installing ${observed.agent.displayName}...`))
+    },
+    outputMode: context.outputMode,
+    timeoutMs: context.timeoutMs,
+  })
+
+  const handleSignal = (signal: NodeJS.Signals): void => {
+    cancellationSignal ??= signal
+    void dependencies.cancelOperations()
   }
+  const sigintHandler = (): void => handleSignal('SIGINT')
+  const sigtermHandler = (): void => handleSignal('SIGTERM')
+  process.once('SIGINT', sigintHandler)
+  process.once('SIGTERM', sigtermHandler)
 
-  if (!resolved) {
+  try {
+    const outcome = await service.execute({ agentName, args, installPolicy })
+    return presentExecutionOutcome(outcome, {
+      agentName,
+      args,
+      cancellationSignal,
+      installPolicy,
+      interactive,
+    })
+  } finally {
+    process.off('SIGINT', sigintHandler)
+    process.off('SIGTERM', sigtermHandler)
+    service.dispose()
+  }
+}
+
+interface ExecutionPresentationContext {
+  readonly agentName: string
+  readonly args: string[]
+  readonly cancellationSignal?: NodeJS.Signals
+  readonly installPolicy: ExecInstallPolicy | 'prompt'
+  readonly interactive: boolean
+}
+
+function presentExecutionOutcome(outcome: AgentExecutionOutcome, context: ExecutionPresentationContext): number {
+  if (outcome.kind === 'not-found') {
     emitExecPreflightError({
-      agent: {
-        name: agentName,
-      },
+      agent: { name: context.agentName },
       errorCode: 'AGENT_NOT_FOUND',
-      errorMessage: `Unknown agent: ${agentName}`,
-      execution: {
-        args,
-        installPolicy: options.install ?? 'prompt',
-        installed: false,
-        interactive: false,
-        launched: false,
-      },
+      errorMessage: `Unknown agent: ${context.agentName}`,
+      execution: executionData(context, false),
     })
     return getExitCodeForError('AGENT_NOT_FOUND')
   }
 
-  const { agent, inspection } = resolved
-  const interactive = options.nonInteractive ? false : getCliContext().interactive
-  const assumeYes = options.assumeYes ?? isAssumeYesEnabled()
-  const dryRun = options.dryRun ?? isDryRunEnabled()
-  const installPolicy = options.install ?? 'prompt'
-
-  if (!inspection.inPath) {
-    if (installPolicy === 'never') {
-      emitExecPreflightError({
-        agent: {
-          binaryName: agent.binaryName,
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        errorCode: 'AGENT_NOT_INSTALLED',
-        errorMessage: `${agent.displayName} is not installed.`,
-        execution: {
-          args,
-          installGuidance: createExecInstallGuidance(agent, inspection.methods, args),
-          installPolicy,
-          installed: false,
-          interactive,
-          launched: false,
-        },
-      })
-      return getExitCodeForError('AGENT_NOT_INSTALLED')
-    }
-
-    if (installPolicy === 'if-missing' || installPolicy === 'always') {
-      if (dryRun) {
-        writeDirectOutput(pc.cyan(`Dry run: would install ${agent.displayName}.`))
-      } else {
-        printInfo(pc.cyan(`Installing ${agent.displayName}...`))
-      }
-      const installResult = await runInstallForRunWithTimeout(agent, dryRun)
-      if (installResult === 'timeout') return getExitCodeForError('TIMEOUT')
-      if (!installResult.success) {
-        printError(pc.red(`Failed to install ${agent.displayName}.`))
-        return 1
-      }
-    } else if (!interactive) {
-      emitExecPreflightError({
-        agent: {
-          binaryName: agent.binaryName,
-          displayName: agent.displayName,
-          name: agent.name,
-        },
-        errorCode: 'INTERACTION_REQUIRED',
-        errorMessage: `${agent.displayName} is not installed and interactive installation is disabled.`,
-        execution: {
-          args,
-          installGuidance: createExecInstallGuidance(agent, inspection.methods, args),
-          installPolicy,
-          installed: false,
-          interactive,
-          launched: false,
-        },
-      })
-      return getExitCodeForError('INTERACTION_REQUIRED')
-    } else {
-      const response =
-        assumeYes || dryRun
-          ? { install: true }
-          : await prompts({
-              type: 'confirm',
-              name: 'install',
-              message: `${agent.displayName} is not installed. Would you like to install it?`,
-              initial: true,
-            })
-
-      if (!response.install) {
-        printWarn(pc.yellow('Installation cancelled.'))
-        return 1
-      }
-
-      if (dryRun) {
-        writeDirectOutput(pc.cyan(`Dry run: would install ${agent.displayName}.`))
-      } else {
-        printInfo(pc.cyan(`Installing ${agent.displayName}...`))
-      }
-      const installResult = await runInstallForRunWithTimeout(agent, dryRun)
-      if (installResult === 'timeout') return getExitCodeForError('TIMEOUT')
-      if (!installResult.success) {
-        printError(pc.red(`Failed to install ${agent.displayName}.`))
-        return 1
-      }
-    }
+  if (outcome.kind === 'observation-failed') {
+    return emitExecRuntimeError(context.agentName, outcome.error)
   }
 
-  if (dryRun) {
-    emitExecDryRun({
-      agent: {
-        binaryName: agent.binaryName,
-        displayName: agent.displayName,
-        name: agent.name,
-      },
+  const { observed } = outcome
+  const agent = observed.agent
+  if (outcome.kind === 'not-installed' || outcome.kind === 'interaction-required') {
+    const interactionRequired = outcome.kind === 'interaction-required'
+    emitExecPreflightError({
+      agent,
+      errorCode: interactionRequired ? 'INTERACTION_REQUIRED' : 'AGENT_NOT_INSTALLED',
+      errorMessage: interactionRequired
+        ? `${agent.displayName} is not installed and interactive installation is disabled.`
+        : `${agent.displayName} is not installed.`,
       execution: {
-        args,
-        installPolicy,
-        installed: true,
-        interactive,
-        launched: false,
+        ...executionData(context, false),
+        installGuidance: createExecInstallGuidance(agent, observed.methods, context.args),
       },
-      message: `Dry run: would run ${[agent.binaryName, ...args].join(' ')}`,
     })
-    return 0
+    return getExitCodeForError(interactionRequired ? 'INTERACTION_REQUIRED' : 'AGENT_NOT_INSTALLED')
   }
 
-  try {
-    return await runSpawnedAgentProcess(spawnWithQuantexStdio([agent.binaryName, ...args]), agent.displayName)
-  } catch (e) {
-    printError(pc.red(`Failed to launch ${agent.displayName}: ${e instanceof Error ? e.message : String(e)}`))
-    return 1
+  switch (outcome.kind) {
+    case 'install-declined':
+      printWarn(pc.yellow('Installation cancelled.'))
+      return 1
+    case 'install-failed':
+      printError(pc.red(`Failed to install ${agent.displayName}.`))
+      return getExitCodeForError('INSTALL_FAILED')
+    case 'dry-run':
+      if (outcome.wouldInstall) writeDirectOutput(pc.cyan(`Dry run: would install ${agent.displayName}.`))
+      emitExecDryRun({
+        agent,
+        execution: executionData(context, true),
+        message: `Dry run: would run ${outcome.argv.join(' ')}`,
+      })
+      return 0
+    case 'launch-failed':
+      printError(pc.red(`Failed to launch ${agent.displayName}: ${outcome.reason}`))
+      return 1
+    case 'cancelled':
+      printError(
+        pc.red(
+          context.cancellationSignal
+            ? `${agent.displayName} was cancelled by ${context.cancellationSignal}.`
+            : `${agent.displayName} was cancelled.`,
+        ),
+      )
+      return getExitCodeForError('CANCELLED')
+    case 'timed-out':
+      printError(
+        pc.red(
+          outcome.phase === 'install'
+            ? `Installing ${agent.displayName} timed out after ${outcome.timeoutMs}ms.`
+            : `${agent.displayName} timed out after ${outcome.timeoutMs}ms.`,
+        ),
+      )
+      return getExitCodeForError('TIMEOUT')
+    case 'exited':
+      return outcome.exitCode
   }
+}
+
+function executionData(context: ExecutionPresentationContext, installed: boolean): ExecPreflightData['execution'] {
+  return {
+    args: context.args,
+    installPolicy: context.installPolicy,
+    installed,
+    interactive: context.interactive,
+    launched: false,
+  }
+}
+
+function emitExecRuntimeError(agentName: string, error: RuntimeFailure): number {
+  const code = isCliErrorCode(error.code) ? error.code : 'INSTALL_FAILED'
+  const context = getCliContext()
+  if (context.outputMode === 'human') {
+    printError(pc.red(error.message))
+  } else {
+    emitCommandResult(
+      createErrorResult({
+        action: 'exec',
+        error: { code, details: error.details, message: error.message },
+        target: { kind: 'agent', name: agentName },
+      }),
+      () => {},
+    )
+  }
+  return getExitCodeForError(code)
+}
+
+function isCliErrorCode(value: string | undefined): value is CliErrorCode {
+  return value !== undefined && (cliErrorCodes as readonly string[]).includes(value)
 }
 
 function createExecInstallGuidance(
@@ -212,7 +242,7 @@ function createExecInstallGuidance(
     name: string
     packages?: AgentDefinition['packages']
   },
-  methods: InstallMethod[],
+  methods: readonly InstallMethod[],
   args: string[],
 ): ExecPreflightData['execution']['installGuidance'] {
   const installMethods = methods
@@ -230,27 +260,6 @@ function createExecInstallGuidance(
     suggestedEnsureCommand: `quantex ensure ${agent.name}`,
     suggestedExecCommand: ['quantex', 'exec', agent.name, '--install', 'if-missing', '--', ...args].join(' '),
   }
-}
-
-function emitStateReadError(agentName: string, error: StateFileError): void {
-  const stateError = createStateReadError(error, getStateFilePath(), {
-    kind: 'agent',
-    name: agentName,
-  })
-  const context = getCliContext()
-
-  if (context.outputMode === 'human') {
-    printError(pc.red(stateError.error.message))
-    return
-  }
-
-  emitCommandResult(
-    createErrorResult<ExecPreflightData>({
-      action: 'exec',
-      ...stateError,
-    }),
-    () => {},
-  )
 }
 
 function emitExecPreflightError(input: {
@@ -273,19 +282,13 @@ function emitExecPreflightError(input: {
   emitCommandResult(
     createErrorResult<ExecPreflightData>({
       action: 'exec',
-      data: {
-        agent: input.agent,
-        execution: input.execution,
-      },
+      data: { agent: input.agent, execution: input.execution },
       error: {
         code: input.errorCode,
         details: input.execution.installGuidance,
         message: input.errorMessage,
       },
-      target: {
-        kind: 'agent',
-        name: input.agent.name,
-      },
+      target: { kind: 'agent', name: input.agent.name },
     }),
     () => {},
   )
@@ -305,177 +308,9 @@ function emitExecDryRun(input: {
   emitCommandResult(
     createSuccessResult<ExecPreflightData>({
       action: 'exec',
-      data: {
-        agent: input.agent,
-        execution: input.execution,
-      },
-      target: {
-        kind: 'agent',
-        name: input.agent.name,
-      },
+      data: { agent: input.agent, execution: input.execution },
+      target: { kind: 'agent', name: input.agent.name },
     }),
     () => {},
   )
-}
-
-type InstallForRunResult = Awaited<ReturnType<typeof tryInstallForRun>>
-
-async function runInstallForRunWithTimeout(
-  agent: { displayName: string } & Parameters<typeof installAgent>[0],
-  dryRun: boolean = isDryRunEnabled(),
-): Promise<InstallForRunResult | 'timeout'> {
-  const { timeoutMs } = getCliContext()
-  if (timeoutMs === undefined) return tryInstallForRun(agent, dryRun)
-
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-  const installPromise = tryInstallForRun(agent, dryRun)
-
-  try {
-    const timeoutPromise = new Promise<'timeout'>(resolve => {
-      timeoutId = setTimeout(() => {
-        resolve('timeout')
-      }, timeoutMs)
-    })
-
-    const result = await Promise.race([installPromise, timeoutPromise])
-    if (result === 'timeout') {
-      const lateResult = await waitForLateInstallResult(installPromise, timeoutMs)
-      if (lateResult?.success) {
-        clearCliContextCancelled()
-        return lateResult
-      }
-      if (lateResult) return lateResult
-
-      await cancelCliContextOperations()
-      printError(pc.red(`Installing ${agent.displayName} timed out after ${timeoutMs}ms.`))
-      return 'timeout'
-    }
-
-    if (getCliContext().cancelled && result.success) clearCliContextCancelled()
-    return result
-  } finally {
-    if (timeoutId) clearTimeout(timeoutId)
-  }
-}
-
-async function waitForLateInstallResult(
-  installPromise: Promise<InstallForRunResult>,
-  timeoutMs: number,
-): Promise<InstallForRunResult | undefined> {
-  const graceMs = Math.min(timeoutMs, 250)
-  return await Promise.race([
-    installPromise,
-    new Promise<undefined>(resolve => {
-      setTimeout(() => resolve(undefined), graceMs)
-    }),
-  ])
-}
-
-async function tryInstallForRun(
-  agent: { displayName: string } & Parameters<typeof installAgent>[0],
-  dryRun: boolean = isDryRunEnabled(),
-): Promise<Awaited<ReturnType<typeof installAgent>>> {
-  if (dryRun) return { success: true }
-
-  try {
-    return await installAgent(agent)
-  } catch (error) {
-    if (isResourceLockError(error)) {
-      printError(pc.red(error.message))
-      return { success: false }
-    }
-
-    printError(
-      pc.red(`Failed to install ${agent.displayName}: ${error instanceof Error ? error.message : String(error)}`),
-    )
-    return { success: false }
-  }
-}
-
-async function runSpawnedAgentProcess(handle: SpawnHandle, displayName: string): Promise<number> {
-  const { timeoutMs } = getCliContext()
-  let cancellationCodePromise: Promise<number> | undefined
-  let cleanup: (() => void) | undefined
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-
-  try {
-    const signalPromise = new Promise<number>(resolve => {
-      const handleSignal = (signal: NodeJS.Signals): void => {
-        cancellationCodePromise ??= (async () => {
-          await cancelCliContextOperations()
-          printError(pc.red(`${displayName} was cancelled by ${signal}.`))
-          return getExitCodeForError('CANCELLED')
-        })()
-        void cancellationCodePromise.then(resolve)
-      }
-
-      const sigintHandler = (): void => handleSignal('SIGINT')
-      const sigtermHandler = (): void => handleSignal('SIGTERM')
-      process.once('SIGINT', sigintHandler)
-      process.once('SIGTERM', sigtermHandler)
-      cleanup = (): void => {
-        process.off('SIGINT', sigintHandler)
-        process.off('SIGTERM', sigtermHandler)
-      }
-    })
-
-    const spawnPromise = waitForSpawnedAgentCommand(handle, () => cancellationCodePromise)
-
-    if (timeoutMs === undefined) {
-      return await Promise.race([spawnPromise, signalPromise])
-    }
-
-    const timeoutPromise = new Promise<'timeout'>(resolve => {
-      timeoutId = setTimeout(() => {
-        resolve('timeout')
-      }, timeoutMs)
-    })
-
-    const result = await Promise.race([spawnPromise, signalPromise, timeoutPromise])
-    if (result === 'timeout') {
-      const lateCode = await waitForLateSpawnResult(spawnPromise, timeoutMs)
-      if (lateCode !== undefined) {
-        clearCliContextCancelled()
-        return lateCode
-      }
-
-      cancellationCodePromise ??= (async () => {
-        await cancelCliContextOperations()
-        printError(pc.red(`${displayName} timed out after ${timeoutMs}ms.`))
-        return getExitCodeForError('TIMEOUT')
-      })()
-      return await cancellationCodePromise
-    }
-
-    return result
-  } finally {
-    if (timeoutId) clearTimeout(timeoutId)
-    cleanup?.()
-  }
-}
-
-async function waitForLateSpawnResult(spawnPromise: Promise<number>, timeoutMs: number): Promise<number | undefined> {
-  const graceMs = Math.min(timeoutMs, 250)
-  return await Promise.race([
-    spawnPromise,
-    new Promise<undefined>(resolve => {
-      setTimeout(() => resolve(undefined), graceMs)
-    }),
-  ])
-}
-
-async function waitForSpawnedAgentCommand(
-  handle: SpawnHandle,
-  getCancellationCode: () => Promise<number> | undefined,
-): Promise<number> {
-  try {
-    const code = await waitForSpawnedCommand(handle)
-    const cancellationCode = getCancellationCode()
-    if (getCliContext().cancelled && cancellationCode) return cancellationCode
-    return code
-  } catch (error) {
-    const cancellationCode = getCancellationCode()
-    if (getCliContext().cancelled && cancellationCode) return cancellationCode
-    throw error
-  }
 }

--- a/src/commands/shortcut.ts
+++ b/src/commands/shortcut.ts
@@ -1,0 +1,172 @@
+export interface ShortcutInvocation {
+  agentArgs: string[]
+  agentName: string
+  color?: string
+  dryRun?: boolean
+  error?: string
+  idempotencyKey?: string
+  logLevel?: string
+  noCache?: boolean
+  nonInteractive?: boolean
+  quiet?: boolean
+  refresh?: boolean
+  runId?: string
+  timeout?: string
+  yes?: boolean
+}
+
+export interface ResolveShortcutInvocationOptions {
+  readonly agentFriendly: boolean
+}
+
+export function resolveShortcutInvocation(
+  argv: string[],
+  knownCommandNames: Set<string>,
+  options: ResolveShortcutInvocationOptions,
+): ShortcutInvocation | undefined {
+  let color: string | undefined
+  let dryRun = false
+  let index = 0
+  let idempotencyKey: string | undefined
+  let jsonOutputRequested = false
+  let logLevel: string | undefined
+  let noCache = false
+  let nonInteractive = false
+  let outputMode: string | undefined
+  let quiet = false
+  let refresh = false
+  let runId: string | undefined
+  let timeout: string | undefined
+  let yes = false
+
+  while (index < argv.length) {
+    const arg = argv[index]
+
+    if (arg === '--json') {
+      jsonOutputRequested = true
+      index += 1
+      continue
+    }
+
+    if (arg === '--output') {
+      const value = argv[index + 1]
+      if (!value) return missingValue(arg)
+      outputMode = value
+      index += 2
+      continue
+    }
+
+    if (arg === '--non-interactive') {
+      nonInteractive = true
+      index += 1
+      continue
+    }
+
+    if (arg === '--yes') {
+      yes = true
+      index += 1
+      continue
+    }
+
+    if (arg === '--quiet') {
+      quiet = true
+      index += 1
+      continue
+    }
+
+    if (arg === '--color') {
+      const value = argv[index + 1]
+      if (!value) return missingValue(arg)
+      color = value
+      index += 2
+      continue
+    }
+
+    if (arg === '--log-level') {
+      const value = argv[index + 1]
+      if (!value) return missingValue(arg)
+      logLevel = value
+      index += 2
+      continue
+    }
+
+    if (arg === '--dry-run') {
+      dryRun = true
+      index += 1
+      continue
+    }
+
+    if (arg === '--refresh') {
+      refresh = true
+      index += 1
+      continue
+    }
+
+    if (arg === '--no-cache') {
+      noCache = true
+      index += 1
+      continue
+    }
+
+    if (arg === '--idempotency-key') {
+      const value = argv[index + 1]
+      if (!value) return missingValue(arg)
+      idempotencyKey = value
+      index += 2
+      continue
+    }
+
+    if (arg === '--run-id') {
+      const value = argv[index + 1]
+      if (!value) return missingValue(arg)
+      runId = value
+      index += 2
+      continue
+    }
+
+    if (arg === '--timeout') {
+      const value = argv[index + 1]
+      if (!value) return missingValue(arg)
+      timeout = value
+      index += 2
+      continue
+    }
+
+    if (arg.startsWith('-') || knownCommandNames.has(arg)) return undefined
+
+    if (
+      jsonOutputRequested ||
+      outputMode === 'json' ||
+      outputMode === 'ndjson' ||
+      (options.agentFriendly && outputMode !== 'human')
+    ) {
+      return {
+        agentArgs: [],
+        agentName: '',
+        error: 'Structured output is not supported for shortcut agent execution yet. Use a management command instead.',
+      }
+    }
+
+    return {
+      agentArgs: argv.slice(index + 1),
+      agentName: arg,
+      color,
+      dryRun,
+      idempotencyKey,
+      logLevel,
+      noCache,
+      nonInteractive,
+      quiet,
+      refresh,
+      runId,
+      timeout,
+      yes,
+    }
+  }
+
+  return undefined
+}
+
+function missingValue(option: string): ShortcutInvocation {
+  return { agentArgs: [], agentName: '', error: `${option} requires a value` }
+}

--- a/src/lifecycle/agent-execution.ts
+++ b/src/lifecycle/agent-execution.ts
@@ -1,0 +1,29 @@
+import type { AgentExecutableObservation } from './agent-observation'
+import type { LifecycleObservation } from './model'
+
+export type AgentExecutionInstallPolicy = 'always' | 'if-missing' | 'never' | 'prompt'
+
+export interface AgentExecutionPreflightInput {
+  readonly dryRun: boolean
+  readonly executable: AgentExecutableObservation
+  readonly installPolicy: AgentExecutionInstallPolicy
+  readonly interactive: boolean
+  readonly observation: LifecycleObservation
+}
+
+export type AgentExecutionPreflightPlan =
+  | { readonly decision: 'dry-run' | 'install-and-launch' | 'launch' | 'prompt-install' }
+  | {
+      readonly decision: 'reject'
+      readonly errorCode: 'AGENT_NOT_INSTALLED' | 'INTERACTION_REQUIRED'
+    }
+
+export function planAgentExecutionPreflight(input: AgentExecutionPreflightInput): AgentExecutionPreflightPlan {
+  if (input.executable.present) return { decision: input.dryRun ? 'dry-run' : 'launch' }
+  if (input.installPolicy === 'never') return { decision: 'reject', errorCode: 'AGENT_NOT_INSTALLED' }
+  if (input.installPolicy === 'prompt' && !input.interactive) {
+    return { decision: 'reject', errorCode: 'INTERACTION_REQUIRED' }
+  }
+  if (input.dryRun) return { decision: 'dry-run' }
+  return { decision: input.installPolicy === 'prompt' ? 'prompt-install' : 'install-and-launch' }
+}

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -4,6 +4,12 @@ export {
   reconcileAgentInstallation,
   type ReconcileAgentInstallationInput,
 } from './agent-installation'
+export {
+  type AgentExecutionInstallPolicy,
+  type AgentExecutionPreflightInput,
+  type AgentExecutionPreflightPlan,
+  planAgentExecutionPreflight,
+} from './agent-execution'
 export type {
   LifecycleDrift,
   LifecycleEffect,

--- a/src/runtime/agent-process.ts
+++ b/src/runtime/agent-process.ts
@@ -1,0 +1,151 @@
+import type { ProcessPort, ProcessRequest, ProcessResult, RuntimeOutcome } from './ports'
+import {
+  readProcessOutput,
+  spawnCommand,
+  type SpawnedProcessHandle,
+  terminateProcessTree,
+} from '../utils/child-process'
+
+interface AgentProcessSpawnOptions {
+  readonly cwd?: string
+  readonly detached: boolean
+  readonly env?: NodeJS.ProcessEnv
+  readonly stdio?: ProcessRequest['stdio']
+}
+
+export interface AgentProcessPortDependencies {
+  readonly platform: NodeJS.Platform
+  readonly spawn: (argv: readonly string[], options: AgentProcessSpawnOptions) => SpawnedProcessHandle
+  readonly terminate: (handle: SpawnedProcessHandle) => Promise<void>
+  readonly writeStderr: (value: string) => void
+}
+
+const defaultDependencies: AgentProcessPortDependencies = {
+  platform: process.platform,
+  spawn: (argv, options) =>
+    spawnCommand(argv, {
+      ...options,
+      stdio: options.stdio ? [...options.stdio] : undefined,
+    }),
+  terminate: terminateProcessTree,
+  writeStderr: value => {
+    process.stderr.write(value)
+  },
+}
+
+type ProcessRaceResult =
+  | { readonly kind: 'cancelled' }
+  | { readonly kind: 'completed'; readonly result: Awaited<ReturnType<typeof readProcessOutput>> }
+  | { readonly kind: 'timed-out' }
+
+export function createAgentProcessPort(dependencies: AgentProcessPortDependencies = defaultDependencies): ProcessPort {
+  return {
+    async run(request): Promise<RuntimeOutcome<ProcessResult>> {
+      if (request.signal.aborted) return cancelled(request.signal)
+
+      let handle: SpawnedProcessHandle
+      try {
+        handle = dependencies.spawn(request.argv, {
+          ...(request.cwd ? { cwd: request.cwd } : {}),
+          detached: dependencies.platform !== 'win32',
+          ...(request.env ? { env: { ...process.env, ...request.env } } : {}),
+          stdio: request.stdio,
+        })
+      } catch (error) {
+        return failure('failed', errorReason(error, 'Failed to launch agent process.'))
+      }
+
+      const completed = readProcessOutput(handle)
+      let timeout: ReturnType<typeof setTimeout> | undefined
+      let resolveCancelled!: () => void
+      const cancellation = new Promise<ProcessRaceResult>(resolve => {
+        resolveCancelled = () => resolve({ kind: 'cancelled' })
+        request.signal.addEventListener('abort', resolveCancelled, { once: true })
+        if (request.signal.aborted) resolveCancelled()
+      })
+      const completion = completed.then(result => ({ kind: 'completed' as const, result }))
+      const timeoutResult =
+        request.timeoutMs === undefined
+          ? undefined
+          : new Promise<ProcessRaceResult>(resolve => {
+              timeout = setTimeout(() => resolve({ kind: 'timed-out' }), request.timeoutMs)
+            })
+
+      try {
+        const result = await Promise.race(
+          timeoutResult ? [completion, cancellation, timeoutResult] : [completion, cancellation],
+        )
+        if (result.kind === 'completed') return complete(result.result, request, dependencies)
+
+        if (result.kind === 'cancelled') {
+          await dependencies.terminate(handle)
+          await completed.catch(() => undefined)
+          return cancelled(request.signal)
+        }
+
+        const lateResult = await settleWithin(completion, timeoutGraceMs(request.timeoutMs!))
+        if (lateResult) return complete(lateResult.result, request, dependencies)
+
+        await dependencies.terminate(handle)
+        await completed.catch(() => undefined)
+        return failure('timed-out', `Agent process timed out after ${request.timeoutMs}ms.`)
+      } finally {
+        if (timeout) clearTimeout(timeout)
+        request.signal.removeEventListener('abort', resolveCancelled)
+      }
+    },
+  }
+}
+
+function complete(
+  result: Awaited<ReturnType<typeof readProcessOutput>>,
+  request: ProcessRequest,
+  dependencies: AgentProcessPortDependencies,
+): RuntimeOutcome<ProcessResult> {
+  if (request.stdio?.[1] === 'pipe' && result.stdout) dependencies.writeStderr(result.stdout)
+  if (request.stdio?.[2] === 'pipe' && result.stderr) dependencies.writeStderr(result.stderr)
+  const encoder = new TextEncoder()
+  return {
+    kind: 'success',
+    value: {
+      exitCode: result.exitCode,
+      ...(result.stderr ? { stderr: encoder.encode(result.stderr) } : {}),
+      ...(result.stdout ? { stdout: encoder.encode(result.stdout) } : {}),
+    },
+  }
+}
+
+function cancelled(signal: AbortSignal): RuntimeOutcome<never> {
+  return failure('cancelled', abortReason(signal) ?? 'Agent process was cancelled.')
+}
+
+function failure(kind: 'cancelled' | 'failed' | 'timed-out', message: string): RuntimeOutcome<never> {
+  return { error: { kind, message }, kind: 'failure' }
+}
+
+function abortReason(signal: AbortSignal): string | undefined {
+  if (signal.reason === undefined) return undefined
+  return signal.reason instanceof Error ? signal.reason.message : String(signal.reason)
+}
+
+function errorReason(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message.trim() ? error.message : fallback
+}
+
+function timeoutGraceMs(timeoutMs: number): number {
+  return Math.max(1, Math.min(timeoutMs, 250))
+}
+
+async function settleWithin<T>(promise: Promise<T>, durationMs: number): Promise<T | undefined> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>(resolve => {
+        timeout = setTimeout(() => resolve(undefined), durationMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,2 +1,4 @@
+export * from './agent-process'
+export * from './cli-operation-context'
 export * from './invocation-context'
 export * from './ports'

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,4 +1,17 @@
 export { inspectRegisteredAgents, resolveAgent, resolveAgentInspection } from './agents'
 export type { ResolvedAgentInspection } from './agents'
+export {
+  type AgentExecutionOutcome,
+  type ExecuteAgentLifecycleInput,
+  executeAgentLifecycle,
+  type LifecycleExecutionObservedAgent,
+  type LifecycleExecutionServicePorts,
+} from './lifecycle-execution'
+export {
+  createProductionLifecycleExecutionService,
+  type ProductionLifecycleExecutionDependencies,
+  type ProductionLifecycleExecutionOptions,
+  type ProductionLifecycleExecutionService,
+} from './lifecycle-execution-production'
 export { getSingleAgentUpdateStatus, planAgentUpdates } from './update'
 export type { ManagedUpdateBucket, PendingAgentUpdate, PlannedAgentUpdates, SingleAgentUpdateStatus } from './update'

--- a/src/services/lifecycle-execution-production.ts
+++ b/src/services/lifecycle-execution-production.ts
@@ -1,0 +1,196 @@
+import type { LifecycleOutcome } from '../lifecycle'
+import type { ProcessPort, RuntimeFailure, RuntimeOutcome } from '../runtime'
+import type { ResolvedAgentInspection } from './agents'
+import type { LifecycleObservationService, LifecycleObservationServiceOptions } from './lifecycle-observations'
+import { cancelCliContextOperations } from '../cli-context'
+import { reconcileAgentInstallation } from '../lifecycle'
+import { createAgentProcessPort, createCliOperationContext } from '../runtime'
+import { getStateFilePath, StateFileError } from '../state'
+import { isProcessInterruptionError } from '../utils/child-process'
+import { resolveAgentInspection } from './agents'
+import {
+  type AgentExecutionOutcome,
+  type ExecuteAgentLifecycleInput,
+  executeAgentLifecycle,
+  type LifecycleExecutionObservedAgent,
+} from './lifecycle-execution'
+import { createProductionLifecycleObservationService } from './lifecycle-observations'
+
+export interface ProductionLifecycleExecutionOptions {
+  readonly confirmInstall: (observed: LifecycleExecutionObservedAgent) => Promise<boolean>
+  readonly dryRun: boolean
+  readonly interactive: boolean
+  readonly outputMode: 'human' | 'json' | 'ndjson'
+  readonly onInstallStart?: (observed: LifecycleExecutionObservedAgent) => Promise<void> | void
+  readonly timeoutMs?: number
+}
+
+interface ProductionOperationContext {
+  readonly context: ReturnType<typeof createCliOperationContext>['context']
+  dispose(): void
+}
+
+export interface ProductionLifecycleExecutionDependencies {
+  readonly cancelOperations: typeof cancelCliContextOperations
+  readonly createObservationService: (
+    context: ProductionOperationContext['context'],
+    options: LifecycleObservationServiceOptions,
+  ) => LifecycleObservationService
+  readonly createOperationContext: () => ProductionOperationContext
+  readonly createProcessPort: () => ProcessPort
+  readonly reconcileAgentInstallation: typeof reconcileAgentInstallation
+  readonly resolveAgentInspection: (agentName: string) => Promise<ResolvedAgentInspection | undefined>
+}
+
+export interface ProductionLifecycleExecutionService {
+  dispose(): void
+  execute(input: ExecuteAgentLifecycleInput): Promise<AgentExecutionOutcome>
+}
+
+const defaultDependencies: ProductionLifecycleExecutionDependencies = {
+  cancelOperations: cancelCliContextOperations,
+  createObservationService: createProductionLifecycleObservationService,
+  createOperationContext: createCliOperationContext,
+  createProcessPort: createAgentProcessPort,
+  reconcileAgentInstallation,
+  resolveAgentInspection,
+}
+
+export function createProductionLifecycleExecutionService(
+  options: ProductionLifecycleExecutionOptions,
+  dependencies: ProductionLifecycleExecutionDependencies = defaultDependencies,
+): ProductionLifecycleExecutionService {
+  const operation = dependencies.createOperationContext()
+  const observationService = dependencies.createObservationService(operation.context, {
+    resolveLatestVersion: false,
+  })
+  const process = dependencies.createProcessPort()
+
+  return {
+    dispose: operation.dispose,
+    execute: input =>
+      executeAgentLifecycle(input, {
+        confirmInstall: options.confirmInstall,
+        dryRun: options.dryRun,
+        install: agentName => installAgent(agentName, options.timeoutMs, dependencies),
+        interactive: options.interactive,
+        observe: agentName => observeAgent(agentName, observationService),
+        onInstallStart: options.onInstallStart,
+        outputMode: options.outputMode,
+        process,
+        signal: operation.context.signal,
+        timeoutMs: options.timeoutMs,
+      }),
+  }
+}
+
+async function observeAgent(
+  agentName: string,
+  service: LifecycleObservationService,
+): Promise<RuntimeOutcome<LifecycleExecutionObservedAgent | undefined>> {
+  try {
+    const resolved = await service.resolveAgentObservation(agentName)
+    return {
+      kind: 'success',
+      value: resolved
+        ? {
+            agent: resolved.agent,
+            executable: resolved.pathExecutable,
+            methods: resolved.methods,
+            observation: resolved.observation,
+          }
+        : undefined,
+    }
+  } catch (error) {
+    return { error: observationFailure(error), kind: 'failure' }
+  }
+}
+
+async function installAgent(
+  agentName: string,
+  timeoutMs: number | undefined,
+  dependencies: ProductionLifecycleExecutionDependencies,
+): Promise<LifecycleOutcome<void>> {
+  try {
+    const resolved = await dependencies.resolveAgentInspection(agentName)
+    if (!resolved) return { kind: 'indeterminate', reason: `Unknown agent: ${agentName}` }
+    if (resolved.inspection.inPath) return { kind: 'success', value: undefined }
+
+    const reconciliation = dependencies.reconcileAgentInstallation({
+      agent: resolved.agent,
+      inspection: resolved.inspection,
+      operation: 'install',
+      route: 'install',
+    })
+    const outcome = await withInstallTimeout(reconciliation, timeoutMs, dependencies.cancelOperations)
+    if (!outcome) return { kind: 'timed-out', timeoutMs: timeoutMs! }
+    if (outcome.kind === 'success') return { kind: 'success', value: undefined }
+    return outcome
+  } catch (error) {
+    if (isProcessInterruptionError(error)) {
+      return error.kind === 'timed-out'
+        ? { kind: 'timed-out', timeoutMs: timeoutMs ?? 0 }
+        : { kind: 'cancelled', reason: error.message }
+    }
+    return { kind: 'failed', reason: errorReason(error, 'Failed to install agent.'), retryable: false }
+  }
+}
+
+async function withInstallTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number | undefined,
+  cancelOperations: typeof cancelCliContextOperations,
+): Promise<T | undefined> {
+  if (timeoutMs === undefined) return operation
+
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    const result = await Promise.race([
+      operation.then(value => ({ kind: 'completed' as const, value })),
+      new Promise<{ readonly kind: 'timed-out' }>(resolve => {
+        timeout = setTimeout(() => resolve({ kind: 'timed-out' }), timeoutMs)
+      }),
+    ])
+    if (result.kind === 'completed') return result.value
+
+    const late = await settleWithin(operation, Math.max(1, Math.min(timeoutMs, 250)))
+    if (late !== undefined) return late
+    await cancelOperations()
+    return undefined
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+function observationFailure(error: unknown): RuntimeFailure {
+  if (error instanceof StateFileError) {
+    return {
+      code: 'STATE_READ_ERROR',
+      details: { stateFilePath: getStateFilePath() },
+      kind: 'invalid-data',
+      message: error.message,
+    }
+  }
+  if (isProcessInterruptionError(error)) {
+    return { kind: error.kind, message: error.message }
+  }
+  return { kind: 'failed', message: errorReason(error, 'Failed to observe agent execution state.') }
+}
+
+function errorReason(error: unknown, fallback: string): string {
+  return error instanceof Error && error.message.trim() ? error.message : fallback
+}
+
+async function settleWithin<T>(promise: Promise<T>, durationMs: number): Promise<T | undefined> {
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<undefined>(resolve => {
+        timeout = setTimeout(() => resolve(undefined), durationMs)
+      }),
+    ])
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}

--- a/src/services/lifecycle-execution.ts
+++ b/src/services/lifecycle-execution.ts
@@ -1,0 +1,189 @@
+import type { InstallMethod } from '../agents'
+import type { OutputMode, ProcessPort, RuntimeFailure, RuntimeOutcome } from '../runtime'
+import {
+  type AgentExecutableObservation,
+  type AgentExecutionInstallPolicy,
+  type LifecycleObservation,
+  type LifecycleOutcome,
+  planAgentExecutionPreflight,
+} from '../lifecycle'
+
+export interface LifecycleExecutionObservedAgent {
+  readonly agent: {
+    readonly binaryName: string
+    readonly displayName: string
+    readonly name: string
+  }
+  readonly executable: AgentExecutableObservation
+  readonly methods: readonly InstallMethod[]
+  readonly observation: LifecycleObservation
+}
+
+export interface LifecycleExecutionServicePorts {
+  readonly confirmInstall: (observed: LifecycleExecutionObservedAgent) => Promise<boolean>
+  readonly dryRun: boolean
+  readonly install: (agentName: string) => Promise<LifecycleOutcome<void>>
+  readonly interactive: boolean
+  readonly observe: (agentName: string) => Promise<RuntimeOutcome<LifecycleExecutionObservedAgent | undefined>>
+  readonly onInstallStart?: (observed: LifecycleExecutionObservedAgent) => Promise<void> | void
+  readonly outputMode: OutputMode
+  readonly process: ProcessPort
+  readonly signal: AbortSignal
+  readonly timeoutMs?: number
+}
+
+export interface ExecuteAgentLifecycleInput {
+  readonly agentName: string
+  readonly args: readonly string[]
+  readonly installPolicy: AgentExecutionInstallPolicy
+}
+
+type ObservedExecutionOutcome = {
+  readonly observed: LifecycleExecutionObservedAgent
+}
+
+export type AgentExecutionOutcome =
+  | { readonly kind: 'not-found' }
+  | ({ readonly kind: 'not-installed' } & ObservedExecutionOutcome)
+  | ({ readonly kind: 'interaction-required' } & ObservedExecutionOutcome)
+  | ({ readonly kind: 'install-declined' } & ObservedExecutionOutcome)
+  | ({ readonly kind: 'install-failed'; readonly reason: string } & ObservedExecutionOutcome)
+  | ({
+      readonly argv: readonly string[]
+      readonly kind: 'dry-run'
+      readonly wouldInstall: boolean
+    } & ObservedExecutionOutcome)
+  | { readonly error: RuntimeFailure; readonly kind: 'observation-failed' }
+  | ({ readonly kind: 'launch-failed'; readonly reason: string } & ObservedExecutionOutcome)
+  | ({
+      readonly kind: 'cancelled'
+      readonly phase: 'install' | 'launch'
+      readonly reason?: string
+    } & ObservedExecutionOutcome)
+  | ({
+      readonly kind: 'timed-out'
+      readonly phase: 'install' | 'launch'
+      readonly reason?: string
+      readonly timeoutMs: number
+    } & ObservedExecutionOutcome)
+  | ({
+      readonly exitCode: number
+      readonly kind: 'exited'
+      readonly stderr?: Uint8Array
+      readonly stdout?: Uint8Array
+    } & ObservedExecutionOutcome)
+
+export async function executeAgentLifecycle(
+  input: ExecuteAgentLifecycleInput,
+  ports: LifecycleExecutionServicePorts,
+): Promise<AgentExecutionOutcome> {
+  const initial = await ports.observe(input.agentName)
+  if (initial.kind === 'failure') return { error: initial.error, kind: 'observation-failed' }
+  if (!initial.value) return { kind: 'not-found' }
+
+  let observed = initial.value
+  const planned = planAgentExecutionPreflight({
+    dryRun: ports.dryRun,
+    executable: observed.executable,
+    installPolicy: input.installPolicy,
+    interactive: ports.interactive,
+    observation: observed.observation,
+  })
+
+  if (planned.decision === 'reject') {
+    return planned.errorCode === 'AGENT_NOT_INSTALLED'
+      ? { kind: 'not-installed', observed }
+      : { kind: 'interaction-required', observed }
+  }
+
+  const argv = [observed.agent.binaryName, ...input.args]
+  if (planned.decision === 'dry-run') {
+    return { argv, kind: 'dry-run', observed, wouldInstall: !observed.executable.present }
+  }
+
+  if (planned.decision === 'prompt-install' && !(await ports.confirmInstall(observed))) {
+    return { kind: 'install-declined', observed }
+  }
+
+  if (planned.decision === 'install-and-launch' || planned.decision === 'prompt-install') {
+    await ports.onInstallStart?.(observed)
+    const installed = await ports.install(observed.agent.name)
+    const installationFailure = mapInstallationFailure(installed, observed)
+    if (installationFailure) return installationFailure
+
+    const refreshed = await ports.observe(input.agentName)
+    if (refreshed.kind === 'failure') return { error: refreshed.error, kind: 'observation-failed' }
+    if (!refreshed.value) return { kind: 'install-failed', observed, reason: 'agent-missing-after-install' }
+    observed = refreshed.value
+    if (!observed.executable.present) {
+      return { kind: 'install-failed', observed, reason: 'executable-absent-after-install' }
+    }
+  }
+
+  const processOutcome = await ports.process.run({
+    argv,
+    signal: ports.signal,
+    stdio: ports.outputMode === 'human' ? ['inherit', 'inherit', 'inherit'] : ['ignore', 'pipe', 'pipe'],
+    timeoutMs: ports.timeoutMs,
+  })
+  return mapProcessOutcome(processOutcome, observed, ports.timeoutMs)
+}
+
+function mapInstallationFailure(
+  outcome: LifecycleOutcome<void>,
+  observed: LifecycleExecutionObservedAgent,
+): AgentExecutionOutcome | undefined {
+  switch (outcome.kind) {
+    case 'success':
+      return undefined
+    case 'cancelled':
+      return { kind: 'cancelled', observed, phase: 'install', reason: outcome.reason }
+    case 'timed-out':
+      return { kind: 'timed-out', observed, phase: 'install', timeoutMs: outcome.timeoutMs }
+    case 'failed':
+    case 'indeterminate':
+      return { kind: 'install-failed', observed, reason: outcome.reason }
+    case 'unsupported':
+      return {
+        kind: 'install-failed',
+        observed,
+        reason: outcome.reason ?? `Missing installation capability: ${outcome.capability}`,
+      }
+  }
+}
+
+function mapProcessOutcome(
+  outcome: RuntimeOutcome<{
+    readonly exitCode: number | null
+    readonly stderr?: Uint8Array
+    readonly stdout?: Uint8Array
+    readonly terminationSignal?: string
+  }>,
+  observed: LifecycleExecutionObservedAgent,
+  timeoutMs: number | undefined,
+): AgentExecutionOutcome {
+  if (outcome.kind === 'failure') {
+    if (outcome.error.kind === 'cancelled') {
+      return { kind: 'cancelled', observed, phase: 'launch', reason: outcome.error.message }
+    }
+    if (outcome.error.kind === 'timed-out') {
+      return { kind: 'timed-out', observed, phase: 'launch', reason: outcome.error.message, timeoutMs: timeoutMs ?? 0 }
+    }
+    return { kind: 'launch-failed', observed, reason: outcome.error.message }
+  }
+
+  if (outcome.value.exitCode === null) {
+    const reason = outcome.value.terminationSignal
+      ? `Agent terminated by ${outcome.value.terminationSignal}.`
+      : 'Agent process exited without an exit code.'
+    return { kind: 'launch-failed', observed, reason }
+  }
+
+  return {
+    exitCode: outcome.value.exitCode,
+    kind: 'exited',
+    observed,
+    stderr: outcome.value.stderr,
+    stdout: outcome.value.stdout,
+  }
+}

--- a/src/services/lifecycle-observations.ts
+++ b/src/services/lifecycle-observations.ts
@@ -56,8 +56,13 @@ export interface LifecycleObservationService {
   resolveAgentObservation(agentName: string): Promise<ResolvedAgentObservation | undefined>
 }
 
+export interface LifecycleObservationServiceOptions {
+  readonly resolveLatestVersion?: boolean
+}
+
 export function createLifecycleObservationService(
   ports: LifecycleObservationServicePorts,
+  options: LifecycleObservationServiceOptions = {},
 ): LifecycleObservationService {
   async function observe(agent: AgentDefinition): Promise<ResolvedAgentObservation> {
     let installedStatePromise: Promise<InstalledAgentState | undefined> | undefined
@@ -79,7 +84,9 @@ export function createLifecycleObservationService(
       }),
     ])
     const [latestVersion, resolvedBinaryPath] = await Promise.all([
-      ports.getLatestVersion(agent, result.installedState, methods),
+      options.resolveLatestVersion === false
+        ? Promise.resolve(undefined)
+        : ports.getLatestVersion(agent, result.installedState, methods),
       ports.getResolvedBinaryPath(result.pathExecutable.path),
     ])
 
@@ -113,23 +120,28 @@ export function observeRegisteredAgents(): Promise<ResolvedAgentObservation[]> {
 
 export function createProductionLifecycleObservationService(
   context: ProviderOperationContext,
+  options: LifecycleObservationServiceOptions = {},
 ): LifecycleObservationService {
-  return createLifecycleObservationService({
-    clock: () => new Date().toISOString(),
-    getAllAgents: agentRegistry.getAllAgents,
-    getAgentByNameOrAlias: agentRegistry.getAgentByNameOrAlias,
-    getLatestVersion: (agent, installedState, methods) => resolveLatestVersion(agent, installedState, methods, context),
-    getOrderedInstallMethods,
-    getPlatform,
-    getResolvedBinaryPath: binaryPath => getResolvedBinaryPath(binaryPath, context),
-    inspectExecutable: (agent, installedState) => inspectExecutable(agent, installedState, context),
-    observeAgentLifecycle,
-    providerRegistry: firstPartyProviderRegistry,
-    readInstalledState: getInstalledAgentState,
-    readReceipt: getLifecycleReceipt,
-    signal: context.signal,
-    timeoutMs: context.timeoutMs,
-  })
+  return createLifecycleObservationService(
+    {
+      clock: () => new Date().toISOString(),
+      getAllAgents: agentRegistry.getAllAgents,
+      getAgentByNameOrAlias: agentRegistry.getAgentByNameOrAlias,
+      getLatestVersion: (agent, installedState, methods) =>
+        resolveLatestVersion(agent, installedState, methods, context),
+      getOrderedInstallMethods,
+      getPlatform,
+      getResolvedBinaryPath: binaryPath => getResolvedBinaryPath(binaryPath, context),
+      inspectExecutable: (agent, installedState) => inspectExecutable(agent, installedState, context),
+      observeAgentLifecycle,
+      providerRegistry: firstPartyProviderRegistry,
+      readInstalledState: getInstalledAgentState,
+      readReceipt: getLifecycleReceipt,
+      signal: context.signal,
+      timeoutMs: context.timeoutMs,
+    },
+    options,
+  )
 }
 
 async function withProductionObservationService<T>(

--- a/test/commands/run.test.ts
+++ b/test/commands/run.test.ts
@@ -1,62 +1,13 @@
-import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import * as agents from '../../src/agents'
-import { setCliContext, getCliContext } from '../../src/cli-context'
-import { runCommand } from '../../src/commands/run'
-import * as pm from '../../src/package-manager'
-import * as detect from '../../src/utils/detect'
+import type { AgentExecutionOutcome, LifecycleExecutionObservedAgent } from '../../src/services'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setCliContext } from '../../src/cli-context'
+import { runCommand, type RunCommandDependencies } from '../../src/commands/run'
 
 const mockPrompts = vi.fn()
 
 vi.mock('prompts', () => ({
-  default: (...args: any[]) => mockPrompts(...args),
+  default: (...args: unknown[]) => mockPrompts(...args),
 }))
-
-const agentSpy = vi.spyOn(agents, 'getAgentByNameOrAlias')
-const installSpy = vi.spyOn(pm, 'installAgent')
-const binaryInPathSpy = vi.spyOn(detect, 'isBinaryInPath')
-
-const mockSpawn = vi.fn()
-const mockFetch = vi.fn()
-let originalSpawn: typeof Bun.spawn
-const originalFetch = globalThis.fetch
-
-const testAgent = {
-  name: 'test-agent',
-  lookupAliases: ['ta'],
-  displayName: 'Test Agent',
-  homepage: 'https://example.com',
-  packages: { npm: 'test-pkg' },
-  binaryName: 'test-bin',
-  platforms: {
-    linux: [{ type: 'bun' as const }],
-    macos: [{ type: 'bun' as const }],
-    windows: [{ type: 'bun' as const }],
-  },
-}
-
-beforeEach(() => {
-  originalSpawn = Bun.spawn
-  Bun.spawn = mockSpawn as any
-  globalThis.fetch = mockFetch as any
-  agentSpy.mockClear()
-  installSpy.mockClear()
-  binaryInPathSpy.mockClear()
-  mockPrompts.mockClear()
-  mockSpawn.mockClear()
-  mockFetch.mockClear()
-  mockFetch.mockResolvedValue(new Response(JSON.stringify({ version: '1.0.0' }), { status: 200 }))
-})
-
-afterEach(() => {
-  Bun.spawn = originalSpawn
-  globalThis.fetch = originalFetch
-})
-
-afterAll(() => {
-  agentSpy.mockRestore()
-  installSpy.mockRestore()
-  binaryInPathSpy.mockRestore()
-})
 
 describe('runCommand', () => {
   let logSpy: ReturnType<typeof vi.spyOn>
@@ -65,386 +16,251 @@ describe('runCommand', () => {
   beforeEach(() => {
     logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true)
+    mockPrompts.mockReset()
   })
 
   afterEach(() => {
     logSpy.mockRestore()
     stdoutWriteSpy.mockRestore()
-    vi.useRealTimers()
   })
 
-  it('shows error for unknown agent', async () => {
-    agentSpy.mockReturnValue(undefined)
-    const code = await runCommand('unknown', [])
-    expect(code).toBe(3)
+  it('shows an error for an unknown agent and disposes the execution service', async () => {
+    const fixture = executionFixture({ kind: 'not-found' })
+
+    await expect(runCommand('unknown', [], {}, fixture.dependencies)).resolves.toBe(3)
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Unknown agent'))
+    expect(fixture.service.dispose).toHaveBeenCalledOnce()
   })
 
-  it('runs agent directly if installed, returns exit code', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    mockSpawn.mockReturnValue({ exited: Promise.resolve(), exitCode: 0 })
-    const code = await runCommand('test-agent', ['--help'])
-    expect(code).toBe(0)
-    expect(mockSpawn).toHaveBeenCalledWith(['test-bin', '--help'], expect.any(Object))
+  it('passes the exact request to the service and preserves the agent exit code', async () => {
+    const fixture = executionFixture({ exitCode: 42, kind: 'exited', observed })
+
+    await expect(runCommand('test-agent', ['--help'], { install: 'never' }, fixture.dependencies)).resolves.toBe(42)
+    expect(fixture.service.execute).toHaveBeenCalledWith({
+      agentName: 'test-agent',
+      args: ['--help'],
+      installPolicy: 'never',
+    })
   })
 
-  it('prompts for install when not installed, then runs if confirmed', async () => {
+  it('prompts through the production-service confirmation port', async () => {
     mockPrompts.mockResolvedValue({ install: true })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-    installSpy.mockResolvedValue({ success: true })
-    mockSpawn.mockReturnValue({ exited: Promise.resolve(), exitCode: 0 })
-    const code = await runCommand('test-agent', [])
-    expect(code).toBe(0)
-    expect(installSpy).toHaveBeenCalledWith(testAgent)
+    const fixture = executionFixture(async options => {
+      expect(await options.confirmInstall(observed)).toBe(true)
+      return { exitCode: 0, kind: 'exited', observed }
+    })
+
+    await expect(runCommand('test-agent', [], {}, fixture.dependencies)).resolves.toBe(0)
+    expect(mockPrompts).toHaveBeenCalledWith(expect.objectContaining({ type: 'confirm' }))
   })
 
-  it('returns 1 when user cancels install', async () => {
-    mockPrompts.mockResolvedValue({ install: false })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-    const code = await runCommand('test-agent', [])
-    expect(code).toBe(1)
+  it('does not prompt when assume-yes confirms installation', async () => {
+    const fixture = executionFixture(async options => {
+      expect(await options.confirmInstall(observed)).toBe(true)
+      return { exitCode: 0, kind: 'exited', observed }
+    })
+
+    await expect(runCommand('test-agent', [], { assumeYes: true }, fixture.dependencies)).resolves.toBe(0)
+    expect(mockPrompts).not.toHaveBeenCalled()
+  })
+
+  it('reports a declined installation', async () => {
+    const fixture = executionFixture({ kind: 'install-declined', observed })
+
+    await expect(runCommand('test-agent', [], {}, fixture.dependencies)).resolves.toBe(1)
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('cancelled'))
   })
 
-  it('returns 1 when install fails', async () => {
-    mockPrompts.mockResolvedValue({ install: true })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-    installSpy.mockResolvedValue({ success: false })
-    const code = await runCommand('test-agent', [])
-    expect(code).toBe(1)
+  it('reports a failed installation without leaking service internals', async () => {
+    const fixture = executionFixture({ kind: 'install-failed', observed, reason: 'provider failed' })
+
+    await expect(runCommand('test-agent', [], {}, fixture.dependencies)).resolves.toBe(1)
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to install'))
   })
 
-  it('returns 1 when spawn fails', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    mockSpawn.mockImplementation(() => {
-      throw new Error('spawn error')
-    })
-    const code = await runCommand('test-agent', [])
-    expect(code).toBe(1)
-    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to launch'))
+  it('reports launch failures', async () => {
+    const fixture = executionFixture({ kind: 'launch-failed', observed, reason: 'spawn error' })
+
+    await expect(runCommand('test-agent', [], {}, fixture.dependencies)).resolves.toBe(1)
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to launch Test Agent: spawn error'))
   })
 
-  it('does not prompt in non-interactive mode when install is required', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
+  it('does not prompt when non-interactive execution requires interaction', async () => {
+    const fixture = executionFixture({ kind: 'interaction-required', observed })
 
-    const code = await runCommand('test-agent', [], { nonInteractive: true })
-
-    expect(code).toBe(7)
+    await expect(runCommand('test-agent', [], { nonInteractive: true }, fixture.dependencies)).resolves.toBe(7)
     expect(mockPrompts).not.toHaveBeenCalled()
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('interactive installation is disabled'))
   })
 
-  it('emits structured rerun guidance when non-interactive mode blocks install prompting', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'json',
-      runId: 'exec-interaction-run-id',
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
+  it('emits structured rerun guidance for interaction-required outcomes', async () => {
+    setJsonContext('exec-interaction-run-id')
+    const fixture = executionFixture({ kind: 'interaction-required', observed })
 
-    const code = await runCommand('test-agent', ['--help'], { nonInteractive: true })
-
-    expect(code).toBe(7)
-    const payload = JSON.parse(logSpy.mock.calls[0][0])
-    expect(payload.action).toBe('exec')
+    await expect(runCommand('test-agent', ['--help'], { nonInteractive: true }, fixture.dependencies)).resolves.toBe(7)
+    const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0]))
     expect(payload.error.code).toBe('INTERACTION_REQUIRED')
-    expect(payload.data.execution.installGuidance.suggestedAction).toBe('rerun-with-install-policy')
     expect(payload.data.execution.installGuidance.suggestedExecCommand).toBe(
       'quantex exec test-agent --install if-missing -- --help',
     )
   })
 
-  it('returns agent-not-installed when install policy is never', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
+  it('reports a forbidden missing installation without prompting', async () => {
+    const fixture = executionFixture({ kind: 'not-installed', observed })
 
-    const code = await runCommand('test-agent', [], { install: 'never' })
-
-    expect(code).toBe(4)
+    await expect(runCommand('test-agent', [], { install: 'never' }, fixture.dependencies)).resolves.toBe(4)
     expect(mockPrompts).not.toHaveBeenCalled()
-    expect(installSpy).not.toHaveBeenCalled()
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('is not installed'))
   })
 
-  it('emits structured install guidance when install policy is never in json mode', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'json',
-      runId: 'exec-missing-run-id',
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
+  it('emits structured installation guidance for not-installed outcomes', async () => {
+    setJsonContext('exec-missing-run-id')
+    const fixture = executionFixture({ kind: 'not-installed', observed })
 
-    const code = await runCommand('test-agent', ['--help'], { install: 'never' })
-
-    expect(code).toBe(4)
-    const payload = JSON.parse(logSpy.mock.calls[0][0])
-    expect(payload.ok).toBe(false)
-    expect(payload.action).toBe('exec')
+    await expect(runCommand('test-agent', ['--help'], { install: 'never' }, fixture.dependencies)).resolves.toBe(4)
+    const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0]))
     expect(payload.error.code).toBe('AGENT_NOT_INSTALLED')
     expect(payload.data.execution.installGuidance.suggestedEnsureCommand).toBe('quantex ensure test-agent')
-    expect(payload.data.execution.installGuidance.suggestedExecCommand).toBe(
-      'quantex exec test-agent --install if-missing -- --help',
+  })
+
+  it('passes automatic installation policy without prompting', async () => {
+    const fixture = executionFixture({ exitCode: 0, kind: 'exited', observed })
+
+    await expect(
+      runCommand('test-agent', ['--help'], { install: 'if-missing', nonInteractive: true }, fixture.dependencies),
+    ).resolves.toBe(0)
+    expect(fixture.service.execute).toHaveBeenCalledWith(expect.objectContaining({ installPolicy: 'if-missing' }))
+    expect(mockPrompts).not.toHaveBeenCalled()
+  })
+
+  it('renders the installation-start event supplied to the service', async () => {
+    const fixture = executionFixture(async options => {
+      await options.onInstallStart?.(observed)
+      return { exitCode: 0, kind: 'exited', observed }
+    })
+
+    await expect(runCommand('test-agent', [], {}, fixture.dependencies)).resolves.toBe(0)
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Installing Test Agent'))
+  })
+
+  it('returns dry-run success without presenting the installation event as real work', async () => {
+    const fixture = executionFixture({
+      argv: ['test-bin', '--help'],
+      kind: 'dry-run',
+      observed,
+      wouldInstall: true,
+    })
+
+    await expect(
+      runCommand('test-agent', ['--help'], { dryRun: true, install: 'if-missing' }, fixture.dependencies),
+    ).resolves.toBe(0)
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('would install Test Agent'))
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('would run test-bin --help'))
+  })
+
+  it('emits a structured dry-run result', async () => {
+    setJsonContext('exec-dry-run-id')
+    const fixture = executionFixture({ argv: ['test-bin'], kind: 'dry-run', observed, wouldInstall: false })
+
+    await expect(runCommand('test-agent', [], { dryRun: true }, fixture.dependencies)).resolves.toBe(0)
+    const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0]))
+    expect(payload.ok).toBe(true)
+    expect(payload.data.execution).toMatchObject({ installed: true, launched: false })
+  })
+
+  it('distinguishes an installation timeout in the compatibility message', async () => {
+    const fixture = executionFixture({ kind: 'timed-out', observed, phase: 'install', timeoutMs: 25 })
+
+    await expect(runCommand('test-agent', [], {}, fixture.dependencies)).resolves.toBe(10)
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Installing Test Agent timed out after 25ms'))
+  })
+
+  it('distinguishes a launch timeout in the compatibility message', async () => {
+    const fixture = executionFixture({ kind: 'timed-out', observed, phase: 'launch', timeoutMs: 25 })
+
+    await expect(runCommand('test-agent', [], {}, fixture.dependencies)).resolves.toBe(10)
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Test Agent timed out after 25ms'))
+  })
+
+  it('preserves structured state-read errors from lifecycle observation', async () => {
+    setJsonContext('exec-state-error-id')
+    const fixture = executionFixture({
+      error: {
+        code: 'STATE_READ_ERROR',
+        details: { stateFilePath: '/tmp/state.json' },
+        kind: 'invalid-data',
+        message: 'State is corrupt.',
+      },
+      kind: 'observation-failed',
+    })
+
+    await expect(runCommand('test-agent', [], {}, fixture.dependencies)).resolves.toBe(12)
+    const payload = JSON.parse(String(logSpy.mock.calls[0]?.[0]))
+    expect(payload.error).toMatchObject({
+      code: 'STATE_READ_ERROR',
+      details: { stateFilePath: '/tmp/state.json' },
+    })
+  })
+
+  it('cancels active operations on SIGTERM and reports the cancellation signal', async () => {
+    let finish: ((outcome: AgentExecutionOutcome) => void) | undefined
+    const fixture = executionFixture(
+      () =>
+        new Promise<AgentExecutionOutcome>(resolve => {
+          finish = resolve
+        }),
     )
-  })
+    const execution = runCommand('test-agent', [], {}, fixture.dependencies)
+    await vi.waitFor(() => expect(fixture.service.execute).toHaveBeenCalledOnce())
 
-  it('installs automatically when install policy is if-missing', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-    installSpy.mockResolvedValue({ success: true })
-    mockSpawn.mockReturnValue({ exited: Promise.resolve(), exitCode: 0 })
-
-    const code = await runCommand('test-agent', ['--help'], { install: 'if-missing', nonInteractive: true })
-
-    expect(code).toBe(0)
-    expect(mockPrompts).not.toHaveBeenCalled()
-    expect(installSpy).toHaveBeenCalledWith(testAgent)
-    expect(mockSpawn).toHaveBeenCalledWith(['test-bin', '--help'], expect.any(Object))
-  })
-
-  it('accepts the install prompt automatically when assumeYes is enabled', async () => {
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-    installSpy.mockResolvedValue({ success: true })
-    mockSpawn.mockReturnValue({ exited: Promise.resolve(), exitCode: 0 })
-
-    const code = await runCommand('test-agent', ['--help'], { assumeYes: true })
-
-    expect(code).toBe(0)
-    expect(mockPrompts).not.toHaveBeenCalled()
-    expect(installSpy).toHaveBeenCalledWith(testAgent)
-  })
-
-  it('returns a dry-run success without installing or spawning', async () => {
-    setCliContext({
-      dryRun: true,
-      interactive: false,
-      outputMode: 'human',
-      runId: 'dry-run-id',
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-
-    const code = await runCommand('test-agent', ['--help'], {
-      dryRun: true,
-      install: 'if-missing',
-      nonInteractive: true,
-    })
-
-    expect(code).toBe(0)
-    expect(mockPrompts).not.toHaveBeenCalled()
-    expect(installSpy).not.toHaveBeenCalled()
-    expect(mockSpawn).not.toHaveBeenCalled()
-  })
-
-  it('returns timeout when install exceeds the configured limit', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'human',
-      runId: 'run-install-timeout-id',
-      timeoutMs: 1,
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-    installSpy.mockImplementation(() => new Promise(() => {}))
-
-    const code = await runCommand('test-agent', ['--help'], {
-      install: 'if-missing',
-      nonInteractive: true,
-    })
-
-    expect(code).toBe(10)
-    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('timed out'))
-    expect(mockSpawn).not.toHaveBeenCalled()
-  })
-
-  it('returns success when install completes successfully after the timeout deadline fires', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'human',
-      runId: 'run-install-late-success-id',
-      timeoutMs: 20,
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-    installSpy.mockImplementation(async () => {
-      await new Promise(resolve => setTimeout(resolve, 30))
-      if (getCliContext().cancelled) return { success: false }
-      return { success: true }
-    })
-    mockSpawn.mockReturnValue({ exited: Promise.resolve(), exitCode: 0 })
-
-    const code = await runCommand('test-agent', ['--help'], {
-      install: 'if-missing',
-      nonInteractive: true,
-    })
-
-    expect(code).toBe(0)
-    expect(mockSpawn).toHaveBeenCalledWith(['test-bin', '--help'], expect.any(Object))
-  })
-
-  it('returns install failure when install fails after the timeout deadline fires', async () => {
-    setCliContext({
-      interactive: false,
-      outputMode: 'human',
-      runId: 'run-install-late-failure-id',
-      timeoutMs: 20,
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(false)
-    installSpy.mockImplementation(async () => {
-      await new Promise(resolve => setTimeout(resolve, 30))
-      return { success: false }
-    })
-
-    const code = await runCommand('test-agent', ['--help'], {
-      install: 'if-missing',
-      nonInteractive: true,
-    })
-
-    expect(code).toBe(1)
-    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to install'))
-    expect(mockSpawn).not.toHaveBeenCalled()
-  })
-
-  it('returns timeout when the spawned agent exceeds the configured limit', async () => {
-    let resolveExited: (() => void) | undefined
-    const proc: any = {
-      exitCode: null,
-      exited: new Promise<void>(resolve => {
-        resolveExited = resolve
-      }),
-      kill: vi.fn(() => {
-        proc.exitCode = 143
-        resolveExited?.()
-      }),
-    }
-
-    setCliContext({
-      interactive: false,
-      outputMode: 'human',
-      runId: 'run-timeout-id',
-      timeoutMs: 1,
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    mockSpawn.mockImplementation((command: string[]) => {
-      if (command[1] === '--help') return proc
-
-      if (command[1] === '--version') {
-        return {
-          exitCode: 0,
-          exited: Promise.resolve(),
-          stderr: '',
-          stdout: 'test-bin 1.0.0\n',
-        }
-      }
-
-      return {
-        exitCode: 0,
-        exited: Promise.resolve(),
-        stderr: '',
-        stdout: '/tmp/test-bin\n',
-      }
-    })
-
-    const code = await runCommand('test-agent', ['--help'])
-
-    expect(code).toBe(10)
-    expect(proc.kill).toHaveBeenCalledWith('SIGTERM')
-    expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('timed out'))
-  })
-
-  it('returns agent exit code when spawn completes successfully after the timeout deadline fires', async () => {
-    const proc: any = {
-      exitCode: null,
-      exited: new Promise<number>(resolve => {
-        setTimeout(() => {
-          proc.exitCode = 0
-          resolve(0)
-        }, 30)
-      }),
-      kill: vi.fn(),
-    }
-
-    setCliContext({
-      interactive: false,
-      outputMode: 'human',
-      runId: 'run-spawn-late-success-id',
-      timeoutMs: 20,
-    })
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    mockSpawn.mockImplementation((command: string[]) => {
-      if (command[1] === '--help') return proc
-
-      return {
-        exitCode: 0,
-        exited: Promise.resolve(0),
-        stderr: '',
-        stdout: '/tmp/test-bin\n',
-      }
-    })
-
-    const code = await runCommand('test-agent', ['--help'])
-
-    expect(code).toBe(0)
-    expect(proc.kill).not.toHaveBeenCalled()
-  })
-
-  it('returns cancelled when the spawned agent receives a termination signal', async () => {
-    let resolveExited: (() => void) | undefined
-    const proc: any = {
-      exitCode: null,
-      exited: new Promise<void>(resolve => {
-        resolveExited = resolve
-      }),
-      kill: vi.fn(() => {
-        proc.exitCode = 143
-        resolveExited?.()
-      }),
-    }
-
-    agentSpy.mockReturnValue(testAgent)
-    binaryInPathSpy.mockResolvedValue(true)
-    mockSpawn.mockImplementation((command: string[]) => {
-      if (command[1] === '--help') return proc
-
-      if (command[1] === '--version') {
-        return {
-          exitCode: 0,
-          exited: Promise.resolve(),
-          stderr: '',
-          stdout: 'test-bin 1.0.0\n',
-        }
-      }
-
-      return {
-        exitCode: 0,
-        exited: Promise.resolve(),
-        stderr: '',
-        stdout: '/tmp/test-bin\n',
-      }
-    })
-
-    const execution = runCommand('test-agent', ['--help'])
-    await vi.waitFor(() => {
-      expect(mockSpawn).toHaveBeenCalledWith(['test-bin', '--help'], expect.any(Object))
-    })
     process.emit('SIGTERM')
+    await vi.waitFor(() => expect(fixture.dependencies.cancelOperations).toHaveBeenCalledOnce())
+    finish?.({ kind: 'cancelled', observed, phase: 'launch' })
 
-    const code = await execution
-
-    expect(code).toBe(11)
-    expect(proc.kill).toHaveBeenCalledWith('SIGTERM')
+    await expect(execution).resolves.toBe(11)
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('cancelled by SIGTERM'))
   })
 })
+
+type ExecutionFactoryOptions = Parameters<RunCommandDependencies['createExecutionService']>[0]
+
+function executionFixture(
+  result:
+    | AgentExecutionOutcome
+    | ((options: ExecutionFactoryOptions) => AgentExecutionOutcome | Promise<AgentExecutionOutcome>),
+) {
+  let options: ExecutionFactoryOptions
+  const service = {
+    dispose: vi.fn(),
+    execute: vi.fn(async () => (typeof result === 'function' ? await result(options) : result)),
+  }
+  const dependencies: RunCommandDependencies = {
+    cancelOperations: vi.fn(async () => undefined),
+    createExecutionService: vi.fn(received => {
+      options = received
+      return service
+    }),
+  }
+  return { dependencies, service }
+}
+
+function setJsonContext(runId: string): void {
+  setCliContext({ interactive: false, outputMode: 'json', runId })
+}
+
+const observed: LifecycleExecutionObservedAgent = {
+  agent: {
+    binaryName: 'test-bin',
+    displayName: 'Test Agent',
+    name: 'test-agent',
+  },
+  executable: { path: '/tmp/test-bin', present: true, version: '1.0.0' },
+  methods: [{ packageName: 'test-pkg', type: 'npm' }],
+  observation: {
+    drift: { kind: 'none' },
+    executablePath: '/tmp/test-bin',
+    kind: 'present',
+    targetId: 'test-agent',
+    version: '1.0.0',
+  },
+}

--- a/test/commands/shortcut.test.ts
+++ b/test/commands/shortcut.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { resolveShortcutInvocation } from '../../src/commands/shortcut'
+
+const knownCommands = new Set(['install', 'exec', 'help', '--help', '--version', '-v'])
+
+describe('resolveShortcutInvocation', () => {
+  it('returns undefined for an empty invocation, a known command, or an unknown leading option', () => {
+    expect(resolveShortcutInvocation([], knownCommands, { agentFriendly: false })).toBeUndefined()
+    expect(resolveShortcutInvocation(['install', 'codex'], knownCommands, { agentFriendly: false })).toBeUndefined()
+    expect(resolveShortcutInvocation(['--unknown', 'codex'], knownCommands, { agentFriendly: false })).toBeUndefined()
+  })
+
+  it('preserves agent argument order after the shortcut target', () => {
+    expect(resolveShortcutInvocation(['codex', '--model', 'gpt-5', '--', 'prompt'], knownCommands, options())).toEqual({
+      agentArgs: ['--model', 'gpt-5', '--', 'prompt'],
+      agentName: 'codex',
+      dryRun: false,
+      noCache: false,
+      nonInteractive: false,
+      quiet: false,
+      refresh: false,
+      yes: false,
+    })
+  })
+
+  it('normalizes every supported shortcut global before the agent', () => {
+    expect(
+      resolveShortcutInvocation(
+        [
+          '--yes',
+          '--quiet',
+          '--non-interactive',
+          '--dry-run',
+          '--refresh',
+          '--color',
+          'always',
+          '--log-level',
+          'debug',
+          '--idempotency-key',
+          'key-1',
+          '--run-id',
+          'run-1',
+          '--timeout',
+          '5s',
+          'codex',
+          '--help',
+        ],
+        knownCommands,
+        options(),
+      ),
+    ).toEqual({
+      agentArgs: ['--help'],
+      agentName: 'codex',
+      color: 'always',
+      dryRun: true,
+      idempotencyKey: 'key-1',
+      logLevel: 'debug',
+      noCache: false,
+      nonInteractive: true,
+      quiet: true,
+      refresh: true,
+      runId: 'run-1',
+      timeout: '5s',
+      yes: true,
+    })
+  })
+
+  it('recognizes no-cache independently of refresh', () => {
+    expect(resolveShortcutInvocation(['--no-cache', 'codex'], knownCommands, options())).toMatchObject({
+      agentName: 'codex',
+      noCache: true,
+      refresh: false,
+    })
+  })
+
+  it.each(['--output', '--color', '--log-level', '--idempotency-key', '--run-id', '--timeout'])(
+    'returns a stable missing-value error for %s',
+    option => {
+      expect(resolveShortcutInvocation([option], knownCommands, options())).toEqual({
+        agentArgs: [],
+        agentName: '',
+        error: `${option} requires a value`,
+      })
+    },
+  )
+
+  it.each([{ argv: ['--json'] }, { argv: ['--output', 'json'] }, { argv: ['--output', 'ndjson'] }])(
+    'rejects structured shortcut output for $argv',
+    ({ argv }) => {
+      expect(resolveShortcutInvocation([...argv, 'codex'], knownCommands, options())).toEqual({
+        agentArgs: [],
+        agentName: '',
+        error: 'Structured output is not supported for shortcut agent execution yet. Use a management command instead.',
+      })
+    },
+  )
+
+  it('rejects implicit agent-friendly mode but honors explicit human output', () => {
+    expect(resolveShortcutInvocation(['codex'], knownCommands, { agentFriendly: true })).toMatchObject({
+      error: expect.stringContaining('Structured output is not supported'),
+    })
+    expect(
+      resolveShortcutInvocation(['--output', 'human', 'codex'], knownCommands, { agentFriendly: true }),
+    ).toMatchObject({
+      agentName: 'codex',
+    })
+  })
+})
+
+function options() {
+  return { agentFriendly: false }
+}

--- a/test/lifecycle/agent-execution.test.ts
+++ b/test/lifecycle/agent-execution.test.ts
@@ -1,0 +1,146 @@
+import type { AgentExecutionPreflightInput, AgentExecutionPreflightPlan } from '../../src/lifecycle/agent-execution'
+import { describe, expect, it } from 'vitest'
+import { planAgentExecutionPreflight } from '../../src/lifecycle/agent-execution'
+
+const presentObservation = {
+  drift: { kind: 'none' as const },
+  executablePath: '/tmp/test-agent',
+  kind: 'present' as const,
+  targetId: 'test-agent',
+}
+
+const absentObservation = {
+  drift: { kind: 'none' as const },
+  kind: 'absent' as const,
+  targetId: 'test-agent',
+}
+
+describe('planAgentExecutionPreflight', () => {
+  it.each<{
+    expected: AgentExecutionPreflightPlan
+    input: AgentExecutionPreflightInput
+    label: string
+  }>([
+    {
+      expected: { decision: 'launch' },
+      input: input({ installPolicy: 'never' }),
+      label: 'launches a present executable with the explicit exec default',
+    },
+    {
+      expected: { decision: 'launch' },
+      input: input({ installPolicy: 'always' }),
+      label: 'does not reinstall a present executable for the compatibility always policy',
+    },
+    {
+      expected: { decision: 'dry-run' },
+      input: input({ dryRun: true, installPolicy: 'prompt' }),
+      label: 'projects a present interactive shortcut as a dry run',
+    },
+    {
+      expected: { decision: 'reject', errorCode: 'AGENT_NOT_INSTALLED' },
+      input: input({ executablePresent: false, installPolicy: 'never' }),
+      label: 'rejects an absent executable when installation is forbidden',
+    },
+    {
+      expected: { decision: 'reject', errorCode: 'AGENT_NOT_INSTALLED' },
+      input: input({ dryRun: true, executablePresent: false, installPolicy: 'never' }),
+      label: 'keeps the never policy authoritative during dry run',
+    },
+    {
+      expected: { decision: 'install-and-launch' },
+      input: input({ executablePresent: false, installPolicy: 'if-missing' }),
+      label: 'installs an absent executable for if-missing',
+    },
+    {
+      expected: { decision: 'install-and-launch' },
+      input: input({ executablePresent: false, installPolicy: 'always' }),
+      label: 'installs an absent executable for always',
+    },
+    {
+      expected: { decision: 'dry-run' },
+      input: input({ dryRun: true, executablePresent: false, installPolicy: 'if-missing' }),
+      label: 'does not install an absent executable during dry run',
+    },
+    {
+      expected: { decision: 'prompt-install' },
+      input: input({ executablePresent: false, installPolicy: 'prompt' }),
+      label: 'requests confirmation for an interactive shortcut',
+    },
+    {
+      expected: { decision: 'dry-run' },
+      input: input({ dryRun: true, executablePresent: false, installPolicy: 'prompt' }),
+      label: 'does not prompt for an interactive shortcut dry run',
+    },
+    {
+      expected: { decision: 'reject', errorCode: 'INTERACTION_REQUIRED' },
+      input: input({ executablePresent: false, installPolicy: 'prompt', interactive: false }),
+      label: 'rejects a prompt policy when interaction is unavailable',
+    },
+    {
+      expected: { decision: 'reject', errorCode: 'INTERACTION_REQUIRED' },
+      input: input({ dryRun: true, executablePresent: false, installPolicy: 'prompt', interactive: false }),
+      label: 'preserves the non-interactive prompt rejection during dry run',
+    },
+  ])('$label', ({ expected, input: scenario }) => {
+    expect(planAgentExecutionPreflight(scenario)).toEqual(expected)
+  })
+
+  it.each([
+    {
+      executable: { path: '/tmp/test-agent', present: true, version: '1.0.0' },
+      observation: {
+        drift: {
+          kind: 'conflicting-source' as const,
+          observedProviderId: 'npm',
+          recordedProviderId: 'bun',
+        },
+        executablePath: '/tmp/test-agent',
+        kind: 'present' as const,
+        targetId: 'test-agent',
+      },
+    },
+    {
+      executable: { path: '/tmp/test-agent', present: true },
+      observation: {
+        drift: { kind: 'indeterminate' as const, reason: 'provider probe unavailable' },
+        kind: 'indeterminate' as const,
+        reason: 'provider probe unavailable',
+        targetId: 'test-agent',
+      },
+    },
+  ])('keeps a live executable launchable despite provider uncertainty', scenario => {
+    expect(
+      planAgentExecutionPreflight({
+        dryRun: false,
+        installPolicy: 'never',
+        interactive: false,
+        ...scenario,
+      }),
+    ).toEqual({ decision: 'launch' })
+  })
+
+  it('is deterministic and leaves its input unchanged', () => {
+    const scenario = input({ executablePresent: false, installPolicy: 'if-missing' })
+    const before = structuredClone(scenario)
+
+    expect(planAgentExecutionPreflight(scenario)).toEqual(planAgentExecutionPreflight(scenario))
+    expect(scenario).toEqual(before)
+  })
+})
+
+function input(
+  overrides: Partial<
+    Pick<AgentExecutionPreflightInput, 'dryRun' | 'installPolicy' | 'interactive'> & {
+      executablePresent: boolean
+    }
+  > = {},
+): AgentExecutionPreflightInput {
+  const executablePresent = overrides.executablePresent ?? true
+  return {
+    dryRun: overrides.dryRun ?? false,
+    executable: executablePresent ? { path: '/tmp/test-agent', present: true } : { present: false },
+    installPolicy: overrides.installPolicy ?? 'prompt',
+    interactive: overrides.interactive ?? true,
+    observation: executablePresent ? presentObservation : absentObservation,
+  }
+}

--- a/test/managed-installer-cancellation.e2e.test.ts
+++ b/test/managed-installer-cancellation.e2e.test.ts
@@ -38,12 +38,23 @@ describe('managed installer cancellation e2e', () => {
 
       const state = await readJsonFile(join(homeDir, '.quantex', 'state.json'))
       expect(state?.installedAgents?.['cargo-cancel-smoke-agent']).toBeUndefined()
+      expect(state?.lifecycleReceipts?.['cargo-cancel-smoke-agent']).toBeUndefined()
 
       const log = await readFile(fakeCargoLog, 'utf8')
       expect(log).toContain('cargo --version')
       expect(log).toContain('cargo install cargo-cancel-smoke-agent')
       expect(log).not.toContain('fake cargo completed without cancellation')
       if (process.platform !== 'win32') expect(log).toContain('fake cargo received SIGTERM')
+
+      const installerPid = Number(log.match(/fake cargo pid (\d+)/)?.[1])
+      expect(Number.isInteger(installerPid)).toBe(true)
+      await expectProcessToExit(installerPid)
+
+      const stateAfterCancellation = await readFileIfPresent(join(homeDir, '.quantex', 'state.json'))
+      const logAfterCancellation = await readFile(fakeCargoLog, 'utf8')
+      await new Promise(resolve => setTimeout(resolve, 100))
+      expect(await readFileIfPresent(join(homeDir, '.quantex', 'state.json'))).toEqual(stateAfterCancellation)
+      expect(await readFile(fakeCargoLog, 'utf8')).toBe(logAfterCancellation)
     } finally {
       await rm(sandboxRoot, { force: true, recursive: true })
     }
@@ -59,6 +70,7 @@ async function installFakeCargo(fakeBinDir: string, logPath: string): Promise<vo
     'const logPath = process.env.QTX_FAKE_CARGO_LOG',
     'if (!logPath) throw new Error("QTX_FAKE_CARGO_LOG is required")',
     'const log = message => appendFileSync(logPath, `${message}\\n`)',
+    'log(`fake cargo pid ${process.pid}`)',
     'log(`cargo ${args.join(" ")}`)',
     'if (args[0] === "--version") {',
     '  console.log("cargo 1.88.0")',
@@ -130,5 +142,31 @@ async function readJsonFile(path: string): Promise<any | undefined> {
     return JSON.parse(await readFile(path, 'utf8'))
   } catch {
     return undefined
+  }
+}
+
+async function readFileIfPresent(path: string): Promise<Uint8Array | undefined> {
+  try {
+    return await readFile(path)
+  } catch {
+    return undefined
+  }
+}
+
+async function expectProcessToExit(pid: number): Promise<void> {
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+  expect(isProcessAlive(pid), `installer process ${pid} should have exited`).toBe(false)
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
   }
 }

--- a/test/runtime/agent-process.test.ts
+++ b/test/runtime/agent-process.test.ts
@@ -1,0 +1,214 @@
+import type { SpawnedProcessHandle } from '../../src/utils/child-process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createAgentProcessPort } from '../../src/runtime/agent-process'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createAgentProcessPort', () => {
+  it('spawns a Unix process group with inherited stdio and preserves a normal exit code', async () => {
+    const handle = completedHandle(42)
+    const spawn = vi.fn(() => handle)
+    const port = createAgentProcessPort({ platform: 'linux', spawn, terminate: vi.fn(), writeStderr: vi.fn() })
+
+    await expect(
+      port.run({
+        argv: ['test-bin', '--help'],
+        signal: new AbortController().signal,
+        stdio: ['inherit', 'inherit', 'inherit'],
+      }),
+    ).resolves.toEqual({ kind: 'success', value: { exitCode: 42 } })
+    expect(spawn).toHaveBeenCalledWith(['test-bin', '--help'], {
+      detached: true,
+      stdio: ['inherit', 'inherit', 'inherit'],
+    })
+  })
+
+  it('forwards captured structured output to stderr and returns the bytes', async () => {
+    const writeStderr = vi.fn()
+    const port = createAgentProcessPort({
+      platform: 'linux',
+      spawn: vi.fn(() => completedHandle(0, 'child stdout', 'child stderr')),
+      terminate: vi.fn(),
+      writeStderr,
+    })
+
+    const outcome = await port.run({
+      argv: ['test-bin'],
+      signal: new AbortController().signal,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    expect(outcome).toEqual({
+      kind: 'success',
+      value: {
+        exitCode: 0,
+        stderr: new TextEncoder().encode('child stderr'),
+        stdout: new TextEncoder().encode('child stdout'),
+      },
+    })
+    expect(writeStderr.mock.calls.map(([value]) => value)).toEqual(['child stdout', 'child stderr'])
+  })
+
+  it('returns a typed launch failure when spawn throws', async () => {
+    const port = createAgentProcessPort({
+      platform: 'linux',
+      spawn: vi.fn(() => {
+        throw new Error('spawn exploded')
+      }),
+      terminate: vi.fn(),
+      writeStderr: vi.fn(),
+    })
+
+    await expect(port.run({ argv: ['missing-bin'], signal: new AbortController().signal })).resolves.toEqual({
+      error: { kind: 'failed', message: 'spawn exploded' },
+      kind: 'failure',
+    })
+  })
+
+  it('does not spawn when the invocation is already cancelled', async () => {
+    const controller = new AbortController()
+    controller.abort('cancelled before launch')
+    const spawn = vi.fn(() => completedHandle(0))
+    const port = createAgentProcessPort({ platform: 'linux', spawn, terminate: vi.fn(), writeStderr: vi.fn() })
+
+    await expect(port.run({ argv: ['test-bin'], signal: controller.signal })).resolves.toEqual({
+      error: { kind: 'cancelled', message: 'cancelled before launch' },
+      kind: 'failure',
+    })
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('terminates the process tree and removes the abort listener on cancellation', async () => {
+    const controller = new AbortController()
+    const deferred = deferredExit()
+    const terminate = vi.fn(async () => deferred.resolve(143))
+    const removeListener = vi.spyOn(controller.signal, 'removeEventListener')
+    const port = createAgentProcessPort({
+      platform: 'linux',
+      spawn: vi.fn(() => deferred.handle),
+      terminate,
+      writeStderr: vi.fn(),
+    })
+
+    const running = port.run({ argv: ['test-bin'], signal: controller.signal })
+    controller.abort('SIGTERM')
+
+    await expect(running).resolves.toEqual({
+      error: { kind: 'cancelled', message: 'SIGTERM' },
+      kind: 'failure',
+    })
+    expect(terminate).toHaveBeenCalledWith(deferred.handle)
+    expect(removeListener).toHaveBeenCalled()
+  })
+
+  it('does not lose cancellation when the signal aborts synchronously during spawn', async () => {
+    const controller = new AbortController()
+    const deferred = deferredExit()
+    const terminate = vi.fn(async () => deferred.resolve(143))
+    const port = createAgentProcessPort({
+      platform: 'linux',
+      spawn: vi.fn(() => {
+        controller.abort('cancelled during spawn')
+        return deferred.handle
+      }),
+      terminate,
+      writeStderr: vi.fn(),
+    })
+
+    const outcome = await Promise.race([
+      port.run({ argv: ['test-bin'], signal: controller.signal }),
+      new Promise<'hung'>(resolve => setTimeout(() => resolve('hung'), 30)),
+    ])
+
+    expect(outcome).toEqual({
+      error: { kind: 'cancelled', message: 'cancelled during spawn' },
+      kind: 'failure',
+    })
+    expect(terminate).toHaveBeenCalledWith(deferred.handle)
+  })
+
+  it('accepts a normal exit that settles inside the timeout grace window', async () => {
+    vi.useFakeTimers()
+    const deferred = deferredExit()
+    const terminate = vi.fn()
+    const port = createAgentProcessPort({
+      platform: 'linux',
+      spawn: vi.fn(() => deferred.handle),
+      terminate,
+      writeStderr: vi.fn(),
+    })
+
+    const running = port.run({ argv: ['test-bin'], signal: new AbortController().signal, timeoutMs: 20 })
+    await vi.advanceTimersByTimeAsync(20)
+    deferred.resolve(7)
+    await vi.advanceTimersByTimeAsync(1)
+
+    await expect(running).resolves.toEqual({ kind: 'success', value: { exitCode: 7 } })
+    expect(terminate).not.toHaveBeenCalled()
+  })
+
+  it('terminates and returns timed-out after the grace window expires', async () => {
+    vi.useFakeTimers()
+    const deferred = deferredExit()
+    const terminate = vi.fn(async () => deferred.resolve(143))
+    const port = createAgentProcessPort({
+      platform: 'linux',
+      spawn: vi.fn(() => deferred.handle),
+      terminate,
+      writeStderr: vi.fn(),
+    })
+
+    const running = port.run({ argv: ['test-bin'], signal: new AbortController().signal, timeoutMs: 20 })
+    await vi.advanceTimersByTimeAsync(41)
+
+    await expect(running).resolves.toEqual({
+      error: { kind: 'timed-out', message: 'Agent process timed out after 20ms.' },
+      kind: 'failure',
+    })
+    expect(terminate).toHaveBeenCalledWith(deferred.handle)
+  })
+
+  it('does not request a detached process group on Windows', async () => {
+    const spawn = vi.fn(() => completedHandle(0))
+    const port = createAgentProcessPort({ platform: 'win32', spawn, terminate: vi.fn(), writeStderr: vi.fn() })
+
+    await port.run({ argv: ['test-bin'], signal: new AbortController().signal })
+
+    expect(spawn).toHaveBeenCalledWith(['test-bin'], { detached: false, stdio: undefined })
+  })
+})
+
+function completedHandle(exitCode: number, stdout = '', stderr = ''): SpawnedProcessHandle {
+  return {
+    exitCode,
+    exited: Promise.resolve(exitCode),
+    kill: vi.fn(),
+    stderr: stderr as never,
+    stdout: stdout as never,
+    unref: vi.fn(),
+  }
+}
+
+function deferredExit(): { handle: SpawnedProcessHandle; resolve: (exitCode: number) => void } {
+  let exitCode: number | null = null
+  let resolve!: (exitCode: number) => void
+  const exited = new Promise<number>(complete => {
+    resolve = value => {
+      exitCode = value
+      complete(value)
+    }
+  })
+  const handle: SpawnedProcessHandle = {
+    get exitCode() {
+      return exitCode
+    },
+    exited,
+    kill: vi.fn(),
+    stderr: '' as never,
+    stdout: '' as never,
+    unref: vi.fn(),
+  }
+  return { handle, resolve }
+}

--- a/test/services/lifecycle-execution-production.test.ts
+++ b/test/services/lifecycle-execution-production.test.ts
@@ -1,0 +1,162 @@
+import type { AgentDefinition } from '../../src/agents'
+import type { LifecycleObservationService } from '../../src/services/lifecycle-observations'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  createProductionLifecycleExecutionService,
+  type ProductionLifecycleExecutionDependencies,
+} from '../../src/services/lifecycle-execution-production'
+
+describe('createProductionLifecycleExecutionService', () => {
+  it('uses the PATH executable and disables latest-version resolution for preflight', async () => {
+    const observationService = serviceWithObservations([resolvedObservation(false, true)])
+    const dependencies = fakeDependencies(observationService)
+    const service = createProductionLifecycleExecutionService(options(), dependencies)
+
+    await expect(
+      service.execute({ agentName: 'test-agent', args: ['--help'], installPolicy: 'never' }),
+    ).resolves.toMatchObject({ kind: 'not-installed' })
+    expect(dependencies.createObservationService).toHaveBeenCalledWith(expect.anything(), {
+      resolveLatestVersion: false,
+    })
+    expect(dependencies.createProcessPort().run).not.toHaveBeenCalled()
+    service.dispose()
+  })
+
+  it('adapts verified installation reconciliation before re-observation and launch', async () => {
+    const observationService = serviceWithObservations([resolvedObservation(false), resolvedObservation(true)])
+    const dependencies = fakeDependencies(observationService)
+    const service = createProductionLifecycleExecutionService(options(), dependencies)
+
+    await expect(
+      service.execute({ agentName: 'test-agent', args: ['--help'], installPolicy: 'if-missing' }),
+    ).resolves.toMatchObject({ exitCode: 0, kind: 'exited' })
+    expect(dependencies.reconcileAgentInstallation).toHaveBeenCalledWith({
+      agent: testAgent,
+      inspection: expect.objectContaining({ inPath: false }),
+      operation: 'install',
+      route: 'install',
+    })
+    expect(dependencies.createProcessPort().run).toHaveBeenCalledWith(
+      expect.objectContaining({ argv: ['test-bin', '--help'] }),
+    )
+    service.dispose()
+  })
+})
+
+function fakeDependencies(observationService: LifecycleObservationService): ProductionLifecycleExecutionDependencies {
+  const processPort = { run: vi.fn(async () => ({ kind: 'success' as const, value: { exitCode: 0 } })) }
+  return {
+    cancelOperations: vi.fn(async () => undefined),
+    createObservationService: vi.fn(() => observationService),
+    createOperationContext: vi.fn(() => ({
+      context: {
+        registerCleanup: () => () => undefined,
+        signal: new AbortController().signal,
+        timeoutMs: 5_000,
+      },
+      dispose: vi.fn(),
+      run: vi.fn(),
+    })),
+    createProcessPort: vi.fn(() => processPort),
+    reconcileAgentInstallation: vi.fn(
+      async () =>
+        ({
+          kind: 'success' as const,
+          value: {
+            changed: true,
+            receipt: {
+              kind: 'lifecycle-receipt' as const,
+              providerId: 'npm',
+              providerTargetId: 'test-package',
+              providerTargetKind: 'package' as const,
+              schemaVersion: 1 as const,
+              targetId: 'test-agent',
+              verifiedAt: '2026-07-15T08:00:00.000Z',
+            },
+            value: {
+              installedState: {
+                agentName: 'test-agent',
+                installType: 'npm' as const,
+                packageName: 'test-package',
+              },
+            },
+            verification: {
+              kind: 'satisfied' as const,
+              observation: {
+                drift: { kind: 'none' as const },
+                kind: 'present' as const,
+                targetId: 'test-agent',
+              },
+              postcondition: { executable: 'test-bin', kind: 'executable-present' as const },
+            },
+          },
+        }) as const,
+    ) as unknown as ProductionLifecycleExecutionDependencies['reconcileAgentInstallation'],
+    resolveAgentInspection: vi.fn(
+      async () =>
+        ({
+          agent: testAgent,
+          inspection: {
+            agent: testAgent,
+            binaryPath: undefined,
+            inPath: false,
+            methods: [{ packageName: 'test-package', type: 'npm' as const }],
+          },
+        }) as never,
+    ) as unknown as ProductionLifecycleExecutionDependencies['resolveAgentInspection'],
+  }
+}
+
+function serviceWithObservations(
+  observations: Array<ReturnType<typeof resolvedObservation>>,
+): LifecycleObservationService {
+  return {
+    observeRegisteredAgents: vi.fn(async () => []),
+    resolveAgentObservation: vi.fn(async () => observations.shift()),
+  }
+}
+
+function resolvedObservation(pathPresent: boolean, providerPresent = pathPresent) {
+  const pathExecutable = pathPresent ? { path: '/path/test-bin', present: true, version: '1.0.0' } : { present: false }
+  return {
+    agent: testAgent,
+    capabilities: [],
+    catalogMethods: [],
+    executable: providerPresent ? { path: '/provider/test-bin', present: true, version: '1.0.0' } : { present: false },
+    latestVersion: undefined,
+    methods: [{ packageName: 'test-package', type: 'npm' as const }],
+    observation: providerPresent
+      ? {
+          drift: { kind: 'untracked' as const },
+          executablePath: '/provider/test-bin',
+          kind: 'present' as const,
+          targetId: 'test-agent',
+        }
+      : {
+          drift: { kind: 'none' as const },
+          kind: 'absent' as const,
+          targetId: 'test-agent',
+        },
+    pathExecutable,
+    resolvedBinaryPath: pathPresent ? '/path/test-bin' : undefined,
+  }
+}
+
+function options() {
+  return {
+    confirmInstall: vi.fn(async () => true),
+    dryRun: false,
+    interactive: false,
+    outputMode: 'human' as const,
+    timeoutMs: 5_000,
+  }
+}
+
+const testAgent: AgentDefinition = {
+  binaryName: 'test-bin',
+  displayName: 'Test Agent',
+  homepage: 'https://example.com',
+  name: 'test-agent',
+  packages: { npm: 'test-package' },
+  platforms: { linux: [{ packageName: 'test-package', type: 'npm' }] },
+}

--- a/test/services/lifecycle-execution.test.ts
+++ b/test/services/lifecycle-execution.test.ts
@@ -1,0 +1,247 @@
+import type { RuntimeFailure, RuntimeOutcome } from '../../src/runtime'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  executeAgentLifecycle,
+  type LifecycleExecutionObservedAgent,
+  type LifecycleExecutionServicePorts,
+} from '../../src/services/lifecycle-execution'
+
+const controller = new AbortController()
+
+describe('executeAgentLifecycle', () => {
+  it('returns not-found without installing or launching', async () => {
+    const ports = fakePorts({ observations: [undefined] })
+
+    await expect(executeAgentLifecycle(request(), ports)).resolves.toEqual({ kind: 'not-found' })
+    expect(ports.install).not.toHaveBeenCalled()
+    expect(ports.process.run).not.toHaveBeenCalled()
+  })
+
+  it('launches an observed executable with inherited human stdio and preserves its exit code', async () => {
+    const ports = fakePorts({ processResult: success({ exitCode: 42 }), observations: [observed(true)] })
+
+    await expect(executeAgentLifecycle(request({ args: ['--help'] }), ports)).resolves.toMatchObject({
+      exitCode: 42,
+      kind: 'exited',
+    })
+    expect(ports.process.run).toHaveBeenCalledWith({
+      argv: ['test-bin', '--help'],
+      signal: controller.signal,
+      stdio: ['inherit', 'inherit', 'inherit'],
+      timeoutMs: 5_000,
+    })
+  })
+
+  it('reserves stdout for structured output', async () => {
+    const ports = fakePorts({ observations: [observed(true)], outputMode: 'json' })
+
+    await executeAgentLifecycle(request(), ports)
+
+    expect(ports.process.run).toHaveBeenCalledWith(expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }))
+  })
+
+  it('rejects an absent executable when installation is forbidden', async () => {
+    const ports = fakePorts({ observations: [observed(false)] })
+
+    await expect(executeAgentLifecycle(request({ installPolicy: 'never' }), ports)).resolves.toMatchObject({
+      kind: 'not-installed',
+      observed: observed(false),
+    })
+    expect(ports.install).not.toHaveBeenCalled()
+    expect(ports.process.run).not.toHaveBeenCalled()
+  })
+
+  it('returns interaction-required without prompting in non-interactive prompt mode', async () => {
+    const ports = fakePorts({ interactive: false, observations: [observed(false)] })
+
+    await expect(executeAgentLifecycle(request({ installPolicy: 'prompt' }), ports)).resolves.toMatchObject({
+      kind: 'interaction-required',
+    })
+    expect(ports.confirmInstall).not.toHaveBeenCalled()
+  })
+
+  it('returns install-declined when the user rejects the prompt', async () => {
+    const ports = fakePorts({ confirmInstall: false, observations: [observed(false)] })
+
+    await expect(executeAgentLifecycle(request({ installPolicy: 'prompt' }), ports)).resolves.toMatchObject({
+      kind: 'install-declined',
+    })
+    expect(ports.install).not.toHaveBeenCalled()
+    expect(ports.process.run).not.toHaveBeenCalled()
+  })
+
+  it('installs, re-observes, and only then launches', async () => {
+    const callOrder: string[] = []
+    const ports = fakePorts({ observations: [observed(false), observed(true)] })
+    vi.mocked(ports.observe).mockImplementation(async () => {
+      callOrder.push('observe')
+      return success(callOrder.length === 1 ? observed(false) : observed(true))
+    })
+    vi.mocked(ports.install).mockImplementation(async () => {
+      callOrder.push('install')
+      return { kind: 'success', value: undefined }
+    })
+    vi.mocked(ports.onInstallStart!).mockImplementation(() => {
+      callOrder.push('install-start')
+    })
+    vi.mocked(ports.process.run).mockImplementation(async () => {
+      callOrder.push('launch')
+      return success({ exitCode: 0 })
+    })
+
+    await expect(executeAgentLifecycle(request({ installPolicy: 'if-missing' }), ports)).resolves.toMatchObject({
+      exitCode: 0,
+      kind: 'exited',
+    })
+    expect(callOrder).toEqual(['observe', 'install-start', 'install', 'observe', 'launch'])
+  })
+
+  it('does not launch when installation reports success but fresh observation remains absent', async () => {
+    const ports = fakePorts({ observations: [observed(false), observed(false)] })
+
+    await expect(executeAgentLifecycle(request({ installPolicy: 'if-missing' }), ports)).resolves.toMatchObject({
+      kind: 'install-failed',
+      reason: 'executable-absent-after-install',
+    })
+    expect(ports.process.run).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [
+      { kind: 'cancelled' as const, reason: 'cancelled' },
+      { kind: 'cancelled', reason: 'cancelled' },
+    ],
+    [
+      { kind: 'timed-out' as const, timeoutMs: 123 },
+      { kind: 'timed-out', timeoutMs: 123 },
+    ],
+    [
+      { kind: 'failed' as const, reason: 'provider failed', retryable: false },
+      { kind: 'install-failed', reason: 'provider failed' },
+    ],
+    [
+      { kind: 'indeterminate' as const, reason: 'verification unavailable' },
+      { kind: 'install-failed', reason: 'verification unavailable' },
+    ],
+  ])('maps a non-success installation outcome without launching', async (installResult, expected) => {
+    const ports = fakePorts({ installResult, observations: [observed(false)] })
+
+    await expect(executeAgentLifecycle(request({ installPolicy: 'if-missing' }), ports)).resolves.toMatchObject(
+      expected,
+    )
+    expect(ports.process.run).not.toHaveBeenCalled()
+  })
+
+  it('returns a dry-run plan without prompting, installing, or launching', async () => {
+    const ports = fakePorts({ dryRun: true, observations: [observed(false)] })
+
+    await expect(executeAgentLifecycle(request({ installPolicy: 'prompt' }), ports)).resolves.toMatchObject({
+      argv: ['test-bin', '--version'],
+      kind: 'dry-run',
+      wouldInstall: true,
+    })
+    expect(ports.confirmInstall).not.toHaveBeenCalled()
+    expect(ports.install).not.toHaveBeenCalled()
+    expect(ports.process.run).not.toHaveBeenCalled()
+  })
+
+  it('reports a present dry run without an install action', async () => {
+    const ports = fakePorts({ dryRun: true, observations: [observed(true)] })
+
+    await expect(executeAgentLifecycle(request({ installPolicy: 'always' }), ports)).resolves.toMatchObject({
+      kind: 'dry-run',
+      wouldInstall: false,
+    })
+  })
+
+  it.each([
+    [failure('cancelled', 'child cancelled'), { kind: 'cancelled', reason: 'child cancelled' }],
+    [failure('timed-out', 'child timed out'), { kind: 'timed-out', timeoutMs: 5_000 }],
+    [failure('failed', 'spawn failed'), { kind: 'launch-failed', reason: 'spawn failed' }],
+  ])('maps typed process failures', async (processResult, expected) => {
+    const ports = fakePorts({ observations: [observed(true)], processResult })
+
+    await expect(executeAgentLifecycle(request(), ports)).resolves.toMatchObject(expected)
+  })
+
+  it('returns observation-failed when live preflight observation fails', async () => {
+    const ports = fakePorts({ observationResult: failure('invalid-data', 'state is corrupt') })
+
+    await expect(executeAgentLifecycle(request(), ports)).resolves.toMatchObject({
+      error: { kind: 'invalid-data', message: 'state is corrupt' },
+      kind: 'observation-failed',
+    })
+    expect(ports.process.run).not.toHaveBeenCalled()
+  })
+})
+
+interface FakePortsOptions {
+  confirmInstall?: boolean
+  dryRun?: boolean
+  installResult?: Awaited<ReturnType<LifecycleExecutionServicePorts['install']>>
+  interactive?: boolean
+  observationResult?: RuntimeOutcome<LifecycleExecutionObservedAgent | undefined>
+  observations?: Array<LifecycleExecutionObservedAgent | undefined>
+  outputMode?: LifecycleExecutionServicePorts['outputMode']
+  processResult?: Awaited<ReturnType<LifecycleExecutionServicePorts['process']['run']>>
+}
+
+function fakePorts(options: FakePortsOptions = {}): LifecycleExecutionServicePorts {
+  const observations = [...(options.observations ?? [observed(true)])]
+  return {
+    confirmInstall: vi.fn(async () => options.confirmInstall ?? true),
+    dryRun: options.dryRun ?? false,
+    install: vi.fn(async () => options.installResult ?? ({ kind: 'success', value: undefined } as const)),
+    interactive: options.interactive ?? true,
+    observe: vi.fn(async () => options.observationResult ?? success(observations.shift())),
+    onInstallStart: vi.fn(),
+    outputMode: options.outputMode ?? 'human',
+    process: {
+      run: vi.fn(async () => options.processResult ?? success({ exitCode: 0 })),
+    },
+    signal: controller.signal,
+    timeoutMs: 5_000,
+  }
+}
+
+function request(overrides: Partial<Parameters<typeof executeAgentLifecycle>[0]> = {}) {
+  return {
+    agentName: 'test-agent',
+    args: ['--version'],
+    installPolicy: 'never' as const,
+    ...overrides,
+  }
+}
+
+function observed(present: boolean): LifecycleExecutionObservedAgent {
+  return {
+    agent: {
+      binaryName: 'test-bin',
+      displayName: 'Test Agent',
+      name: 'test-agent',
+    },
+    executable: present ? { path: '/tmp/test-bin', present: true, version: '1.0.0' } : { present: false },
+    methods: [{ packageName: 'test-package', type: 'npm' }],
+    observation: present
+      ? {
+          drift: { kind: 'none' },
+          executablePath: '/tmp/test-bin',
+          kind: 'present',
+          targetId: 'test-agent',
+          version: '1.0.0',
+        }
+      : {
+          drift: { kind: 'none' },
+          kind: 'absent',
+          targetId: 'test-agent',
+        },
+  }
+}
+
+function success<T>(value: T): RuntimeOutcome<T> {
+  return { kind: 'success', value }
+}
+
+function failure(kind: RuntimeFailure['kind'], message: string): RuntimeOutcome<never> {
+  return { kind: 'failure', error: { kind, message } }
+}

--- a/test/services/lifecycle-observations.test.ts
+++ b/test/services/lifecycle-observations.test.ts
@@ -118,6 +118,22 @@ describe('lifecycle observation application service', () => {
     expect(result?.resolvedBinaryPath).toBe('/path/alpha-bin')
   })
 
+  it('can skip remote latest-version resolution for execution preflight', async () => {
+    const getLatestVersion = vi.fn(async () => '2.0.0')
+    const service = createLifecycleObservationService(
+      ports({
+        getAgentByNameOrAlias: () => firstAgent,
+        getLatestVersion,
+      }),
+      { resolveLatestVersion: false },
+    )
+
+    const result = await service.resolveAgentObservation('alpha')
+
+    expect(result?.latestVersion).toBeUndefined()
+    expect(getLatestVersion).not.toHaveBeenCalled()
+  })
+
   it('exposes production entry points without routing through legacy inspection', async () => {
     expect(typeof createProductionLifecycleObservationService).toBe('function')
     expect(typeof resolveAgentObservation).toBe('function')
@@ -128,7 +144,7 @@ describe('lifecycle observation application service', () => {
 })
 
 describe('legacy mutation and execution boundary', () => {
-  it('keeps legacy exports and callers on services/agents', async () => {
+  it('keeps remaining legacy mutation callers on services/agents', async () => {
     const agentsSource = await source('src/services/agents.ts')
     expect(agentsSource).toContain('export async function resolveAgentInspection')
     expect(agentsSource).toContain('export async function inspectRegisteredAgents')
@@ -137,7 +153,6 @@ describe('legacy mutation and execution boundary', () => {
     const expectedRoutes = {
       'src/commands/ensure.ts': { exports: ['resolveAgent', 'resolveAgentInspection'], route: '../services/agents' },
       'src/commands/install.ts': { exports: ['resolveAgent', 'resolveAgentInspection'], route: '../services/agents' },
-      'src/commands/run.ts': { exports: ['resolveAgentInspection'], route: '../services/agents' },
       'src/commands/update.ts': { exports: ['resolveAgent'], route: '../services/agents' },
       'src/services/update.ts': { exports: ['inspectRegisteredAgents'], route: './agents' },
     }
@@ -148,6 +163,15 @@ describe('legacy mutation and execution boundary', () => {
       expect(contents).not.toContain('lifecycle-observations')
       for (const exportName of expected.exports) expect(contents).toContain(exportName)
     }
+  })
+
+  it('routes execution through the lifecycle application service', async () => {
+    const runSource = await source('src/commands/run.ts')
+
+    expect(runSource).toContain("from '../services'")
+    expect(runSource).toContain('createProductionLifecycleExecutionService')
+    expect(runSource).not.toContain('resolveAgentInspection')
+    expect(runSource).not.toContain('lifecycle-observations')
   })
 
   it('keeps the new application boundary read-only and presenter-independent', async () => {


### PR DESCRIPTION
## Summary

- Route explicit `exec` and shortcut launch through one observation-driven lifecycle execution use case with a pure install-policy planner, verified install reconciliation, and fresh pre-launch observation.
- Add a managed process port that preserves human inherited stdio, structured child-output routing, exact child exit codes, Unix process groups, Windows tree termination delegation, timeout, cancellation, and listener cleanup.
- Preserve v1 CLI syntax, prompt/install guidance, dry-run and error envelopes while adding real explicit/shortcut execution smoke coverage and cancellation tests that exclude successful receipts, living child processes, and delayed state writes.

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `openspec/changes/redesign-lifecycle-engine` (Phase 8 complete; 48/74 and remains active)
- Discussion: none

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (1494/1494)
- [ ] Not run, explained below

Additional validation:

- `bun run openspec:validate` (16/16)
- `bun run build`
- `QTX_ISOLATION_AGENTS=codex QTX_ISOLATION_SCENARIOS=managed,deno-managed,uv-managed bun run test:container` (normalized tree passed; one bounded network-install timeout was followed by a successful retry)
- Whole-branch review and remediation re-review: Spec Approved; Code Quality Approved; no remaining findings
- Initial PR head: macOS, Ubuntu, Windows, and trusted sandbox passed; refreshed governance and required checks remain mandatory after the OpenSpec-only head update.

## Release Intent

- Release: not applicable - intermediate milestone into the non-release integration branch; final release closure occurs only after integration promotion to `main`.

## Docs Updated

- [ ] Not needed
- [x] `docs/superpowers/plans/2026-07-15-agent-execution-milestone.md`
- [x] `openspec/changes/redesign-lifecycle-engine/tasks.md` (tasks 8.1-8.4 complete; active total 48/74)
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change remains active across milestone merges by design.
- [x] Release is not applicable for this integration-targeted PR.

## Notes

- Base: `codex/redesign-lifecycle-integration`
- OpenSpec is 48/74 after the initial PR head passed macOS, Ubuntu, Windows, and trusted sandbox validation; the change remains active and unarchived.
- The normalized milestone commit has integration tip `9213bd92cc555e2625067625cc05b2cce994f09d` as its sole parent and exactly preserves reviewed granular tree `a4ea542d22078187f6db17234947e3edc847411d`.
- Do not enable auto-merge. Merge only with rebase after required CI, review, trusted sandbox checks, OpenSpec update, and final integration base compare-and-swap validation.
