### PR TITLE
refactor(self): migrate self upgrade to runtime ports

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,17 +1,17 @@
-# Agent Execution Milestone Progress
+# Self-Upgrade Integration Milestone Progress
 
-Base: `origin/codex/redesign-lifecycle-integration@9213bd92cc555e2625067625cc05b2cce994f09d`
+Base: `origin/codex/redesign-lifecycle-integration@09fe7b1a57dd0482b91ee1a6d24f314e5b8bad56`
 
-Plan: `docs/superpowers/plans/2026-07-15-agent-execution-milestone.md`
+Plan: `docs/superpowers/plans/2026-07-15-self-upgrade-integration-milestone.md`
 
 | Task | State | Checkpoint | Evidence |
 | --- | --- | --- | --- |
-| 1. Pure execution preflight planning | complete | `b642ee5` | 15/15 decision-table tests; lint, format, typecheck pass |
-| 2. Observation-driven execution service | complete | `f4e20ef` | 18 service tests plus 15 planner tests; no launch before fresh verified observation |
-| 3. Production process port and unified surface | complete | task-3 commit | explicit exec and shortcut share the lifecycle execution service; 48 focused tests plus full static validation pass |
-| 4. Cross-platform execution verification | complete | PR #459 first head | 1494/1494 local tests, managed/deno/uv container, macOS/Ubuntu/Windows CI, and trusted sandbox pass; independent review approved |
-| 5. PR delivery to integration | in progress | PR #459 | OpenSpec 48/74 update and refreshed CI/governance/final rebase CAS pending |
+| 1. Cache-only passive metadata | complete | task-1 commit | typed source/channel metadata; passive cache-only projection; 107 focused compatibility/network/self tests plus static/OpenSpec gates pass |
+| 2. Invocation-scoped self-upgrade service | complete | task-2 commit | per-invocation application/composition, shared cache/lock/signal/timeout, v1 presenter retained; 81 focused tests and static/OpenSpec gates pass |
+| 3. Managed process/network ports | complete | managed-process + network commits | child `ProcessPort`, exact Bun/npm argv/verification, fetch `NetworkPort`, and injected registry/release resolution pass 120 focused tests plus static/OpenSpec gates |
+| 4. Binary/Windows runtime ports | complete | binary-port + persistence/fault commits | standalone download/verification use shared network/process ports; install-source evidence uses shared persistence; cancellation/timeout retain typed interruption; atomic rollback and Windows quoting/peer/delayed-swap coverage pass 94 focused self/state tests plus static/OpenSpec gates |
+| 5. Release validation and PR delivery | in progress | PR #460 initial head | 1544/1544 full tests, static/OpenSpec/memory gates, build, five binaries, package, artifacts, release smoke, isolated Bun-managed self-upgrade, and initial remote lint/Ubuntu/Windows/macOS/Modal sandbox all pass; both independent reviews have no remaining Critical/Important; tasks 9.1-9.5 are complete at 53/74, while normalized-head CI, merge, and integration verification remain pending |
 
-Baseline: lint, format, typecheck, and 329/329 suites with 1434/1434 tests pass on integration tip `9213bd9`. CodeGraph initialized with 450 files, 3923 nodes, and 10203 edges.
+Baseline: lint, format check, and typecheck pass on integration tip `09fe7b1`. The initial full suite reported 1491/1494 with three concurrent signal/timing failures; an immediate focused rerun of the affected files passed 53/53, so recurrence must be classified with systematic debugging rather than silently accepted. CodeGraph is initialized with 460 files, 4023 nodes, and 10466 edges.
 
-Recovery rule: resume the first row that is not `complete`; inspect its tests, `git log`, `git status`, and CodeGraph pending-sync banner before editing. Commit each reviewed task, preserve the granular head on `refs/quantex/recovery/redesign-agent-execution-granular`, and normalize only after the refreshed integration-base gate.
+Recovery rule: resume the first row that is not `complete`; inspect its tests, `git log`, `git status`, and CodeGraph pending-sync banner before editing. Commit every reviewed task, preserve the granular head on `refs/quantex/recovery/redesign-self-upgrade-granular`, and normalize only immediately before a PR to `codex/redesign-lifecycle-integration`.

--- a/docs/superpowers/plans/2026-07-15-self-upgrade-integration-milestone.md
+++ b/docs/superpowers/plans/2026-07-15-self-upgrade-integration-milestone.md
@@ -1,0 +1,264 @@
+# Self-Upgrade Integration Milestone Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete OpenSpec tasks 9.1–9.5 by moving Quantex self-upgrade onto the shared invocation/runtime boundaries, eliminating passive network checks, and preserving managed-package and standalone-binary safety on every supported platform.
+
+**Architecture:** Keep `src/self` as a sibling bounded context with its own facts, target, plan, outcome, recovery, and verification types. Add an invocation-scoped self-upgrade application service that consumes the existing shared runtime ports, then bind current Bun/npm, registry, release, state, lock, filesystem, and process behavior in a production composition root. Keep `src/commands/upgrade.ts` as the v1 result/presentation compatibility adapter. Passive notices consume a schema-validated, unexpired self-update metadata record written only by explicit fresh checks; they never call the fresh planner.
+
+**Tech Stack:** Bun 1.3.x, strict TypeScript, Commander 14, Vitest, existing runtime ports and command-result presenters, OpenSpec, release-artifact tooling.
+
+## Global Constraints
+
+- Scope is OpenSpec tasks 9.1–9.5 only. Do not remove compatibility facades, reshape public exports, or begin Phase 10/11 work.
+- Self-upgrade MUST NOT import `src/lifecycle` domain types or model Quantex as an agent. Shared runtime values are infrastructure contracts, not shared lifecycle business semantics.
+- `upgrade --check`, `upgrade`, and explicitly network-aware diagnostics retain their declared fresh network effect. A successful ordinary command may read a valid cache entry but MUST NOT issue network I/O, refresh TTLs, or write cache/state while deciding whether to show a notice.
+- Preserve stable human, JSON, and NDJSON result fields, warning/error codes, exit mappings, install-source detection, registry override precedence, stale-registry warnings, dry-run behavior, and recovery hints.
+- Preserve Bun/npm global install commands and post-install verification against the managed CLI entry point with executable-path fallback.
+- Preserve standalone checksum validation, same-directory temporary/backup replacement, executable verification, rollback, failure classification, and cleanup.
+- Preserve Windows delayed replacement, backup restoration, `qtx.exe`/`quantex.exe` peer entry-point synchronization, custom-name exclusion, and hidden PowerShell launch semantics.
+- All blocking port requests carry the invocation signal and bounded timeout. Lock release and rollback cleanup MUST remain possible after cancellation.
+- Keep `redesign-lifecycle-engine` and `support-integration-branch-delivery` active. Check tasks 9.1–9.5 only after local, platform CI, sandbox, build, binary, release-artifact, and release-smoke evidence exists.
+- Create granular recovery commits and retain the final granular head on `refs/quantex/recovery/redesign-self-upgrade-granular`. Normalize to one conventional commit only immediately before the PR.
+
+Baseline note: static gates passed at integration `09fe7b1`; the first full test run had three existing concurrent signal/timing flakes, while the focused rerun passed 53/53. Treat any recurrence with systematic debugging and a bounded focused rerun; do not hide a deterministic regression as a flake.
+
+---
+
+### Task 1: Cache-Only Passive Self-Update Metadata
+
+**Files:**
+- Create: `src/self/update-metadata.ts`
+- Create: `src/runtime/version-cache.ts`
+- Modify: `src/runtime/index.ts`
+- Modify: `src/self/planning.ts`
+- Modify: `src/self/update-notice.ts`
+- Test: `test/self-update-metadata.test.ts`
+- Modify: `test/self-update-notice.test.ts`
+- Modify: `test/commands/upgrade.test.ts`
+
+**Interfaces:**
+- `SelfUpdateMetadata` contains a schema version, current install source, channel, target version, `canAutoUpdate`, and explicit `fetchedAtMs`/`expiresAtMs` evidence.
+- `parseSelfUpdateMetadata(value, now)` is pure and rejects malformed, expired, channel/source-mismatched, non-semver, or non-installable data.
+- `createVersionCachePort()` implements the shared `CachePort` over the existing `~/.quantex/cache/versions.json` store without changing existing cache keys or network fallback behavior.
+- Explicit target resolution writes the typed self metadata only after a fresh/cached explicit check resolves a valid target. Passive notice reads only that typed record and never calls `inspectSelfReadOnly`, a network port, or a cache write.
+
+- [ ] **Step 1: Add failing metadata and passive-I/O tests**
+
+  Cover valid newer metadata, equal/older versions, expiration boundary, malformed schema, wrong channel/source, unavailable auto-update, cache miss, cache read failure, and `--no-cache`. Instrument network, cache writes, and state writes and assert all stay at zero during passive evaluation.
+
+- [ ] **Step 2: Run RED**
+
+  Run: `bun run test -- test/self-update-metadata.test.ts test/self-update-notice.test.ts test/commands/upgrade.test.ts`
+
+  Expected: FAIL because the typed metadata contract/cache port do not exist and the notice still invokes the fresh self planner.
+
+- [ ] **Step 3: Implement the cache adapter and pure metadata parser**
+
+  Keep the existing response-cache document readable. Validate every cache boundary as `unknown`; never trust a type assertion from JSON. A passive read returns `miss` for expired or invalid values and performs no cleanup write.
+
+- [ ] **Step 4: Write metadata from explicit planning only**
+
+  Have explicit fresh `planSelfUpgrade` calls record the resolved target metadata through an injected cache port/composition. Do not write metadata for cancellation, unresolved target, manual-only source, or passive/read-only evaluation.
+
+- [ ] **Step 5: Convert passive notice to cache-only projection**
+
+  Resolve local self facts read-only, read the exact source/channel metadata key, validate it, and render through the existing human output helper. Keep the existing throttle comparison but do not persist new notice state in this milestone.
+
+- [ ] **Step 6: Verify GREEN and checkpoint**
+
+  Run:
+
+  ```bash
+  bun run test -- test/self-update-metadata.test.ts test/self-update-notice.test.ts test/commands/upgrade.test.ts
+  bun run lint
+  bun run format:check
+  bun run typecheck
+  ```
+
+  Then commit: `refactor(self): make update notices cache only`.
+
+### Task 2: Invocation-Scoped Self-Upgrade Application Service
+
+**Files:**
+- Create: `src/self/application.ts`
+- Create: `src/services/self-upgrade-production.ts`
+- Modify: `src/self/index.ts`
+- Modify: `src/services/index.ts`
+- Modify: `src/commands/upgrade.ts`
+- Test: `test/self/application.test.ts`
+- Modify: `test/commands/upgrade.test.ts`
+- Modify: `test/runtime/invocation-context.test.ts`
+
+**Interfaces:**
+- `SelfUpgradeApplication` owns `inspect`, `check`, and `execute` use cases over a per-invocation `InvocationContext`.
+- Injected self ports resolve/persist local facts, resolve the explicit target, execute the selected self provider, and verify the postcondition. The service itself coordinates the shared cache, lock, persistence, clock, and cancellation contracts and returns typed self outcomes only.
+- `createProductionSelfUpgradeInvocation()` bridges current CLI cancellation/options into a fresh invocation context and binds production runtime ports. It is the only production composition used by `upgradeCommand`.
+- `src/commands/upgrade.ts` maps typed outcomes to the unchanged v1 `CommandResult` and `renderUpgradeHuman`; it does not acquire locks, select providers, spawn processes, or fetch releases.
+
+- [ ] **Step 1: Add failing service decision/order tests**
+
+  Cover check, dry-run, up-to-date, manual-only, update, target-resolution failure, lock conflict, cancellation before/after lock, provider failure, verification failure, cache write failure tolerance, persistence failure, and idempotent lock release. Assert execution cannot occur without a resolved update plan and that verification always follows successful mutation.
+
+- [ ] **Step 2: Run RED**
+
+  Run: `bun run test -- test/self/application.test.ts test/commands/upgrade.test.ts test/runtime/invocation-context.test.ts`
+
+- [ ] **Step 3: Implement the application service and production composition**
+
+  Keep the service free of Commander, console, command-result, agent catalog, and lifecycle-domain imports. Map `RuntimeOutcome` failures to self error kinds at the composition boundary and preserve stable command errors in the presenter.
+
+- [ ] **Step 4: Route the explicit command through one invocation**
+
+  Replace direct `planSelfUpgrade`/`upgradeSelf` orchestration in `upgradeCommand`. Guarantee `dispose()` in `finally`, preserve CLI cancellation and timeout, and ensure explicit checks own their network/cache effects.
+
+- [ ] **Step 5: Preserve compatibility wrappers**
+
+  Keep exported `inspectSelf`, `inspectSelfReadOnly`, `planSelfUpgrade`, and `upgradeSelf` signatures as compatibility facades backed by the new production service where safe. Do not remove exports in Phase 9.
+
+- [ ] **Step 6: Verify GREEN and checkpoint**
+
+  Run focused self/command/runtime tests plus `test/compatibility/v1-baseline.test.ts`, then commit: `refactor(self): add invocation scoped upgrade service`.
+
+### Task 3: Shared Process and Network Ports for Managed Upgrades
+
+**Files:**
+- Create: `src/runtime/child-process.ts`
+- Create: `src/runtime/fetch-network.ts`
+- Modify: `src/runtime/index.ts`
+- Modify: `src/utils/network.ts`
+- Modify: `src/utils/version.ts`
+- Modify: `src/self/planning.ts`
+- Modify: `src/self/release.ts`
+- Modify: `src/self/providers/bun.ts`
+- Modify: `src/self/providers/npm.ts`
+- Modify: `src/self/planning.ts`
+- Test: `test/runtime/child-process.test.ts`
+- Test: `test/runtime/fetch-network.test.ts`
+- Modify: `test/self.test.ts`
+- Modify: `test/network-cancellation.test.ts`
+
+**Interfaces:**
+- `createChildProcessPort()` implements `ProcessPort` with direct argv, requested stdio, bounded timeout, cancellation, exact exit code, captured pipe output, process-tree termination, and listener cleanup.
+- `createFetchNetworkPort()` implements `NetworkPort` with method/headers/body, timeout, abort propagation, bounded response consumption, and normalized response headers.
+- Fresh version/release resolution consumes the injected network port while retaining the existing retry, ETag, response validation, and selected-registry cache policy.
+- Bun/npm self providers construct the same global install argv and use `ProcessPort`; managed verification uses the same port with the managed entry-point probe followed by executable-path fallback.
+
+- [ ] **Step 1: Add failing port conformance tests**
+
+  Cover success/non-zero exit, inherited and piped stdio, spawn failure, cancellation race, timeout, no late completion, response headers/body, HTTP errors, body cancellation, and cleanup.
+
+- [ ] **Step 2: Add failing managed self-upgrade tests**
+
+  Assert exact Bun/npm argv, dist tag, registry override/default, cancellation, timeout, install failure, verification success, wrong version, unresolved version, and probe fallback. Assert no agent lifecycle provider or catalog module is imported by the self application/domain path.
+
+- [ ] **Step 3: Implement production process/network ports and inject them**
+
+  Preserve current retry/cache semantics above `NetworkPort`; the port performs one request and does not decide caching. Preserve transparent install stdio and exact version probe parsing above `ProcessPort`.
+
+- [ ] **Step 4: Verify managed behavior and checkpoint**
+
+  Run runtime, network, self, upgrade-command, cancellation, and compatibility tests; commit: `refactor(self): migrate managed upgrades to runtime ports`.
+
+### Task 4: Port-Driven Standalone Binary Replacement and Windows Recovery
+
+**Files:**
+- Create: `src/runtime/node-file-system.ts`
+- Create: `src/runtime/resource-lock.ts`
+- Create: `src/runtime/state-persistence.ts`
+- Modify: `src/runtime/index.ts`
+- Modify: `src/self/binary.ts`
+- Modify: `src/self/lock.ts`
+- Modify: `src/self/facts.ts`
+- Modify: `src/self/providers/binary.ts`
+- Test: `test/runtime/node-file-system.test.ts`
+- Test: `test/runtime/resource-lock.test.ts`
+- Test: `test/runtime/state-persistence.test.ts`
+- Modify: `test/self-binary.test.ts`
+- Modify: `test/self-binary-rollback.test.ts`
+- Modify: `test/self-state.test.ts`
+- Modify: `test/self.test.ts`
+
+**Interfaces:**
+- Binary execution consumes `NetworkPort`, `FileSystemPort`, and `ProcessPort`; the binary module owns checksum/replacement/rollback semantics but no direct `fetch`, `Bun.spawn`, or `node:fs/promises` calls.
+- The self-upgrade lease consumes `LockPort`; release is idempotent and independent of the acquisition signal.
+- Self install-source evidence consumes a narrow self persistence projection backed by `PersistencePort`; the self bounded context does not import lifecycle receipts or agent state types.
+
+- [ ] **Step 1: Add failing port and fault-injection tests**
+
+  Inject failure at download, checksum, temp write, chmod/permission mapping where applicable, backup rename, install rename, verification spawn, backup removal, rollback rename, and cleanup. Assert the original executable survives every pre-commit failure and recovery diagnostics retain the download URL.
+
+- [ ] **Step 2: Add failing Windows delayed-swap tests through ports**
+
+  Cover backup creation timeout, install move failure with restoration, verified success cleanup, known peer alias synchronization from either entry point, custom-name exclusion, hidden PowerShell flags, and signal-safe scheduling. Assert exact quoting for paths containing spaces and apostrophes.
+
+- [ ] **Step 3: Implement filesystem/lock/persistence adapters and binary migration**
+
+  Keep atomic same-directory replacement and existing backup suffixes. Do not reuse agent mutation plans or lifecycle receipts. Preserve public binary helper signatures through optional/default production dependencies until Phase 10.
+
+- [ ] **Step 4: Verify fault suites and checkpoint**
+
+  Run all self binary/state/runtime tests and full typecheck; commit: `refactor(self): migrate binary replacement to runtime ports`.
+
+### Task 5: Release, Cross-Platform, OpenSpec, Review, and PR Delivery
+
+**Files:**
+- Modify as needed: `scripts/test-self-upgrade-sandbox.ts`
+- Modify as needed: release-smoke/build scripts only when a migrated-path defect is proven
+- Modify: `openspec/changes/redesign-lifecycle-engine/tasks.md`
+- Replace: `.superpowers/sdd/progress.md`
+
+- [ ] **Step 1: Run focused and full local gates**
+
+  ```bash
+  bun run lint
+  bun run format:check
+  bun run typecheck
+  bun run test
+  bun run openspec:validate
+  bun run memory:check
+  bun run build
+  bun run build:bin
+  bun run package:check
+  bun run release:artifacts
+  bun run release:smoke
+  ```
+
+  Release commands create local artifacts only; they MUST NOT publish npm packages or trigger the Release workflow.
+
+- [ ] **Step 2: Run managed self-upgrade sandbox evidence**
+
+  Run the repository self-upgrade sandbox/container scenario for Bun and npm where supported. Use a bounded retry only for proven transient network acquisition failures; never retry a semantic assertion failure without diagnosis.
+
+- [ ] **Step 3: Independent two-stage whole-branch review**
+
+  Review `origin/codex/redesign-lifecycle-integration...HEAD` first for OpenSpec compliance, then for code quality. Fix every Critical/Important finding and rerun the affected fault and compatibility suites.
+
+- [ ] **Step 4: Complete OpenSpec accounting only with remote evidence**
+
+  After macOS, Ubuntu, Windows, sandbox, build, binary, artifact, and smoke checks pass, mark 9.1–9.5 complete and update progress to 53/74. Keep the change active and unarchived; Release remains not applicable.
+
+- [ ] **Step 5: Preserve recovery history and normalize**
+
+  ```bash
+  git update-ref refs/quantex/recovery/redesign-self-upgrade-granular HEAD
+  git fetch origin codex/redesign-lifecycle-integration
+  # verify the branch still has the expected base/tree, then normalize to one commit
+  ```
+
+  Use `refactor(self): migrate self upgrade to runtime ports` for the normalized commit. Re-run at least lint, format check, typecheck, focused self suites, OpenSpec validation, memory check, build, and release smoke on the normalized tree.
+
+- [ ] **Step 6: Create the milestone PR to integration**
+
+  Build the PR body from `.github/pull_request_template.md`, run `bun run pr:body:check`, push with lease safety, and create a ready PR with base exactly `codex/redesign-lifecycle-integration`. Confirm auto-merge is disabled and no Release workflow starts.
+
+- [ ] **Step 7: Gate and integrate**
+
+  Wait for required lint/format/typecheck/test/OpenSpec/memory/platform/sandbox/governance checks and independent review. Merge with rebase first; use squash only if rebase is unavailable/unsafe and record why. Never create a merge commit. Verify the integration tree equals the reviewed PR tree and OpenSpec remains active at 53/74.
+
+## Recovery and Stop Conditions
+
+- Resume from the first incomplete progress row after checking `git status`, `git log`, CodeGraph pending sync, focused tests, and the recovery ref.
+- If network, GitHub, or quota access interrupts delivery, preserve a reviewed granular commit plus the recovery ref before stopping. Split the next unit until each can finish inside one bounded execution window.
+- If a deterministic compatibility, checksum, rollback, Windows, or release-smoke failure remains, do not mark the corresponding OpenSpec task complete and do not open a ready PR.
+- If the runtime-port migration requires changing a public v1 schema or agent lifecycle semantics, stop and revise the active OpenSpec design instead of expanding Phase 9 implicitly.

--- a/openspec/changes/redesign-lifecycle-engine/tasks.md
+++ b/openspec/changes/redesign-lifecycle-engine/tasks.md
@@ -81,11 +81,11 @@
 
 ## 9. Self-Upgrade Integration
 
-- [ ] 9.1 Adapt self-upgrade to shared invocation, process, network, lock, cache, persistence, result, and presentation ports without importing agent lifecycle domain types.
-- [ ] 9.2 Make passive self-update notices consume valid cached metadata only and keep fresh checks limited to explicitly declared commands.
-- [ ] 9.3 Preserve Bun/npm registry resolution, managed-install verification, binary checksum, replacement, rollback, and recovery behavior.
-- [ ] 9.4 Preserve Windows peer entry point and delayed replacement semantics with fault-injection coverage.
-- [ ] 9.5 Run build, binary, release artifact, and release smoke verification for the migrated self-upgrade path.
+- [x] 9.1 Adapt self-upgrade to shared invocation, process, network, lock, cache, persistence, result, and presentation ports without importing agent lifecycle domain types.
+- [x] 9.2 Make passive self-update notices consume valid cached metadata only and keep fresh checks limited to explicitly declared commands.
+- [x] 9.3 Preserve Bun/npm registry resolution, managed-install verification, binary checksum, replacement, rollback, and recovery behavior.
+- [x] 9.4 Preserve Windows peer entry point and delayed replacement semantics with fault-injection coverage.
+- [x] 9.5 Run build, binary, release artifact, and release smoke verification for the migrated self-upgrade path.
 
 ## 10. Compatibility Facade and Legacy Removal
 

--- a/scripts/read-only-lifecycle-smoke.ts
+++ b/scripts/read-only-lifecycle-smoke.ts
@@ -21,7 +21,7 @@ const MODES = ['human', 'json'] as const
 const AGENT_COMMANDS = new Set(['info', 'inspect', 'resolve'])
 const COMMAND_TIMEOUT_MS = 30_000
 const COMMAND_TIMEOUT_GRACE_MS = 1_000
-const PASSIVE_NOTICE_MARKER =
+const LEGACY_PASSIVE_NOTICE_MARKER =
   'Quantex CLI 99.0.0 is available (current 0.29.0). Run `quantex doctor` for source-specific update steps.'
 
 type SmokeCommand = (typeof COMMANDS)[number]
@@ -567,6 +567,10 @@ function pickObservation(value: Record<string, any>, includeUpdateLabel: boolean
 
 function normalizeHumanEvidence(command: SmokeCommand, fixture: SmokeFixture, stdout: string): string[] {
   const normalized = stdout.replace(/\s+/g, ' ').trim()
+  assert(
+    !normalized.includes(LEGACY_PASSIVE_NOTICE_MARKER),
+    `${fixture}/human/${command}: ordinary command emitted the legacy implicit self-update notice.`,
+  )
   const markers = READ_ONLY_LIFECYCLE_BASELINE[fixture].commands[command].human
   for (const marker of markers) {
     assert(normalized.includes(marker), `${fixture}/human/${command}: missing compatibility marker "${marker}".`)
@@ -654,7 +658,7 @@ function fixtureBaseline(
   return {
     commands: {
       capabilities: {
-        human: ['Quantex Capabilities', 'Installers:', 'Features:', 'codex', PASSIVE_NOTICE_MARKER],
+        human: ['Quantex Capabilities', 'Installers:', 'Features:', 'codex'],
         json: {
           agentMarker: true,
           featureKeys: [...FEATURE_KEYS].sort(),
@@ -677,19 +681,14 @@ function fixtureBaseline(
           selfKeys: ['canAutoUpdate', 'currentVersion', 'installSource', 'latestVersion', 'outdated'],
         },
       },
-      info: { human: ['Codex CLI', ...installedHuman, PASSIVE_NOTICE_MARKER], json: observations.info },
-      inspect: { human: ['Codex CLI', ...inspectHuman, PASSIVE_NOTICE_MARKER], json: observations.inspect },
+      info: { human: ['Codex CLI', ...installedHuman], json: observations.info },
+      inspect: { human: ['Codex CLI', ...inspectHuman], json: observations.inspect },
       list: {
-        human: [
-          'AI Agents:',
-          'Codex CLI',
-          installed ? 'Codex CLI installed' : 'Codex CLI not installed',
-          PASSIVE_NOTICE_MARKER,
-        ],
+        human: ['AI Agents:', 'Codex CLI', installed ? 'Codex CLI installed' : 'Codex CLI not installed'],
         json: observations.list,
       },
       resolve: {
-        human: installed ? [...resolveHuman, PASSIVE_NOTICE_MARKER] : resolveHuman,
+        human: resolveHuman,
         json: observations.resolve,
       },
     },

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -2,12 +2,9 @@ import type { CommandResult } from '../output/types'
 import type { CommandWarning } from '../output/types'
 import type { SelfInspection, SelfUpdateChannel } from '../self'
 import { createErrorResult, createSuccessResult, emitCommandResult } from '../output'
-import {
-  buildSelfInspectionFromPlan,
-  getSelfUpgradeRecoveryHintForInspection,
-  planSelfUpgrade,
-  upgradeSelf,
-} from '../self'
+import { buildSelfInspectionFromPlan, getSelfUpgradeRecoveryHintForInspection } from '../self'
+import { createProductionSelfUpgradeInvocation } from '../services/self-upgrade-production'
+import { ProcessInterruptionError } from '../utils/child-process'
 import { pc } from '../utils/color'
 import { isDryRunEnabled, printError, printInfo, printWarn } from '../utils/user-output'
 import { compareVersions } from '../utils/version'
@@ -25,9 +22,16 @@ interface UpgradeCommandData {
 export async function upgradeCommand(
   options: { channel?: SelfUpdateChannel; check?: boolean } = {},
 ): Promise<CommandResult<UpgradeCommandData>> {
-  const plan = await planSelfUpgrade({ updateChannel: options.channel })
-  const inspection = buildSelfInspectionFromPlan(plan)
   const dryRun = isDryRunEnabled()
+  const invocation = createProductionSelfUpgradeInvocation()
+  const outcome = await invocation
+    .run({ check: options.check ?? false, dryRun, updateChannel: options.channel })
+    .finally(() => invocation.dispose())
+  if (outcome.kind === 'interrupted')
+    throw new ProcessInterruptionError({ kind: 'cancelled', reason: outcome.error.message })
+
+  const plan = outcome.plan
+  const inspection = buildSelfInspectionFromPlan(plan)
   const registryWarnings = getManagedRegistryWarnings(inspection)
   const staleLatestWarning = getStaleLatestWarning(inspection)
 
@@ -140,7 +144,8 @@ export async function upgradeCommand(
     )
   }
 
-  const result = await upgradeSelf(plan)
+  if (outcome.kind !== 'executed') throw new Error('Self-upgrade execution did not produce a result.')
+  const result = outcome.result
   if (result.success) {
     return emitCommandResult(
       createSuccessResult<UpgradeCommandData>({

--- a/src/runtime/agent-process.ts
+++ b/src/runtime/agent-process.ts
@@ -17,7 +17,7 @@ export interface AgentProcessPortDependencies {
   readonly platform: NodeJS.Platform
   readonly spawn: (argv: readonly string[], options: AgentProcessSpawnOptions) => SpawnedProcessHandle
   readonly terminate: (handle: SpawnedProcessHandle) => Promise<void>
-  readonly writeStderr: (value: string) => void
+  readonly writeStderr?: (value: string) => void
 }
 
 const defaultDependencies: AgentProcessPortDependencies = {
@@ -102,8 +102,10 @@ function complete(
   request: ProcessRequest,
   dependencies: AgentProcessPortDependencies,
 ): RuntimeOutcome<ProcessResult> {
-  if (request.stdio?.[1] === 'pipe' && result.stdout) dependencies.writeStderr(result.stdout)
-  if (request.stdio?.[2] === 'pipe' && result.stderr) dependencies.writeStderr(result.stderr)
+  if (request.forwardPipedOutput !== false) {
+    if (request.stdio?.[1] === 'pipe' && result.stdout) dependencies.writeStderr?.(result.stdout)
+    if (request.stdio?.[2] === 'pipe' && result.stderr) dependencies.writeStderr?.(result.stderr)
+  }
   const encoder = new TextEncoder()
   return {
     kind: 'success',

--- a/src/runtime/child-process.ts
+++ b/src/runtime/child-process.ts
@@ -1,0 +1,26 @@
+import type { AgentProcessPortDependencies } from './agent-process'
+import type { ProcessPort } from './ports'
+import { spawnCommand, terminateProcessTree } from '../utils/child-process'
+import { createAgentProcessPort } from './agent-process'
+
+export type ChildProcessPortDependencies = AgentProcessPortDependencies
+
+const defaultDependencies: ChildProcessPortDependencies = {
+  platform: process.platform,
+  spawn: (argv, options) =>
+    spawnCommand(argv, {
+      ...options,
+      stdio: options.stdio ? [...options.stdio] : undefined,
+    }),
+  terminate: terminateProcessTree,
+  writeStderr: value => {
+    process.stderr.write(value)
+  },
+}
+
+export function createChildProcessPort(dependencies: ChildProcessPortDependencies = defaultDependencies): ProcessPort {
+  const processPort = createAgentProcessPort(dependencies)
+  return {
+    run: request => processPort.run({ ...request, forwardPipedOutput: request.forwardPipedOutput ?? false }),
+  }
+}

--- a/src/runtime/fetch-network.ts
+++ b/src/runtime/fetch-network.ts
@@ -1,0 +1,84 @@
+import type { NetworkPort, RuntimeOutcome } from './ports'
+
+type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
+export interface FetchNetworkPortDependencies {
+  readonly fetch: FetchLike
+}
+
+const defaultDependencies: FetchNetworkPortDependencies = { fetch: globalThis.fetch.bind(globalThis) }
+
+export function createFetchNetworkPort(dependencies: FetchNetworkPortDependencies = defaultDependencies): NetworkPort {
+  return {
+    async request(request) {
+      if (request.signal.aborted) return cancelled(request.signal)
+
+      const controller = new AbortController()
+      let timeout: ReturnType<typeof setTimeout> | undefined
+      let resolveInterruption!: (outcome: RuntimeOutcome<never>) => void
+      let settled = false
+      const interrupted = new Promise<RuntimeOutcome<never>>(resolve => (resolveInterruption = resolve))
+      const interrupt = (outcome: RuntimeOutcome<never>): void => {
+        if (settled) return
+        settled = true
+        controller.abort()
+        resolveInterruption(outcome)
+      }
+      const abort = () => interrupt(cancelled(request.signal))
+      request.signal.addEventListener('abort', abort, { once: true })
+      if (request.signal.aborted) abort()
+      if (request.timeoutMs !== undefined) {
+        timeout = setTimeout(
+          () => interrupt(failure('timed-out', `Network request timed out after ${request.timeoutMs}ms.`)),
+          request.timeoutMs,
+        )
+      }
+
+      const consumed = Promise.resolve()
+        .then(
+          async (): Promise<RuntimeOutcome<{ body: Uint8Array; headers: Record<string, string>; status: number }>> => {
+            const response = await dependencies.fetch(request.url, {
+              body: request.body as never,
+              headers: request.headers,
+              method: request.method,
+              signal: controller.signal,
+            })
+            const headers: Record<string, string> = {}
+            response.headers.forEach((value, key) => (headers[key.toLowerCase()] = value))
+            return {
+              kind: 'success',
+              value: {
+                body: new Uint8Array(await response.arrayBuffer()),
+                headers,
+                status: response.status,
+              },
+            }
+          },
+        )
+        .catch(error => {
+          if (request.signal.aborted) return cancelled(request.signal)
+          if (controller.signal.aborted && request.timeoutMs !== undefined)
+            return failure('timed-out', `Network request timed out after ${request.timeoutMs}ms.`)
+          return failure('failed', error instanceof Error ? error.message : 'Network request failed.')
+        })
+
+      try {
+        return await Promise.race([consumed, interrupted])
+      } finally {
+        settled = true
+        if (timeout) clearTimeout(timeout)
+        request.signal.removeEventListener('abort', abort)
+      }
+    },
+  }
+}
+
+function cancelled(signal: AbortSignal): RuntimeOutcome<never> {
+  const message =
+    signal.reason instanceof Error ? signal.reason.message : String(signal.reason ?? 'Network request was cancelled.')
+  return failure('cancelled', message)
+}
+
+function failure(kind: 'cancelled' | 'failed' | 'timed-out', message: string): RuntimeOutcome<never> {
+  return { error: { kind, message }, kind: 'failure' }
+}

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -1,4 +1,7 @@
 export * from './agent-process'
 export * from './cli-operation-context'
+export * from './child-process'
+export * from './fetch-network'
 export * from './invocation-context'
 export * from './ports'
+export * from './version-cache'

--- a/src/runtime/ports.ts
+++ b/src/runtime/ports.ts
@@ -33,6 +33,7 @@ export interface ProcessRequest {
   readonly argv: readonly string[]
   readonly cwd?: string
   readonly env?: Readonly<Record<string, string | undefined>>
+  readonly forwardPipedOutput?: boolean
   readonly signal: AbortSignal
   readonly stdio?: readonly [ProcessStdio, ProcessStdio, ProcessStdio]
   readonly timeoutMs?: number

--- a/src/runtime/version-cache.ts
+++ b/src/runtime/version-cache.ts
@@ -1,0 +1,156 @@
+import type { CacheMode } from '../cli-context'
+import type { CacheLookup, CachePort, RuntimeFailure, RuntimeOutcome } from './ports'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { getCliContext } from '../cli-context'
+import { getConfigDir } from '../config'
+
+interface CachedResponseEntry {
+  body: string
+  etag?: string
+  expiresAt: number
+  fetchedAt?: number
+}
+
+interface CachedResponseStore {
+  entries: Record<string, CachedResponseEntry>
+}
+
+export interface VersionCachePortOptions {
+  readonly filePath?: string
+  readonly getCacheMode?: () => CacheMode
+  readonly now?: () => number
+}
+
+export function createVersionCachePort(options: VersionCachePortOptions = {}): CachePort {
+  const filePath = options.filePath ?? join(getConfigDir(), 'cache', 'versions.json')
+  const getCacheMode = options.getCacheMode ?? (() => getCliContext().cacheMode ?? 'default')
+  const now = options.now ?? Date.now
+
+  return {
+    async read(request): Promise<RuntimeOutcome<CacheLookup>> {
+      const interrupted = interruption(request.signal)
+      if (interrupted) return interrupted
+      if (getCacheMode() === 'no-cache') return success({ kind: 'miss' })
+
+      try {
+        const store = await loadStore(filePath)
+        const afterRead = interruption(request.signal)
+        if (afterRead) return afterRead
+        const entry = store.entries[request.key]
+        if (!entry || entry.expiresAt <= now()) return success({ kind: 'miss' })
+
+        try {
+          return success({
+            expiresAtMs: entry.expiresAt,
+            kind: 'hit',
+            value: JSON.parse(entry.body) as unknown,
+          })
+        } catch {
+          return failure('invalid-data', `Cached value for ${request.key} is not valid JSON.`)
+        }
+      } catch (error) {
+        return fromError(error, 'Failed to read the version cache.')
+      }
+    },
+    async remove(request): Promise<RuntimeOutcome<void>> {
+      const interrupted = interruption(request.signal)
+      if (interrupted) return interrupted
+      if (getCacheMode() === 'no-cache') return success(undefined)
+
+      try {
+        const store = await loadStore(filePath)
+        const afterRead = interruption(request.signal)
+        if (afterRead) return afterRead
+        if (!Object.hasOwn(store.entries, request.key)) return success(undefined)
+        delete store.entries[request.key]
+        await saveStore(filePath, store)
+        return interruption(request.signal) ?? success(undefined)
+      } catch (error) {
+        return fromError(error, 'Failed to remove a version cache entry.')
+      }
+    },
+    async write(request): Promise<RuntimeOutcome<void>> {
+      const interrupted = interruption(request.signal)
+      if (interrupted) return interrupted
+      if (getCacheMode() === 'no-cache') return success(undefined)
+
+      try {
+        const store = await loadStore(filePath)
+        const afterRead = interruption(request.signal)
+        if (afterRead) return afterRead
+        const fetchedAt = now()
+        const body = JSON.stringify(request.value)
+        if (body === undefined)
+          return failure('invalid-data', `Cached value for ${request.key} is not JSON serializable.`)
+        store.entries[request.key] = {
+          body,
+          expiresAt: request.expiresAtMs ?? Number.MAX_SAFE_INTEGER,
+          fetchedAt,
+        }
+        await saveStore(filePath, store)
+        return interruption(request.signal) ?? success(undefined)
+      } catch (error) {
+        return fromError(error, 'Failed to write the version cache.')
+      }
+    },
+  }
+}
+
+async function loadStore(filePath: string): Promise<CachedResponseStore> {
+  try {
+    return parseStore(JSON.parse(await readFile(filePath, 'utf8')) as unknown)
+  } catch (error) {
+    if (isMissingFileError(error) || error instanceof SyntaxError) return { entries: {} }
+    throw error
+  }
+}
+
+async function saveStore(filePath: string, store: CachedResponseStore): Promise<void> {
+  await mkdir(dirname(filePath), { recursive: true })
+  await writeFile(filePath, `${JSON.stringify(store, null, 2)}\n`, 'utf8')
+}
+
+function parseStore(value: unknown): CachedResponseStore {
+  if (!isRecord(value) || !isRecord(value.entries)) return { entries: {} }
+  const entries: Record<string, CachedResponseEntry> = {}
+  for (const [key, entry] of Object.entries(value.entries)) {
+    if (!isRecord(entry) || typeof entry.body !== 'string' || !isTimestamp(entry.expiresAt)) continue
+    entries[key] = {
+      body: entry.body,
+      etag: typeof entry.etag === 'string' ? entry.etag : undefined,
+      expiresAt: entry.expiresAt,
+      fetchedAt: isTimestamp(entry.fetchedAt) ? entry.fetchedAt : undefined,
+    }
+  }
+  return { entries }
+}
+
+function success<T>(value: T): RuntimeOutcome<T> {
+  return { kind: 'success', value }
+}
+
+function failure(kind: RuntimeFailure['kind'], message: string, code?: string): RuntimeOutcome<never> {
+  return { error: { code, kind, message }, kind: 'failure' }
+}
+
+function interruption(signal: AbortSignal): RuntimeOutcome<never> | undefined {
+  return signal.aborted ? failure('cancelled', 'Cache operation was cancelled.') : undefined
+}
+
+function fromError(error: unknown, message: string): RuntimeOutcome<never> {
+  const code = isRecord(error) && typeof error.code === 'string' ? error.code : undefined
+  return failure('failed', message, code)
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return isRecord(error) && (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}

--- a/src/self/application.ts
+++ b/src/self/application.ts
@@ -1,0 +1,89 @@
+import type {
+  CachePort,
+  InvocationContext,
+  LockPort,
+  NetworkPort,
+  PersistencePort,
+  ProcessPort,
+  ProcessStdio,
+  RuntimeFailure,
+} from '../runtime'
+import type { SelfUpdateChannel, SelfUpdateResult, SelfUpgradePlan } from './types'
+
+export interface SelfUpgradeApplicationInput {
+  readonly check: boolean
+  readonly dryRun: boolean
+  readonly updateChannel?: SelfUpdateChannel
+}
+
+export interface SelfUpgradeApplicationPlanInput {
+  readonly context: SelfUpgradeOperationContext
+  readonly metadataCache: CachePort
+  readonly networkPort: NetworkPort
+  readonly persistencePort: PersistencePort
+  readonly updateChannel?: SelfUpdateChannel
+}
+
+export interface SelfUpgradeOperationContext {
+  readonly signal: AbortSignal
+  readonly timeoutMs?: number
+}
+
+export interface SelfUpgradeApplicationExecutionInput {
+  readonly lockPort: LockPort
+  readonly networkPort: NetworkPort
+  readonly processPort: ProcessPort
+  readonly signal: AbortSignal
+  readonly stdio: readonly [ProcessStdio, ProcessStdio, ProcessStdio]
+  readonly timeoutMs?: number
+}
+
+export interface SelfUpgradeApplicationPorts {
+  plan(input: SelfUpgradeApplicationPlanInput): Promise<SelfUpgradePlan>
+  upgrade(plan: SelfUpgradePlan, input: SelfUpgradeApplicationExecutionInput): Promise<SelfUpdateResult>
+}
+
+export type SelfUpgradeApplicationOutcome =
+  | { readonly kind: 'executed'; readonly plan: SelfUpgradePlan; readonly result: SelfUpdateResult }
+  | { readonly kind: 'interrupted'; readonly error: RuntimeFailure; readonly plan?: SelfUpgradePlan }
+  | { readonly kind: 'planned'; readonly plan: SelfUpgradePlan }
+
+export async function runSelfUpgradeApplication(
+  input: SelfUpgradeApplicationInput,
+  invocation: InvocationContext,
+  ports: SelfUpgradeApplicationPorts,
+): Promise<SelfUpgradeApplicationOutcome> {
+  if (invocation.signal.aborted) return interrupted()
+
+  const plan = await ports.plan({
+    context: {
+      signal: invocation.signal,
+      timeoutMs: invocation.options.timeoutMs,
+    },
+    metadataCache: invocation.ports.cache,
+    networkPort: invocation.ports.network,
+    persistencePort: invocation.ports.persistence,
+    updateChannel: input.updateChannel,
+  })
+
+  if (invocation.signal.aborted) return interrupted(plan)
+  if (input.check || input.dryRun || plan.status !== 'update-available') return { kind: 'planned', plan }
+
+  const result = await ports.upgrade(plan, {
+    lockPort: invocation.ports.locks,
+    networkPort: invocation.ports.network,
+    processPort: invocation.ports.process,
+    signal: invocation.signal,
+    stdio: invocation.options.outputMode === 'human' ? ['inherit', 'inherit', 'inherit'] : ['ignore', 'pipe', 'pipe'],
+    timeoutMs: invocation.options.timeoutMs,
+  })
+  return { kind: 'executed', plan, result }
+}
+
+function interrupted(plan?: SelfUpgradePlan): SelfUpgradeApplicationOutcome {
+  return {
+    error: { kind: 'cancelled', message: 'Self-upgrade invocation was cancelled.' },
+    kind: 'interrupted',
+    ...(plan ? { plan } : {}),
+  }
+}

--- a/src/self/binary.ts
+++ b/src/self/binary.ts
@@ -1,12 +1,20 @@
+import type { NetworkPort, ProcessPort } from '../runtime'
 import type { SelfUpdateResult, SelfUpgradeErrorKind } from './types'
 import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
 import { chmod, mkdtemp, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, join, win32 } from 'node:path'
 import process from 'node:process'
-import { readProcessOutput, spawnCommand } from '../utils/child-process'
+import { ProcessInterruptionError, readProcessOutput, spawnCommand } from '../utils/child-process'
 
 type BinaryUpgradeResult = Omit<SelfUpdateResult, 'installSource'>
+
+export interface StandaloneBinaryRuntimeOptions {
+  readonly networkPort?: NetworkPort
+  readonly processPort?: ProcessPort
+  readonly signal: AbortSignal
+  readonly timeoutMs?: number
+}
 
 export async function upgradeStandaloneBinary(
   downloadUrl: string,
@@ -14,26 +22,25 @@ export async function upgradeStandaloneBinary(
   expectedChecksum: string,
   expectedVersion?: string,
   windowsPeerExecutablePath: string | undefined = getWindowsStandaloneBinaryPeerPath(executablePath),
+  runtime?: StandaloneBinaryRuntimeOptions,
 ): Promise<BinaryUpgradeResult> {
-  let response: Response
-
-  try {
-    response = await fetch(downloadUrl)
-  } catch (error) {
-    return createBinaryFailure('network', `Failed to download ${downloadUrl}.`, error)
-  }
-
-  if (!response.ok) {
-    return createBinaryFailure('network', `Failed to download ${downloadUrl}: HTTP ${response.status}.`)
-  }
+  const networkPort = runtime?.networkPort
+  const downloaded =
+    networkPort && runtime
+      ? await downloadBinaryWithPort(downloadUrl, { ...runtime, networkPort })
+      : await downloadBinaryWithFetch(downloadUrl)
+  if (downloaded.kind === 'failure') return downloaded.result
+  const binary = downloaded.binary
+  throwIfBinaryUpgradeCancelled(runtime)
 
   const tempDir = await mkdtemp(join(dirname(executablePath), '.quantex-upgrade-'))
   const tempPath = join(tempDir, basename(executablePath))
   const backupPath = `${executablePath}.bak`
   let rollbackAvailable = false
+  let windowsReplacementScheduled = false
 
   try {
-    const binary = Buffer.from(await response.arrayBuffer())
+    throwIfBinaryUpgradeCancelled(runtime)
     const executableMode = await resolveExecutableMode(executablePath)
     const actualChecksum = getSha256(binary)
 
@@ -45,9 +52,10 @@ export async function upgradeStandaloneBinary(
     }
 
     await writeFile(tempPath, binary)
+    throwIfBinaryUpgradeCancelled(runtime)
 
-    if (process.platform === 'win32')
-      return scheduleWindowsBinaryReplacement(
+    if (process.platform === 'win32') {
+      const result = scheduleWindowsBinaryReplacement(
         tempPath,
         executablePath,
         backupPath,
@@ -55,15 +63,19 @@ export async function upgradeStandaloneBinary(
         expectedVersion,
         windowsPeerExecutablePath,
       )
+      windowsReplacementScheduled = result.success
+      return result
+    }
 
     await chmod(tempPath, executableMode)
+    throwIfBinaryUpgradeCancelled(runtime)
     await rm(backupPath, { force: true })
     await rename(executablePath, backupPath)
     rollbackAvailable = true
 
     await rename(tempPath, executablePath)
 
-    const verifyResult = await verifyStandaloneBinary(executablePath, expectedVersion)
+    const verifyResult = await verifyStandaloneBinary(executablePath, expectedVersion, runtime)
 
     if (!verifyResult.success) {
       await restoreStandaloneBinary(backupPath, executablePath)
@@ -89,10 +101,68 @@ export async function upgradeStandaloneBinary(
       rollbackAvailable = false
     }
 
+    if (error instanceof ProcessInterruptionError) throw error
+
     return createBinaryFailure(resolveBinaryErrorKind(error), 'Failed to replace the current Quantex binary.', error)
   } finally {
-    if (process.platform !== 'win32') await rm(tempDir, { recursive: true, force: true })
+    if (process.platform !== 'win32' || !windowsReplacementScheduled)
+      await rm(tempDir, { recursive: true, force: true })
   }
+}
+
+function throwIfBinaryUpgradeCancelled(runtime: StandaloneBinaryRuntimeOptions | undefined): void {
+  if (!runtime?.signal.aborted) return
+  throw new ProcessInterruptionError({
+    kind: 'cancelled',
+    reason:
+      runtime.signal.reason instanceof Error ? runtime.signal.reason.message : String(runtime.signal.reason ?? ''),
+  })
+}
+
+type BinaryDownloadResult =
+  | { readonly binary: Buffer; readonly kind: 'success' }
+  | { readonly kind: 'failure'; readonly result: BinaryUpgradeResult }
+
+async function downloadBinaryWithFetch(downloadUrl: string): Promise<BinaryDownloadResult> {
+  let response: Response
+  try {
+    response = await fetch(downloadUrl)
+  } catch (error) {
+    return { kind: 'failure', result: createBinaryFailure('network', `Failed to download ${downloadUrl}.`, error) }
+  }
+  if (!response.ok)
+    return {
+      kind: 'failure',
+      result: createBinaryFailure('network', `Failed to download ${downloadUrl}: HTTP ${response.status}.`),
+    }
+  return { binary: Buffer.from(await response.arrayBuffer()), kind: 'success' }
+}
+
+async function downloadBinaryWithPort(
+  downloadUrl: string,
+  runtime: StandaloneBinaryRuntimeOptions & { readonly networkPort: NetworkPort },
+): Promise<BinaryDownloadResult> {
+  const outcome = await runtime.networkPort.request({
+    signal: runtime.signal,
+    timeoutMs: runtime.timeoutMs,
+    url: downloadUrl,
+  })
+  if (outcome.kind === 'failure') {
+    if (outcome.error.kind === 'cancelled')
+      throw new ProcessInterruptionError({ kind: 'cancelled', reason: outcome.error.message })
+    if (outcome.error.kind === 'timed-out')
+      throw new ProcessInterruptionError({ kind: 'timed-out', timeoutMs: runtime.timeoutMs ?? 0 })
+    return {
+      kind: 'failure',
+      result: createBinaryFailure('network', `Failed to download ${downloadUrl}.`, outcome.error),
+    }
+  }
+  if (outcome.value.status < 200 || outcome.value.status >= 300)
+    return {
+      kind: 'failure',
+      result: createBinaryFailure('network', `Failed to download ${downloadUrl}: HTTP ${outcome.value.status}.`),
+    }
+  return { binary: Buffer.from(outcome.value.body), kind: 'success' }
 }
 
 export function getWindowsStandaloneBinaryPeerPath(executablePath: string): string | undefined {
@@ -257,10 +327,46 @@ async function restoreStandaloneBinary(backupPath: string, executablePath: strin
   await rename(backupPath, executablePath)
 }
 
-async function verifyStandaloneBinary(executablePath: string, expectedVersion?: string): Promise<BinaryUpgradeResult> {
+async function verifyStandaloneBinary(
+  executablePath: string,
+  expectedVersion?: string,
+  runtime?: StandaloneBinaryRuntimeOptions,
+): Promise<BinaryUpgradeResult> {
   if (!expectedVersion) return { success: true }
 
   try {
+    if (runtime?.processPort) {
+      const outcome = await runtime.processPort.run({
+        argv: [executablePath, '--version'],
+        signal: runtime.signal,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        timeoutMs: runtime.timeoutMs,
+      })
+      if (outcome.kind === 'failure') {
+        if (outcome.error.kind === 'cancelled')
+          throw new ProcessInterruptionError({ kind: 'cancelled', reason: outcome.error.message })
+        if (outcome.error.kind === 'timed-out')
+          throw new ProcessInterruptionError({ kind: 'timed-out', timeoutMs: runtime.timeoutMs ?? 0 })
+        return createBinaryFailure(
+          'verify',
+          'Failed to execute the upgraded Quantex binary for verification.',
+          outcome.error,
+        )
+      }
+      const stdout = outcome.value.stdout ? new TextDecoder().decode(outcome.value.stdout) : ''
+      if (outcome.value.exitCode !== 0)
+        return createBinaryFailure(
+          'verify',
+          `The upgraded Quantex binary exited with code ${outcome.value.exitCode} during verification.`,
+        )
+      if (!stdout.includes(expectedVersion))
+        return createBinaryFailure(
+          'verify',
+          'The upgraded Quantex binary reported an unexpected version during verification.',
+        )
+      return { success: true }
+    }
+
     const proc = spawnCommand([executablePath, '--version'], {
       stdio: ['ignore', 'pipe', 'ignore'] as const,
     })
@@ -284,6 +390,7 @@ async function verifyStandaloneBinary(executablePath: string, expectedVersion?: 
       success: true,
     }
   } catch (error) {
+    if (error instanceof ProcessInterruptionError) throw error
     return createBinaryFailure('verify', 'Failed to execute the upgraded Quantex binary for verification.', error)
   }
 }

--- a/src/self/facts.ts
+++ b/src/self/facts.ts
@@ -1,3 +1,4 @@
+import type { PersistencePort, RuntimeFailure } from '../runtime'
 import type { SelfInstallFacts, SelfInstallSource, SelfPackageMetadata, SelfUpdateChannel } from './types'
 import { readFile } from 'node:fs/promises'
 import { basename, dirname, join } from 'node:path'
@@ -5,27 +6,32 @@ import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 import { loadConfig } from '../config'
 import { BUILD_PACKAGE_NAME, BUILD_VERSION } from '../generated/build-meta'
-import { getSelfState, setSelfInstallSource } from '../state'
+import { ProcessInterruptionError } from '../utils/child-process'
 import { getSelfUpdateChannel } from './release'
+import { SELF_INSTALL_SOURCE_PERSISTENCE_KEY, createSelfInstallSourcePersistencePort } from './state-persistence'
 
 const CLI_NPM_PACKAGE_NAME = BUILD_PACKAGE_NAME
 const BUN_GLOBAL_PATH_SEGMENT = '/.bun/install/global/'
 const NODE_MODULES_SEGMENT = `/node_modules/${CLI_NPM_PACKAGE_NAME}`
 
 export async function resolveSelfInstallFacts(options?: {
+  persistence?: PersistencePort
+  signal?: AbortSignal
   updateChannel?: SelfUpdateChannel
 }): Promise<SelfInstallFacts> {
   return resolveSelfInstallFactsWithPersistence(options, true)
 }
 
 export async function resolveSelfInstallFactsReadOnly(options?: {
+  persistence?: PersistencePort
+  signal?: AbortSignal
   updateChannel?: SelfUpdateChannel
 }): Promise<SelfInstallFacts> {
   return resolveSelfInstallFactsWithPersistence(options, false)
 }
 
 async function resolveSelfInstallFactsWithPersistence(
-  options: { updateChannel?: SelfUpdateChannel } | undefined,
+  options: { persistence?: PersistencePort; signal?: AbortSignal; updateChannel?: SelfUpdateChannel } | undefined,
   persistDetectedSource: boolean,
 ): Promise<SelfInstallFacts> {
   const metadata = await resolveSelfPackageMetadata()
@@ -33,10 +39,12 @@ async function resolveSelfInstallFactsWithPersistence(
   const detectedInstallSource = metadata.foundPackageJson
     ? detectSelfInstallSource(metadata.packageRoot)
     : detectSelfInstallSource('', executablePath)
-  const state = await getSelfState()
+  const persistence = options?.persistence ?? createSelfInstallSourcePersistencePort()
+  const signal = options?.signal ?? new AbortController().signal
+  const storedInstallSource = await loadSelfInstallSource(persistence, signal)
   const installSource = persistDetectedSource
-    ? await reconcileSelfInstallSource(state.installSource, detectedInstallSource)
-    : resolveSelfInstallSource(state.installSource, detectedInstallSource)
+    ? await reconcileSelfInstallSource(storedInstallSource, detectedInstallSource, { persistence, signal })
+    : resolveSelfInstallSource(storedInstallSource, detectedInstallSource)
   const config = await loadConfig()
   const updateChannel = getSelfUpdateChannel(options?.updateChannel, config.selfUpdateChannel)
 
@@ -64,13 +72,40 @@ export function canAutoUpdateSelf(installSource: SelfInstallSource): boolean {
 export async function reconcileSelfInstallSource(
   storedInstallSource: SelfInstallSource | undefined,
   detectedInstallSource: SelfInstallSource,
+  options?: { persistence?: PersistencePort; signal?: AbortSignal },
 ): Promise<SelfInstallSource> {
   if (detectedInstallSource !== 'unknown' && storedInstallSource !== detectedInstallSource) {
-    await setSelfInstallSource(detectedInstallSource)
+    const outcome = await (options?.persistence ?? createSelfInstallSourcePersistencePort()).save({
+      key: SELF_INSTALL_SOURCE_PERSISTENCE_KEY,
+      signal: options?.signal ?? new AbortController().signal,
+      value: detectedInstallSource,
+    })
+    if (outcome.kind === 'failure') throwPersistenceFailure(outcome.error)
     return detectedInstallSource
   }
 
   return resolveSelfInstallSource(storedInstallSource, detectedInstallSource)
+}
+
+async function loadSelfInstallSource(
+  persistence: PersistencePort,
+  signal: AbortSignal,
+): Promise<SelfInstallSource | undefined> {
+  const outcome = await persistence.load({ key: SELF_INSTALL_SOURCE_PERSISTENCE_KEY, signal })
+  if (outcome.kind === 'failure') throwPersistenceFailure(outcome.error)
+  if (outcome.value.kind === 'missing') return undefined
+  const value = outcome.value.snapshot.value
+  if (value === 'binary' || value === 'bun' || value === 'npm' || value === 'source' || value === 'unknown')
+    return value
+  throw new Error('The persisted self install source is invalid.')
+}
+
+function throwPersistenceFailure(error: RuntimeFailure): never {
+  const cause = error.details?.cause
+  if (cause instanceof Error) throw cause
+  if (error.kind === 'cancelled') throw new ProcessInterruptionError({ kind: 'cancelled', reason: error.message })
+  if (error.kind === 'timed-out') throw new ProcessInterruptionError({ kind: 'timed-out', timeoutMs: 0 })
+  throw new Error(error.message)
 }
 
 export function detectSelfInstallSource(

--- a/src/self/index.ts
+++ b/src/self/index.ts
@@ -1,6 +1,8 @@
 import type { ProviderOperationContext } from '../providers'
+import type { LockPort, NetworkPort, ProcessPort, ProcessStdio, RuntimeOutcome } from '../runtime'
 import type { SelfInspection, SelfInstallSource, SelfUpdateChannel, SelfUpdateResult, SelfUpgradePlan } from './types'
 import process from 'node:process'
+import { ProcessInterruptionError } from '../utils/child-process'
 import { resolveSelfInstallFactsReadOnly } from './facts'
 import { acquireSelfUpgradeLock } from './lock'
 import {
@@ -24,26 +26,94 @@ export async function inspectSelfReadOnly(options?: {
   return buildSelfInspectionFromPlan(await planSelfUpgrade({ context: options?.context, facts }))
 }
 
-export async function upgradeSelf(planOrInspection?: SelfInspection | SelfUpgradePlan): Promise<SelfUpdateResult> {
-  const resolvedPlan = await coerceSelfUpgradePlan(planOrInspection)
-  const releaseLock = await acquireSelfUpgradeLock()
+export interface SelfUpgradeExecutionOptions {
+  readonly lockPort?: LockPort
+  readonly networkPort?: NetworkPort
+  readonly processPort?: ProcessPort
+  readonly signal?: AbortSignal
+  readonly stdio?: readonly [ProcessStdio, ProcessStdio, ProcessStdio]
+  readonly timeoutMs?: number
+}
 
-  if (!releaseLock) {
+export async function upgradeSelf(
+  planOrInspection?: SelfInspection | SelfUpgradePlan,
+  options: SelfUpgradeExecutionOptions = {},
+): Promise<SelfUpdateResult> {
+  const resolvedPlan = await coerceSelfUpgradePlan(planOrInspection)
+  const lease = options.lockPort
+    ? await options.lockPort.acquire({
+        resource: 'self upgrade',
+        scope: ['self-upgrade'],
+        signal: options.signal ?? new AbortController().signal,
+        timeoutMs: options.timeoutMs,
+      })
+    : await acquireLegacySelfUpgradeLease()
+
+  if (lease.kind === 'failure') {
+    if (lease.error.kind === 'cancelled') throw new ProcessInterruptionError({ kind: 'cancelled' })
+    if (lease.error.kind === 'timed-out')
+      throw new ProcessInterruptionError({ kind: 'timed-out', timeoutMs: options.timeoutMs ?? 0 })
     return {
       error: {
-        kind: 'locked',
-        message: 'Another qtx upgrade is already running.',
+        kind: lease.error.kind === 'conflict' ? 'locked' : 'unknown',
+        message: lease.error.message,
       },
       installSource: resolvedPlan.facts.installSource,
       success: false,
     }
   }
 
+  let result: SelfUpdateResult
   try {
-    const result = await getSelfUpgradeProvider(resolvedPlan).upgrade(resolvedPlan)
-    return verifySelfUpgradeResult(resolvedPlan, result)
-  } finally {
-    await releaseLock()
+    const useRuntimePorts = options.networkPort !== undefined || options.processPort !== undefined
+    const signal = options.signal ?? new AbortController().signal
+    const providerResult = await getSelfUpgradeProvider(resolvedPlan).upgrade(
+      resolvedPlan,
+      useRuntimePorts
+        ? {
+            network: options.networkPort,
+            process: options.processPort,
+            signal,
+            stdio: options.stdio,
+            timeoutMs: options.timeoutMs,
+          }
+        : undefined,
+    )
+    result = await verifySelfUpgradeResult(
+      resolvedPlan,
+      providerResult,
+      options.processPort ? { process: options.processPort, signal, timeoutMs: options.timeoutMs } : undefined,
+    )
+  } catch (error) {
+    const release = await lease.value.release()
+    if (release.kind === 'failure')
+      throw new Error(`Self-upgrade failed and its lock could not be released: ${release.error.message}`, {
+        cause: error,
+      })
+    throw error
+  }
+
+  const release = await lease.value.release()
+  if (release.kind === 'failure') throw new Error(release.error.message)
+  return result
+}
+
+async function acquireLegacySelfUpgradeLease(): Promise<RuntimeOutcome<{ release(): Promise<RuntimeOutcome<void>> }>> {
+  const release = await acquireSelfUpgradeLock()
+  if (!release)
+    return {
+      error: { kind: 'conflict', message: 'Another qtx upgrade is already running.' },
+      kind: 'failure',
+    }
+
+  return {
+    kind: 'success',
+    value: {
+      async release() {
+        await release()
+        return { kind: 'success', value: undefined }
+      },
+    },
   }
 }
 
@@ -72,7 +142,8 @@ async function coerceSelfUpgradePlan(planOrInspection?: SelfInspection | SelfUpg
   return buildPlanFromInspection(planOrInspection)
 }
 
-export { acquireSelfUpgradeLock, getSelfUpgradeLockPath } from './lock'
+export { acquireSelfUpgradeLock, createSelfUpgradeLockPort, getSelfUpgradeLockPath } from './lock'
+export { createSelfInstallSourcePersistencePort } from './state-persistence'
 export {
   canAutoUpdateSelf,
   detectSelfInstallSource,

--- a/src/self/lock.ts
+++ b/src/self/lock.ts
@@ -1,3 +1,4 @@
+import type { LockPort, RuntimeOutcome } from '../runtime'
 import { acquireResourceLock, getResourceLockPath, isResourceLockError } from '../utils/lock'
 
 export function getSelfUpgradeLockPath(): string {
@@ -15,4 +16,42 @@ export async function acquireSelfUpgradeLock(): Promise<(() => Promise<void>) | 
 
     throw error
   }
+}
+
+export function createSelfUpgradeLockPort(): LockPort {
+  return {
+    async acquire(request) {
+      if (request.signal.aborted) return failure('cancelled', 'Self-upgrade lock acquisition was cancelled.')
+      if (request.scope.length !== 1 || request.scope[0] !== 'self-upgrade')
+        return failure('unavailable', `Unsupported self-upgrade lock scope: ${request.scope.join('/')}`)
+
+      const release = await acquireSelfUpgradeLock()
+      if (!release) return failure('conflict', 'Another qtx upgrade is already running.')
+      if (request.signal.aborted) {
+        await release()
+        return failure('cancelled', 'Self-upgrade lock acquisition was cancelled.')
+      }
+
+      let released = false
+      return {
+        kind: 'success',
+        value: {
+          async release(): Promise<RuntimeOutcome<void>> {
+            if (released) return { kind: 'success', value: undefined }
+            released = true
+            try {
+              await release()
+              return { kind: 'success', value: undefined }
+            } catch (error) {
+              return failure('failed', error instanceof Error ? error.message : 'Failed to release self-upgrade lock.')
+            }
+          },
+        },
+      }
+    },
+  }
+}
+
+function failure(kind: 'cancelled' | 'conflict' | 'failed' | 'unavailable', message: string): RuntimeOutcome<never> {
+  return { error: { kind, message }, kind: 'failure' }
 }

--- a/src/self/planning.ts
+++ b/src/self/planning.ts
@@ -1,27 +1,30 @@
 import type { ProviderOperationContext } from '../providers'
+import type { CachePort, NetworkPort, PersistencePort, ProcessPort } from '../runtime'
 import type { SelfInspection, SelfInstallFacts, SelfUpdateResult, SelfUpdateTarget, SelfUpgradePlan } from './types'
 import { join } from 'node:path'
 import process from 'node:process'
 import { loadConfig } from '../config'
 import { BUILD_PACKAGE_NAME } from '../generated/build-meta'
-import { isProcessInterruptionError } from '../utils/child-process'
+import { isProcessInterruptionError, ProcessInterruptionError } from '../utils/child-process'
 import { OFFICIAL_NPM_REGISTRY } from '../utils/registry'
 import { compareVersions, getInstalledVersion, getLatestVersion, isVersionNewer } from '../utils/version'
 import { resolveSelfInstallFacts } from './facts'
 import { resolveManagedSelfUpdateRegistry } from './registry'
 import { fetchBinaryReleaseManifest, resolveBinaryReleaseAsset } from './release'
+import { createSelfUpdateMetadata, writeSelfUpdateMetadata } from './update-metadata'
 
 export async function resolveSelfUpdateTarget(
   facts: SelfInstallFacts,
   context?: ProviderOperationContext,
+  networkPort?: NetworkPort,
 ): Promise<SelfUpdateTarget> {
   const config = await loadConfig()
 
   if (facts.installSource === 'binary') {
     try {
       const manifest = context
-        ? await fetchBinaryReleaseManifest(facts.updateChannel, context)
-        : await fetchBinaryReleaseManifest(facts.updateChannel)
+        ? await fetchBinaryReleaseManifest(facts.updateChannel, context, networkPort)
+        : await fetchBinaryReleaseManifest(facts.updateChannel, undefined, networkPort)
       const asset = resolveBinaryReleaseAsset(manifest, facts.executablePath)
 
       if (!asset) {
@@ -54,6 +57,7 @@ export async function resolveSelfUpdateTarget(
   const packageTag = facts.updateChannel === 'beta' ? 'beta' : 'latest'
   const upstreamLatestVersion = await getLatestVersion(BUILD_PACKAGE_NAME, packageTag, {
     ...(context ? { context } : {}),
+    networkPort,
     registry: OFFICIAL_NPM_REGISTRY,
   })
 
@@ -66,6 +70,7 @@ export async function resolveSelfUpdateTarget(
       packageTag,
       targetVersion: await getLatestVersion(BUILD_PACKAGE_NAME, packageTag, {
         ...(context ? { context } : {}),
+        networkPort,
         registry: managedRegistry?.registry,
       }),
       upstreamLatestVersion,
@@ -83,19 +88,47 @@ export async function resolveSelfUpdateTarget(
 export async function planSelfUpgrade(options?: {
   context?: ProviderOperationContext
   facts?: SelfInstallFacts
+  metadataCache?: CachePort
+  metadataTtlMs?: number
+  networkPort?: NetworkPort
+  persistencePort?: PersistencePort
+  nowMs?: number
   target?: SelfUpdateTarget
   updateChannel?: SelfInstallFacts['updateChannel']
 }): Promise<SelfUpgradePlan> {
-  const facts = options?.facts ?? (await resolveSelfInstallFacts({ updateChannel: options?.updateChannel }))
-  const target = options?.target ?? (await resolveSelfUpdateTarget(facts, options?.context))
+  const facts =
+    options?.facts ??
+    (await resolveSelfInstallFacts({
+      persistence: options?.persistencePort,
+      signal: options?.context?.signal,
+      updateChannel: options?.updateChannel,
+    }))
+  const target = options?.target ?? (await resolveSelfUpdateTarget(facts, options?.context, options?.networkPort))
   const updateAvailable = target.targetVersion ? isVersionNewer(target.targetVersion, facts.currentVersion) : false
 
-  return {
+  const plan: SelfUpgradePlan = {
     facts,
     status: resolveSelfUpgradePlanStatus(facts, target, updateAvailable),
     target,
     updateAvailable,
   }
+
+  if (options?.metadataCache && facts.canAutoUpdate && target.targetVersion) {
+    const fetchedAtMs = options.nowMs ?? Date.now()
+    const ttlMs = options.metadataTtlMs ?? (await loadConfig()).versionCacheTtlHours * 60 * 60 * 1000
+    await writeSelfUpdateMetadata({
+      cache: options.metadataCache,
+      metadata: createSelfUpdateMetadata({
+        expiresAtMs: fetchedAtMs + ttlMs,
+        facts,
+        fetchedAtMs,
+        targetVersion: target.targetVersion,
+      }),
+      signal: options.context?.signal ?? new AbortController().signal,
+    })
+  }
+
+  return plan
 }
 
 export function buildSelfInspectionFromPlan(plan: SelfUpgradePlan): SelfInspection {
@@ -117,12 +150,13 @@ export function buildSelfInspectionFromPlan(plan: SelfUpgradePlan): SelfInspecti
 export async function verifySelfUpgradeResult(
   plan: SelfUpgradePlan,
   result: SelfUpdateResult,
+  context?: { readonly process?: ProcessPort; readonly signal: AbortSignal; readonly timeoutMs?: number },
 ): Promise<SelfUpdateResult> {
   if (!result.success) return result
 
   if (plan.facts.installSource !== 'bun' && plan.facts.installSource !== 'npm') return result
 
-  const observedVersion = await getInstalledSelfVersion(plan)
+  const observedVersion = await getInstalledSelfVersion(plan, context)
   if (!observedVersion) {
     return {
       error: {
@@ -216,7 +250,20 @@ function resolveSelfUpgradePlanStatus(
   return 'check-unavailable'
 }
 
-async function getInstalledSelfVersion(plan: SelfUpgradePlan): Promise<string | undefined> {
+async function getInstalledSelfVersion(
+  plan: SelfUpgradePlan,
+  context?: { readonly process?: ProcessPort; readonly signal: AbortSignal; readonly timeoutMs?: number },
+): Promise<string | undefined> {
+  const processPort = context?.process
+  if (processPort && context) {
+    const processContext = { ...context, process: processPort }
+    if (plan.target.verificationCommand) {
+      const managedVersion = await probeSelfVersionWithProcess(plan.target.verificationCommand, processContext)
+      if (managedVersion) return managedVersion
+    }
+    return probeSelfVersionWithProcess([plan.facts.executablePath, '--version'], processContext)
+  }
+
   if (plan.target.verificationCommand) {
     const managedVersion = await getInstalledVersion(plan.facts.executablePath, {
       command: plan.target.verificationCommand,
@@ -226,6 +273,31 @@ async function getInstalledSelfVersion(plan: SelfUpgradePlan): Promise<string | 
   }
 
   return getInstalledVersion(plan.facts.executablePath)
+}
+
+async function probeSelfVersionWithProcess(
+  argv: readonly string[],
+  context: { readonly process: ProcessPort; readonly signal: AbortSignal; readonly timeoutMs?: number },
+): Promise<string | undefined> {
+  const outcome = await context.process.run({
+    argv,
+    signal: context.signal,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    timeoutMs: context.timeoutMs,
+  })
+  if (outcome.kind === 'failure') {
+    if (outcome.error.kind === 'cancelled')
+      throw new ProcessInterruptionError({ kind: 'cancelled', reason: outcome.error.message })
+    if (outcome.error.kind === 'timed-out')
+      throw new ProcessInterruptionError({ kind: 'timed-out', timeoutMs: context.timeoutMs ?? 0 })
+    return undefined
+  }
+  if (outcome.value.exitCode !== 0 || !outcome.value.stdout) return undefined
+
+  const firstLine = new TextDecoder().decode(outcome.value.stdout).trim().split('\n')[0]
+  if (!firstLine) return undefined
+  const match = firstLine.match(/v?(\d+\.\d+\.\d+(?:-[a-z0-9.]+)?)/i)
+  return match?.[1] ?? firstLine
 }
 
 function getManagedSelfVersionProbeCommand(packageRoot: string): string[] | undefined {

--- a/src/self/providers/binary.ts
+++ b/src/self/providers/binary.ts
@@ -1,5 +1,5 @@
 import type { SelfInspection, SelfUpdateResult, SelfUpgradePlan } from '../types'
-import type { SelfUpgradeProvider } from './types'
+import type { SelfUpgradeProvider, SelfUpgradeProviderExecutionContext } from './types'
 import { getWindowsStandaloneBinaryPeerPath, upgradeStandaloneBinary } from '../binary'
 import { getBinaryReleaseDownloadUrl } from '../release'
 
@@ -27,7 +27,7 @@ export const binarySelfUpgradeProvider: SelfUpgradeProvider = {
 
     return `download and replace the binary from ${downloadUrl}`
   },
-  async upgrade(plan: SelfUpgradePlan): Promise<SelfUpdateResult> {
+  async upgrade(plan: SelfUpgradePlan, context?: SelfUpgradeProviderExecutionContext): Promise<SelfUpdateResult> {
     const asset = plan.target.binaryAsset
 
     if (!asset) {
@@ -41,13 +41,28 @@ export const binarySelfUpgradeProvider: SelfUpgradeProvider = {
       }
     }
 
-    const result = await upgradeStandaloneBinary(
-      asset.downloadUrl,
-      plan.facts.executablePath,
-      asset.checksum,
-      plan.target.targetVersion ?? 'latest',
-      getWindowsStandaloneBinaryPeerPath(plan.facts.executablePath),
-    )
+    const peerPath = getWindowsStandaloneBinaryPeerPath(plan.facts.executablePath)
+    const result = context
+      ? await upgradeStandaloneBinary(
+          asset.downloadUrl,
+          plan.facts.executablePath,
+          asset.checksum,
+          plan.target.targetVersion ?? 'latest',
+          peerPath,
+          {
+            networkPort: context.network,
+            processPort: context.process,
+            signal: context.signal,
+            timeoutMs: context.timeoutMs,
+          },
+        )
+      : await upgradeStandaloneBinary(
+          asset.downloadUrl,
+          plan.facts.executablePath,
+          asset.checksum,
+          plan.target.targetVersion ?? 'latest',
+          peerPath,
+        )
 
     const enrichedResult =
       !result.success && result.error

--- a/src/self/providers/bun.ts
+++ b/src/self/providers/bun.ts
@@ -1,19 +1,29 @@
 import type { SelfInspection, SelfUpdateResult, SelfUpgradePlan } from '../types'
-import type { SelfUpgradeProvider } from './types'
+import type { SelfUpgradeProvider, SelfUpgradeProviderExecutionContext } from './types'
 import { BUILD_PACKAGE_NAME } from '../../generated/build-meta'
 import * as bunPm from '../../package-manager/bun'
+import { runBunManagedSelfInstall } from './managed-process'
 
 export const bunSelfUpgradeProvider: SelfUpgradeProvider = {
   source: 'bun',
   canHandle: context => getInstallSource(context) === 'bun',
   getRecoveryHint: inspection =>
     `bun add -g ${BUILD_PACKAGE_NAME}@${inspection.updateChannel === 'beta' ? 'beta' : 'latest'}`,
-  async upgrade(plan: SelfUpgradePlan): Promise<SelfUpdateResult> {
-    const success = await bunPm.install(
-      BUILD_PACKAGE_NAME,
-      plan.target.packageTag ?? (plan.facts.updateChannel === 'beta' ? 'beta' : 'latest'),
-      plan.target.managedRegistry,
-    )
+  async upgrade(plan: SelfUpgradePlan, context?: SelfUpgradeProviderExecutionContext): Promise<SelfUpdateResult> {
+    const tag = plan.target.packageTag ?? (plan.facts.updateChannel === 'beta' ? 'beta' : 'latest')
+    const success = context?.process
+      ? await runBunManagedSelfInstall(
+          [
+            'bun',
+            'add',
+            '-g',
+            ...(plan.target.managedRegistry ? ['--registry', plan.target.managedRegistry] : []),
+            `${BUILD_PACKAGE_NAME}@${tag}`,
+          ],
+          BUILD_PACKAGE_NAME,
+          context,
+        )
+      : await bunPm.install(BUILD_PACKAGE_NAME, tag, plan.target.managedRegistry)
     return {
       error: success
         ? undefined

--- a/src/self/providers/managed-process.ts
+++ b/src/self/providers/managed-process.ts
@@ -1,0 +1,83 @@
+import type { ProcessResult } from '../../runtime'
+import type { SelfUpgradeProviderExecutionContext } from './types'
+import { parseUntrustedPackages } from '../../package-manager/bun'
+import { ProcessInterruptionError } from '../../utils/child-process'
+
+export async function runManagedSelfInstall(
+  argv: readonly string[],
+  context: SelfUpgradeProviderExecutionContext,
+): Promise<boolean> {
+  if (!context.process) return false
+  const result = await runManagedSelfProcess(argv, context, {
+    forwardPipedOutput: true,
+    stdio: context.stdio,
+  })
+  return result?.exitCode === 0
+}
+
+export async function runBunManagedSelfInstall(
+  argv: readonly string[],
+  packageName: string,
+  context: SelfUpgradeProviderExecutionContext,
+): Promise<boolean> {
+  if (!(await runManagedSelfInstall(argv, context))) return false
+
+  try {
+    const untrusted = await runManagedSelfProcess(['bun', 'pm', '-g', 'untrusted'], context, {
+      forwardPipedOutput: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    if (!untrusted || untrusted.exitCode !== 0) {
+      await rollbackBunManagedSelfInstall(packageName, context)
+      return false
+    }
+
+    const output = untrusted.stdout ? new TextDecoder().decode(untrusted.stdout) : ''
+    if (!parseUntrustedPackages(output).has(packageName)) return true
+    if (await runManagedSelfInstall(['bun', 'pm', '-g', 'trust', packageName], context)) return true
+
+    await rollbackBunManagedSelfInstall(packageName, context)
+    return false
+  } catch (error) {
+    await rollbackBunManagedSelfInstall(packageName, context)
+    throw error
+  }
+}
+
+async function runManagedSelfProcess(
+  argv: readonly string[],
+  context: SelfUpgradeProviderExecutionContext,
+  options: {
+    readonly forwardPipedOutput: boolean
+    readonly stdio: SelfUpgradeProviderExecutionContext['stdio']
+  },
+): Promise<ProcessResult | undefined> {
+  if (!context.process) return undefined
+  const outcome = await context.process.run({
+    argv,
+    forwardPipedOutput: options.forwardPipedOutput,
+    signal: context.signal,
+    stdio: options.stdio,
+    timeoutMs: context.timeoutMs,
+  })
+  if (outcome.kind === 'success') return outcome.value
+  if (outcome.error.kind === 'cancelled')
+    throw new ProcessInterruptionError({ kind: 'cancelled', reason: outcome.error.message })
+  if (outcome.error.kind === 'timed-out')
+    throw new ProcessInterruptionError({ kind: 'timed-out', timeoutMs: context.timeoutMs ?? 0 })
+  return undefined
+}
+
+async function rollbackBunManagedSelfInstall(
+  packageName: string,
+  context: SelfUpgradeProviderExecutionContext,
+): Promise<void> {
+  try {
+    await runManagedSelfInstall(['bun', 'remove', '-g', packageName], {
+      ...context,
+      signal: new AbortController().signal,
+    })
+  } catch {
+    // Best-effort rollback remains independent of the cancelled mutation signal.
+  }
+}

--- a/src/self/providers/npm.ts
+++ b/src/self/providers/npm.ts
@@ -1,19 +1,28 @@
 import type { SelfInspection, SelfUpdateResult, SelfUpgradePlan } from '../types'
-import type { SelfUpgradeProvider } from './types'
+import type { SelfUpgradeProvider, SelfUpgradeProviderExecutionContext } from './types'
 import { BUILD_PACKAGE_NAME } from '../../generated/build-meta'
 import * as npmPm from '../../package-manager/npm'
+import { runManagedSelfInstall } from './managed-process'
 
 export const npmSelfUpgradeProvider: SelfUpgradeProvider = {
   source: 'npm',
   canHandle: context => getInstallSource(context) === 'npm',
   getRecoveryHint: inspection =>
     `npm install -g ${BUILD_PACKAGE_NAME}@${inspection.updateChannel === 'beta' ? 'beta' : 'latest'}`,
-  async upgrade(plan: SelfUpgradePlan): Promise<SelfUpdateResult> {
-    const success = await npmPm.install(
-      BUILD_PACKAGE_NAME,
-      plan.target.packageTag ?? (plan.facts.updateChannel === 'beta' ? 'beta' : 'latest'),
-      plan.target.managedRegistry,
-    )
+  async upgrade(plan: SelfUpgradePlan, context?: SelfUpgradeProviderExecutionContext): Promise<SelfUpdateResult> {
+    const tag = plan.target.packageTag ?? (plan.facts.updateChannel === 'beta' ? 'beta' : 'latest')
+    const success = context?.process
+      ? await runManagedSelfInstall(
+          [
+            'npm',
+            'install',
+            '-g',
+            `${BUILD_PACKAGE_NAME}@${tag}`,
+            ...(plan.target.managedRegistry ? ['--registry', plan.target.managedRegistry] : []),
+          ],
+          context,
+        )
+      : await npmPm.install(BUILD_PACKAGE_NAME, tag, plan.target.managedRegistry)
     return {
       error: success
         ? undefined

--- a/src/self/providers/types.ts
+++ b/src/self/providers/types.ts
@@ -1,8 +1,17 @@
+import type { NetworkPort, ProcessPort, ProcessStdio } from '../../runtime'
 import type { SelfInspection, SelfInstallSource, SelfUpdateResult, SelfUpgradePlan } from '../types'
+
+export interface SelfUpgradeProviderExecutionContext {
+  readonly process?: ProcessPort
+  readonly network?: NetworkPort
+  readonly signal: AbortSignal
+  readonly stdio?: readonly [ProcessStdio, ProcessStdio, ProcessStdio]
+  readonly timeoutMs?: number
+}
 
 export interface SelfUpgradeProvider {
   canHandle: (context: SelfInspection | SelfUpgradePlan) => boolean
   getRecoveryHint: (inspection: SelfInspection, result?: SelfUpdateResult) => string | undefined
-  upgrade: (plan: SelfUpgradePlan) => Promise<SelfUpdateResult>
+  upgrade: (plan: SelfUpgradePlan, context?: SelfUpgradeProviderExecutionContext) => Promise<SelfUpdateResult>
   source: SelfInstallSource
 }

--- a/src/self/release.ts
+++ b/src/self/release.ts
@@ -1,4 +1,5 @@
 import type { ProviderOperationContext } from '../providers'
+import type { NetworkPort } from '../runtime/ports'
 import type { SelfUpdateChannel } from './types'
 import { basename } from 'node:path'
 import process from 'node:process'
@@ -93,10 +94,12 @@ export async function fetchBinaryReleaseChecksum(assetName: string): Promise<str
 export async function fetchBinaryReleaseManifest(
   channel: SelfUpdateChannel,
   context?: ProviderOperationContext,
+  networkPort?: NetworkPort,
 ): Promise<BinaryReleaseManifest> {
-  const manifestUrl = await resolveBinaryReleaseManifestUrl(channel, context)
+  const manifestUrl = await resolveBinaryReleaseManifestUrl(channel, context, networkPort)
   const manifest = await fetchJsonWithCache<BinaryReleaseManifest>(manifestUrl, `self:manifest:${channel}`, {
     context,
+    networkPort,
   })
 
   if (!manifest) throw new Error('Failed to download release manifest.')
@@ -107,12 +110,13 @@ export async function fetchBinaryReleaseManifest(
 export async function resolveBinaryReleaseManifestUrl(
   channel: SelfUpdateChannel,
   context?: ProviderOperationContext,
+  networkPort?: NetworkPort,
 ): Promise<string> {
   if (!BUILD_REPOSITORY_URL) throw new Error('No repository URL is configured for Quantex releases.')
 
   if (channel === 'stable') return `${BUILD_REPOSITORY_URL}/releases/latest/download/manifest.json`
 
-  const release = await fetchGitHubReleaseSummary(channel, context)
+  const release = await fetchGitHubReleaseSummary(channel, context, networkPort)
   const manifestAsset = release.assets.find(asset => asset.name === 'manifest.json')
 
   if (!manifestAsset?.browser_download_url)
@@ -124,6 +128,7 @@ export async function resolveBinaryReleaseManifestUrl(
 export async function fetchGitHubReleaseSummary(
   channel: SelfUpdateChannel,
   context?: ProviderOperationContext,
+  networkPort?: NetworkPort,
 ): Promise<GitHubReleaseSummary> {
   const repositorySlug = getRepositorySlug()
 
@@ -132,7 +137,7 @@ export async function fetchGitHubReleaseSummary(
   const releases = await fetchJsonWithCache<GitHubReleaseSummary[]>(
     `https://api.github.com/repos/${repositorySlug}/releases?per_page=20`,
     'self:github-releases',
-    { context },
+    { context, networkPort },
   )
 
   if (!releases) throw new Error('Failed to query GitHub releases.')

--- a/src/self/state-persistence.ts
+++ b/src/self/state-persistence.ts
@@ -1,0 +1,92 @@
+import type { PersistencePort, RuntimeFailure, RuntimeOutcome } from '../runtime'
+import type { SelfInstallSource } from './types'
+import { getSelfState, removeSelfInstallSource, setSelfInstallSource } from '../state'
+
+export const SELF_INSTALL_SOURCE_PERSISTENCE_KEY = 'self:install-source'
+
+interface SelfInstallSourcePersistenceDependencies {
+  readonly clearInstallSource: () => Promise<void>
+  readonly getSelfState: typeof getSelfState
+  readonly setInstallSource: (installSource: SelfInstallSource) => Promise<void>
+}
+
+const DEFAULT_DEPENDENCIES: SelfInstallSourcePersistenceDependencies = {
+  clearInstallSource: removeSelfInstallSource,
+  getSelfState,
+  setInstallSource: setSelfInstallSource,
+}
+
+export function createSelfInstallSourcePersistencePort(
+  dependencies: SelfInstallSourcePersistenceDependencies = DEFAULT_DEPENDENCIES,
+): PersistencePort {
+  return {
+    async load(request) {
+      const invalid = validateRequest(request.key, request.signal)
+      if (invalid) return invalid
+
+      try {
+        const installSource = (await dependencies.getSelfState()).installSource
+        return success(
+          installSource === undefined
+            ? { kind: 'missing' as const }
+            : { kind: 'found' as const, snapshot: { value: installSource } },
+        )
+      } catch (error) {
+        return failed('Failed to read the persisted self install source.', error)
+      }
+    },
+    async remove(request) {
+      const invalid = validateRequest(request.key, request.signal)
+      if (invalid) return invalid
+
+      try {
+        await dependencies.clearInstallSource()
+        return success(undefined)
+      } catch (error) {
+        return failed('Failed to remove the persisted self install source.', error)
+      }
+    },
+    async save(request) {
+      const invalid = validateRequest(request.key, request.signal)
+      if (invalid) return invalid
+      if (!isSelfInstallSource(request.value)) {
+        return failure({ kind: 'invalid-data', message: 'The persisted self install source is invalid.' })
+      }
+
+      try {
+        await dependencies.setInstallSource(request.value)
+        return success({})
+      } catch (error) {
+        return failed('Failed to persist the self install source.', error)
+      }
+    },
+  }
+}
+
+function validateRequest(key: string, signal: AbortSignal): RuntimeOutcome<never> | undefined {
+  if (signal.aborted) return failure({ kind: 'cancelled', message: 'Self install-source persistence was cancelled.' })
+  if (key !== SELF_INSTALL_SOURCE_PERSISTENCE_KEY) {
+    return failure({ kind: 'invalid-data', message: `Unsupported self persistence key "${key}".` })
+  }
+  return undefined
+}
+
+function isSelfInstallSource(value: unknown): value is SelfInstallSource {
+  return value === 'binary' || value === 'bun' || value === 'npm' || value === 'source' || value === 'unknown'
+}
+
+function success<T>(value: T): RuntimeOutcome<T> {
+  return { kind: 'success', value }
+}
+
+function failure<T>(error: RuntimeFailure): RuntimeOutcome<T> {
+  return { error, kind: 'failure' }
+}
+
+function failed<T>(message: string, cause: unknown): RuntimeOutcome<T> {
+  return failure({
+    details: { cause },
+    kind: 'failed',
+    message,
+  })
+}

--- a/src/self/update-metadata.ts
+++ b/src/self/update-metadata.ts
@@ -1,0 +1,93 @@
+import type { CachePort, RuntimeOutcome } from '../runtime'
+import type { SelfInstallFacts, SelfInstallSource, SelfUpdateChannel } from './types'
+import { compareVersions } from '../utils/version'
+
+export const SELF_UPDATE_METADATA_SCHEMA_VERSION = 1 as const
+
+export interface SelfUpdateMetadata {
+  readonly canAutoUpdate: true
+  readonly expiresAtMs: number
+  readonly fetchedAtMs: number
+  readonly installSource: SelfInstallSource
+  readonly schemaVersion: typeof SELF_UPDATE_METADATA_SCHEMA_VERSION
+  readonly targetVersion: string
+  readonly updateChannel: SelfUpdateChannel
+}
+
+export function getSelfUpdateMetadataCacheKey(
+  facts: Pick<SelfInstallFacts, 'installSource' | 'updateChannel'>,
+): string {
+  return `self:update-metadata:${facts.installSource}:${facts.updateChannel}`
+}
+
+export function createSelfUpdateMetadata(input: {
+  readonly expiresAtMs: number
+  readonly facts: SelfInstallFacts
+  readonly fetchedAtMs: number
+  readonly targetVersion: string
+}): SelfUpdateMetadata {
+  return {
+    canAutoUpdate: true,
+    expiresAtMs: input.expiresAtMs,
+    fetchedAtMs: input.fetchedAtMs,
+    installSource: input.facts.installSource,
+    schemaVersion: SELF_UPDATE_METADATA_SCHEMA_VERSION,
+    targetVersion: input.targetVersion,
+    updateChannel: input.facts.updateChannel,
+  }
+}
+
+export function parseSelfUpdateMetadata(
+  value: unknown,
+  input: { readonly facts: SelfInstallFacts; readonly nowMs: number },
+): SelfUpdateMetadata | undefined {
+  if (!isRecord(value)) return undefined
+  if (value.schemaVersion !== SELF_UPDATE_METADATA_SCHEMA_VERSION) return undefined
+  if (value.canAutoUpdate !== true || !input.facts.canAutoUpdate) return undefined
+  if (value.installSource !== input.facts.installSource || value.updateChannel !== input.facts.updateChannel)
+    return undefined
+  if (typeof value.targetVersion !== 'string' || compareVersions(value.targetVersion, value.targetVersion) !== 0)
+    return undefined
+  if (!isTimestamp(value.fetchedAtMs) || !isTimestamp(value.expiresAtMs)) return undefined
+  if (value.fetchedAtMs > input.nowMs || value.expiresAtMs <= input.nowMs || value.fetchedAtMs >= value.expiresAtMs)
+    return undefined
+
+  return value as unknown as SelfUpdateMetadata
+}
+
+export async function readSelfUpdateMetadata(input: {
+  readonly cache: CachePort
+  readonly facts: SelfInstallFacts
+  readonly nowMs: number
+  readonly signal: AbortSignal
+}): Promise<SelfUpdateMetadata | undefined> {
+  const outcome = await input.cache.read({
+    key: getSelfUpdateMetadataCacheKey(input.facts),
+    signal: input.signal,
+  })
+  if (outcome.kind === 'failure' || outcome.value.kind === 'miss') return undefined
+  if (outcome.value.expiresAtMs !== undefined && outcome.value.expiresAtMs <= input.nowMs) return undefined
+
+  return parseSelfUpdateMetadata(outcome.value.value, input)
+}
+
+export function writeSelfUpdateMetadata(input: {
+  readonly cache: CachePort
+  readonly metadata: SelfUpdateMetadata
+  readonly signal: AbortSignal
+}): Promise<RuntimeOutcome<void>> {
+  return input.cache.write({
+    expiresAtMs: input.metadata.expiresAtMs,
+    key: getSelfUpdateMetadataCacheKey(input.metadata),
+    signal: input.signal,
+    value: input.metadata,
+  })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+}

--- a/src/self/update-notice.ts
+++ b/src/self/update-notice.ts
@@ -1,37 +1,56 @@
+import type { CachePort } from '../runtime'
+import type { SelfInstallFacts } from './types'
 import { getCliContext } from '../cli-context'
+import { createVersionCachePort } from '../runtime'
 import { getSelfState } from '../state'
 import { pc } from '../utils/color'
 import { printInfo } from '../utils/user-output'
 import { isVersionNewer } from '../utils/version'
-import { inspectSelfReadOnly } from './index'
+import { resolveSelfInstallFactsReadOnly } from './facts'
+import { readSelfUpdateMetadata } from './update-metadata'
 
 const UPDATE_NOTICE_THROTTLE_MS = 24 * 60 * 60 * 1000
 const SELF_UPGRADE_NOTICE_SKIPPED_ACTIONS = new Set(['doctor', 'upgrade'])
 
-export async function maybeRenderSelfUpdateNotice(options: { action: string; ok: boolean }): Promise<void> {
+interface SelfUpdateNoticeDependencies {
+  readonly cache: CachePort
+  readonly getSelfState: typeof getSelfState
+  readonly now: () => number
+  readonly resolveFacts: () => Promise<SelfInstallFacts>
+}
+
+export async function maybeRenderSelfUpdateNotice(
+  options: { action: string; ok: boolean },
+  dependencies: SelfUpdateNoticeDependencies = {
+    cache: createVersionCachePort(),
+    getSelfState,
+    now: Date.now,
+    resolveFacts: resolveSelfInstallFactsReadOnly,
+  },
+): Promise<void> {
   if (!options.ok || SELF_UPGRADE_NOTICE_SKIPPED_ACTIONS.has(options.action)) return
 
   const context = getCliContext()
   if (context.outputMode !== 'human' || context.quiet) return
 
-  const inspection = await inspectSelfReadOnly()
-  if (!inspection.latestVersion || !isVersionNewer(inspection.latestVersion, inspection.currentVersion)) return
+  const facts = await dependencies.resolveFacts()
+  const now = dependencies.now()
+  const metadata = await readSelfUpdateMetadata({
+    cache: dependencies.cache,
+    facts,
+    nowMs: now,
+    signal: new AbortController().signal,
+  })
+  if (!metadata || !isVersionNewer(metadata.targetVersion, facts.currentVersion)) return
 
-  const selfState = await getSelfState()
-  const now = Date.now()
+  const selfState = await dependencies.getSelfState()
 
-  if (
-    shouldSuppressUpdateNotice(selfState.updateNoticeVersion, selfState.updateNoticeAt, inspection.latestVersion, now)
-  )
+  if (shouldSuppressUpdateNotice(selfState.updateNoticeVersion, selfState.updateNoticeAt, metadata.targetVersion, now))
     return
 
-  const nextStep = inspection.canAutoUpdate
-    ? 'Run `quantex upgrade`.'
-    : 'Run `quantex doctor` for source-specific update steps.'
+  const nextStep = 'Run `quantex upgrade`.'
   printInfo(
-    pc.yellow(
-      `Quantex CLI ${inspection.latestVersion} is available (current ${inspection.currentVersion}). ${nextStep}`,
-    ),
+    pc.yellow(`Quantex CLI ${metadata.targetVersion} is available (current ${facts.currentVersion}). ${nextStep}`),
   )
 }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -15,3 +15,4 @@ export {
 } from './lifecycle-execution-production'
 export { getSingleAgentUpdateStatus, planAgentUpdates } from './update'
 export type { ManagedUpdateBucket, PendingAgentUpdate, PlannedAgentUpdates, SingleAgentUpdateStatus } from './update'
+export { createProductionSelfUpgradeInvocation, type ProductionSelfUpgradeInvocation } from './self-upgrade-production'

--- a/src/services/self-upgrade-production.ts
+++ b/src/services/self-upgrade-production.ts
@@ -1,0 +1,82 @@
+import type { RuntimeOutcome, RuntimePorts } from '../runtime'
+import type {
+  SelfUpgradeApplicationInput,
+  SelfUpgradeApplicationOutcome,
+  SelfUpgradeApplicationPorts,
+} from '../self/application'
+import { getCliContext, registerCliCancellationHandler } from '../cli-context'
+import {
+  createChildProcessPort,
+  createFetchNetworkPort,
+  createInvocationContext,
+  createVersionCachePort,
+} from '../runtime'
+import * as selfModule from '../self'
+import { runSelfUpgradeApplication } from '../self/application'
+import { createSelfInstallSourcePersistencePort } from '../self/state-persistence'
+
+export interface ProductionSelfUpgradeInvocation {
+  dispose(): void
+  run(input: SelfUpgradeApplicationInput): Promise<SelfUpgradeApplicationOutcome>
+}
+
+export function createProductionSelfUpgradeInvocation(): ProductionSelfUpgradeInvocation {
+  const cliContext = getCliContext()
+  const invocation = createInvocationContext({
+    cacheMode: cliContext.cacheMode,
+    dryRun: cliContext.dryRun,
+    outputMode: cliContext.outputMode,
+    ports: createSelfUpgradeRuntimePorts(),
+    quiet: cliContext.quiet,
+    timeoutMs: cliContext.timeoutMs,
+  })
+  if (cliContext.cancelled) void invocation.cancel('cancelled')
+  const unregister = registerCliCancellationHandler(() => invocation.cancel('cancelled'))
+  let disposed = false
+
+  const applicationPorts: SelfUpgradeApplicationPorts = {
+    plan: input =>
+      selfModule.planSelfUpgrade({
+        context: input.context,
+        metadataCache: input.metadataCache,
+        networkPort: input.networkPort,
+        persistencePort: input.persistencePort,
+        updateChannel: input.updateChannel,
+      }),
+    upgrade: (plan, input) => selfModule.upgradeSelf(plan, input),
+  }
+
+  return {
+    dispose(): void {
+      if (disposed) return
+      disposed = true
+      unregister()
+    },
+    run: input => runSelfUpgradeApplication(input, invocation, applicationPorts),
+  }
+}
+
+function createSelfUpgradeRuntimePorts(): RuntimePorts {
+  return {
+    cache: createVersionCachePort(),
+    clock: { now: Date.now, sleep: unavailable },
+    fileSystem: {
+      makeDirectory: unavailable,
+      readFile: unavailable,
+      remove: unavailable,
+      rename: unavailable,
+      writeFile: unavailable,
+    },
+    locks: selfModule.createSelfUpgradeLockPort(),
+    network: createFetchNetworkPort(),
+    persistence: createSelfInstallSourcePersistencePort(),
+    process: createChildProcessPort(),
+  }
+}
+
+async function unavailable(): Promise<RuntimeOutcome<never>> {
+  return {
+    error: { kind: 'unavailable', message: 'Runtime port is not bound for this self-upgrade operation.' },
+    kind: 'failure',
+  }
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -8,6 +8,7 @@ export {
   loadState,
   removeInstalledAgentState,
   removeLifecycleReceipt,
+  removeSelfInstallSource,
   saveState,
   setInstalledAgentState,
   setLifecycleReceipt,

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -123,6 +123,12 @@ export async function setSelfInstallSource(installSource: SelfInstallSource): Pr
   })
 }
 
+export async function removeSelfInstallSource(): Promise<void> {
+  await mutateState(state => {
+    delete state.self.installSource
+  })
+}
+
 export async function setSelfUpdateNoticeState(updateNoticeVersion: string, updateNoticeAt: string): Promise<void> {
   await mutateState(state => {
     state.self.updateNoticeVersion = updateNoticeVersion

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,4 +1,5 @@
 import type { ProviderOperationContext } from '../providers'
+import type { NetworkPort } from '../runtime/ports'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { getCliContext, recordCliFreshness } from '../cli-context'
@@ -18,6 +19,7 @@ interface CachedResponseStore {
 
 interface NetworkOperationOptions {
   context?: ProviderOperationContext
+  networkPort?: NetworkPort
   signal?: AbortSignal
 }
 
@@ -81,6 +83,7 @@ export async function fetchTextWithCache(
     context: options.context,
     headers: cacheMode !== 'no-cache' && cachedEntry?.etag ? { 'If-None-Match': cachedEntry.etag } : undefined,
     mode,
+    networkPort: options.networkPort,
     retries: config.networkRetries,
     signal,
     timeoutMs: config.networkTimeoutMs,
@@ -151,6 +154,7 @@ async function fetchTextWithRetries(
     context?: ProviderOperationContext
     headers?: Record<string, string>
     mode: 'json' | 'text'
+    networkPort?: NetworkPort
     retries: number
     signal?: AbortSignal
     timeoutMs: number
@@ -177,10 +181,14 @@ async function fetchTextAttempt(
     headers?: Record<string, string>
     invocationDeadline?: number
     mode: 'json' | 'text'
+    networkPort?: NetworkPort
     signal?: AbortSignal
     timeoutMs: number
   },
 ): Promise<FetchedTextResponse> {
+  const networkPort = options.networkPort
+  if (networkPort) return fetchTextAttemptWithPort(url, { ...options, networkPort })
+
   const controller = new AbortController()
   let reader: { cancel(reason?: unknown): Promise<void> } | undefined
   let response: Response | undefined
@@ -281,6 +289,56 @@ async function fetchTextAttempt(
     if (invocationTimeout) clearTimeout(invocationTimeout)
     options.signal?.removeEventListener('abort', abort)
     unregisterCleanup?.()
+  }
+}
+
+async function fetchTextAttemptWithPort(
+  url: string,
+  options: {
+    context?: ProviderOperationContext
+    headers?: Record<string, string>
+    invocationDeadline?: number
+    mode: 'json' | 'text'
+    networkPort: NetworkPort
+    signal?: AbortSignal
+    timeoutMs: number
+  },
+): Promise<FetchedTextResponse> {
+  if (options.signal?.aborted) throw cancelledError(options.signal)
+  const now = Date.now()
+  if (options.invocationDeadline !== undefined && options.invocationDeadline <= now)
+    throw new ProcessInterruptionError({ kind: 'timed-out', timeoutMs: options.context?.timeoutMs ?? 0 })
+  const timeoutMs =
+    options.invocationDeadline === undefined
+      ? options.timeoutMs
+      : Math.max(1, Math.min(options.timeoutMs, options.invocationDeadline - now))
+  const signal = options.signal ?? new AbortController().signal
+  const outcome = await options.networkPort.request({ headers: options.headers, signal, timeoutMs, url })
+  if (outcome.kind === 'failure') {
+    if (options.signal?.aborted || outcome.error.kind === 'cancelled') throw cancelledError(options.signal)
+    if (outcome.error.kind === 'timed-out') {
+      if (options.invocationDeadline !== undefined && Date.now() >= options.invocationDeadline)
+        throw new ProcessInterruptionError({ kind: 'timed-out', timeoutMs: options.context?.timeoutMs ?? 0 })
+      throw new NetworkAttemptTimeoutError(options.timeoutMs)
+    }
+    throw new Error(outcome.error.message)
+  }
+
+  const body = new TextDecoder().decode(outcome.value.body)
+  let valid = true
+  if (options.mode === 'json' && outcome.value.status >= 200 && outcome.value.status < 300) {
+    try {
+      JSON.parse(body)
+    } catch {
+      valid = false
+    }
+  }
+  return {
+    body: outcome.value.status >= 200 && outcome.value.status < 300 ? body : undefined,
+    etag: outcome.value.headers.etag,
+    ok: outcome.value.status >= 200 && outcome.value.status < 300,
+    status: outcome.value.status,
+    valid,
   }
 }
 

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -1,5 +1,6 @@
 import type { AgentVersionProbe } from '../agents'
 import type { ProviderOperationContext } from '../providers'
+import type { NetworkPort } from '../runtime/ports'
 import { realpath } from 'node:fs/promises'
 import process from 'node:process'
 import {
@@ -66,14 +67,14 @@ export async function getInstalledVersion(
 export async function getLatestVersion(
   packageName: string,
   distTag: string = 'latest',
-  options: { context?: ProviderOperationContext; registry?: string } = {},
+  options: { context?: ProviderOperationContext; networkPort?: NetworkPort; registry?: string } = {},
 ): Promise<string | undefined> {
   try {
     const registry = normalizeRegistryUrl(options.registry) ?? OFFICIAL_NPM_REGISTRY
     const data = await fetchJsonWithCache<{ version: string }>(
       buildRegistryPackageVersionUrl(packageName, distTag, registry),
       `npm:${registry}:${packageName}:${distTag}`,
-      { context: options.context },
+      { context: options.context, networkPort: options.networkPort },
     )
     if (options.context?.signal.aborted) throw cancelledError(options.context.signal)
     return data?.version

--- a/test/commands/upgrade.test.ts
+++ b/test/commands/upgrade.test.ts
@@ -265,7 +265,13 @@ describe('upgradeCommand', () => {
 
     await expect(upgradeCommand()).resolves.toMatchObject({ ok: true })
 
-    expect(upgradeSelfSpy).toHaveBeenCalledWith(plan)
+    expect(upgradeSelfSpy).toHaveBeenCalledWith(
+      plan,
+      expect.objectContaining({
+        lockPort: expect.objectContaining({ acquire: expect.any(Function) }),
+        signal: expect.any(AbortSignal),
+      }),
+    )
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('Upgrading Quantex CLI'))
     expect(stdoutWriteSpy).toHaveBeenCalledWith(expect.stringContaining('upgraded successfully'))
   })

--- a/test/runtime/child-process.test.ts
+++ b/test/runtime/child-process.test.ts
@@ -1,0 +1,101 @@
+import type { SpawnedProcessHandle } from '../../src/utils/child-process'
+import { describe, expect, it, vi } from 'vitest'
+import { createChildProcessPort } from '../../src/runtime/child-process'
+
+describe('createChildProcessPort', () => {
+  it('captures piped output without forwarding it to a presentation stream', async () => {
+    const spawn = vi.fn(() => completedHandle(0, '1.2.3\n', 'warning\n'))
+    const writeStderr = vi.fn()
+    const port = createChildProcessPort({ platform: 'linux', spawn, terminate: vi.fn(), writeStderr })
+
+    await expect(
+      port.run({
+        argv: ['qtx', '--version'],
+        signal: new AbortController().signal,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+    ).resolves.toEqual({
+      kind: 'success',
+      value: {
+        exitCode: 0,
+        stderr: new TextEncoder().encode('warning\n'),
+        stdout: new TextEncoder().encode('1.2.3\n'),
+      },
+    })
+    expect(spawn).toHaveBeenCalledWith(['qtx', '--version'], {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    expect(writeStderr).not.toHaveBeenCalled()
+  })
+
+  it('forwards explicitly requested piped diagnostics to stderr', async () => {
+    const writeStderr = vi.fn()
+    const port = createChildProcessPort({
+      platform: 'linux',
+      spawn: vi.fn(() => completedHandle(1, 'install progress\n', 'install failed\n')),
+      terminate: vi.fn(),
+      writeStderr,
+    })
+
+    await port.run({
+      argv: ['npm', 'install', '-g', 'quantex-cli'],
+      forwardPipedOutput: true,
+      signal: new AbortController().signal,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    expect(writeStderr.mock.calls.map(([value]) => value)).toEqual(['install progress\n', 'install failed\n'])
+  })
+
+  it('terminates the child when cancellation wins', async () => {
+    const controller = new AbortController()
+    const child = deferredHandle()
+    const terminate = vi.fn(async () => child.resolve(143))
+    const port = createChildProcessPort({ platform: 'linux', spawn: vi.fn(() => child.handle), terminate })
+
+    const running = port.run({ argv: ['npm', 'install'], signal: controller.signal })
+    controller.abort('cancelled install')
+
+    await expect(running).resolves.toEqual({
+      error: { kind: 'cancelled', message: 'cancelled install' },
+      kind: 'failure',
+    })
+    expect(terminate).toHaveBeenCalledWith(child.handle)
+  })
+})
+
+function completedHandle(exitCode: number, stdout = '', stderr = ''): SpawnedProcessHandle {
+  return {
+    exitCode,
+    exited: Promise.resolve(exitCode),
+    kill: vi.fn(),
+    stderr: stderr as never,
+    stdout: stdout as never,
+    unref: vi.fn(),
+  }
+}
+
+function deferredHandle(): { handle: SpawnedProcessHandle; resolve(exitCode: number): void } {
+  let exitCode: number | null = null
+  let resolve!: (value: number) => void
+  const exited = new Promise<number>(complete => {
+    resolve = value => {
+      exitCode = value
+      complete(value)
+    }
+  })
+  return {
+    handle: {
+      get exitCode() {
+        return exitCode
+      },
+      exited,
+      kill: vi.fn(),
+      stderr: '' as never,
+      stdout: '' as never,
+      unref: vi.fn(),
+    },
+    resolve,
+  }
+}

--- a/test/runtime/fetch-network.test.ts
+++ b/test/runtime/fetch-network.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createFetchNetworkPort } from '../../src/runtime/fetch-network'
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('createFetchNetworkPort', () => {
+  it('returns status, normalized headers, and response bytes', async () => {
+    const fetch = vi.fn(
+      async () =>
+        new Response('{"version":"1.2.3"}', {
+          headers: { 'content-type': 'application/json', etag: 'test-etag' },
+          status: 200,
+        }),
+    )
+    const port = createFetchNetworkPort({ fetch })
+
+    const outcome = await port.request({
+      headers: { 'if-none-match': 'old-etag' },
+      signal: new AbortController().signal,
+      timeoutMs: 1_000,
+      url: 'https://registry.example/quantex/latest',
+    })
+
+    expect(outcome).toEqual({
+      kind: 'success',
+      value: {
+        body: new TextEncoder().encode('{"version":"1.2.3"}'),
+        headers: expect.objectContaining({ 'content-type': 'application/json', etag: 'test-etag' }),
+        status: 200,
+      },
+    })
+    expect(fetch).toHaveBeenCalledWith(
+      'https://registry.example/quantex/latest',
+      expect.objectContaining({ headers: { 'if-none-match': 'old-etag' }, signal: expect.any(AbortSignal) }),
+    )
+  })
+
+  it('returns cancellation without waiting for an uncooperative fetch', async () => {
+    const controller = new AbortController()
+    const port = createFetchNetworkPort({ fetch: vi.fn(() => new Promise<Response>(() => {})) })
+    const running = port.request({ signal: controller.signal, url: 'https://registry.example/hang' })
+    controller.abort('cancelled request')
+
+    await expect(running).resolves.toEqual({
+      error: { kind: 'cancelled', message: 'cancelled request' },
+      kind: 'failure',
+    })
+  })
+
+  it('returns a typed timeout and aborts the underlying request', async () => {
+    vi.useFakeTimers()
+    let fetchSignal: AbortSignal | undefined
+    const port = createFetchNetworkPort({
+      fetch: vi.fn((_url, init) => {
+        fetchSignal = init?.signal as AbortSignal
+        return new Promise<Response>(() => {})
+      }),
+    })
+    const running = port.request({
+      signal: new AbortController().signal,
+      timeoutMs: 25,
+      url: 'https://registry.example/hang',
+    })
+    await vi.advanceTimersByTimeAsync(25)
+
+    await expect(running).resolves.toEqual({
+      error: { kind: 'timed-out', message: 'Network request timed out after 25ms.' },
+      kind: 'failure',
+    })
+    expect(fetchSignal?.aborted).toBe(true)
+  })
+})

--- a/test/self-binary.test.ts
+++ b/test/self-binary.test.ts
@@ -1,7 +1,8 @@
+import type { NetworkPort } from '../src/runtime'
 import { Buffer } from 'node:buffer'
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { chmod, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -65,6 +66,75 @@ describe('upgradeStandaloneBinary', () => {
         stdio: ['ignore', 'ignore', 'ignore'],
         windowsHide: true,
       })
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('escapes apostrophes in Windows delayed replacement paths', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'quantex-binary-win-escape-'))
+    const escapedDirectory = join(tempRoot, "release's bin")
+    const executablePath = join(escapedDirectory, 'qtx.exe')
+    const mockSpawn = vi.fn().mockReturnValue({
+      exitCode: 0,
+      exited: Promise.resolve(0),
+      unref: vi.fn(),
+    })
+
+    Bun.spawn = mockSpawn as typeof Bun.spawn
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    await mkdir(escapedDirectory)
+    await writeFile(executablePath, 'old-binary', 'utf8')
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(Buffer.from('new-binary'), { status: 200 })) as unknown as typeof fetch
+    const checksum = createHash('sha256').update('new-binary').digest('hex')
+
+    try {
+      expect(await upgradeStandaloneBinary('https://example.com/qtx.exe', executablePath, checksum)).toEqual({
+        success: true,
+      })
+
+      const [command] = mockSpawn.mock.calls[0] as [string[], Record<string, unknown>]
+      const script = command[command.length - 1] as string
+      expect(script).toContain("release''s bin")
+      expect(script).not.toContain("$targetPath = '" + executablePath + "'")
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('does not schedule Windows replacement after post-download cancellation', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'quantex-binary-win-cancel-'))
+    const executablePath = join(tempRoot, 'qtx.exe')
+    const controller = new AbortController()
+    const mockSpawn = vi.fn()
+    const binary = new TextEncoder().encode('new-binary')
+    const networkPort: NetworkPort = {
+      request: async () => {
+        controller.abort('cancel after download')
+        return { kind: 'success', value: { body: binary, headers: {}, status: 200 } }
+      },
+    }
+
+    Bun.spawn = mockSpawn as typeof Bun.spawn
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    await writeFile(executablePath, 'old-binary', 'utf8')
+
+    try {
+      await expect(
+        upgradeStandaloneBinary(
+          'https://example.com/qtx.exe',
+          executablePath,
+          createHash('sha256').update(binary).digest('hex'),
+          '1.2.3',
+          undefined,
+          { networkPort, signal: controller.signal },
+        ),
+      ).rejects.toMatchObject({ kind: 'cancelled' })
+      expect(mockSpawn).not.toHaveBeenCalled()
+      expect(await readFile(executablePath, 'utf8')).toBe('old-binary')
+      expect(await readdir(tempRoot)).toEqual(['qtx.exe'])
     } finally {
       await rm(tempRoot, { recursive: true, force: true })
     }

--- a/test/self-update-metadata.test.ts
+++ b/test/self-update-metadata.test.ts
@@ -1,0 +1,212 @@
+import type { CachePort, RuntimeOutcome } from '../src/runtime'
+import type { SelfInstallFacts } from '../src/self'
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createVersionCachePort } from '../src/runtime'
+import { planSelfUpgrade } from '../src/self/planning'
+import {
+  createSelfUpdateMetadata,
+  getSelfUpdateMetadataCacheKey,
+  parseSelfUpdateMetadata,
+  readSelfUpdateMetadata,
+  writeSelfUpdateMetadata,
+} from '../src/self/update-metadata'
+
+const NOW = Date.parse('2026-07-15T10:00:00.000Z')
+const facts: SelfInstallFacts = {
+  canAutoUpdate: true,
+  currentVersion: '1.0.0',
+  executablePath: '/tmp/qtx',
+  installSource: 'npm',
+  packageRoot: '/tmp/quantex-cli',
+  updateChannel: 'stable',
+}
+
+describe('self update metadata', () => {
+  it('accepts a valid unexpired record for the exact install source and channel', () => {
+    const metadata = createSelfUpdateMetadata({
+      expiresAtMs: NOW + 60_000,
+      facts,
+      fetchedAtMs: NOW,
+      targetVersion: '1.1.0',
+    })
+
+    expect(parseSelfUpdateMetadata(metadata, { facts, nowMs: NOW })).toEqual(metadata)
+  })
+
+  it.each([
+    ['expired', { expiresAtMs: NOW }],
+    ['invalid version', { targetVersion: 'latest' }],
+    ['wrong channel', { updateChannel: 'beta' }],
+    ['wrong source', { installSource: 'bun' }],
+    ['not installable', { canAutoUpdate: false }],
+    ['future fetch time', { fetchedAtMs: NOW + 1 }],
+    ['unknown schema', { schemaVersion: 2 }],
+  ])('rejects %s metadata', (_label, override) => {
+    const metadata = {
+      ...createSelfUpdateMetadata({
+        expiresAtMs: NOW + 60_000,
+        facts,
+        fetchedAtMs: NOW,
+        targetVersion: '1.1.0',
+      }),
+      ...override,
+    }
+
+    expect(parseSelfUpdateMetadata(metadata, { facts, nowMs: NOW })).toBeUndefined()
+  })
+
+  it('reads only the exact metadata key and treats cache failures as absence', async () => {
+    const requests: string[] = []
+    const failingCache = createFakeCache({
+      read: request => {
+        requests.push(request.key)
+        return Promise.resolve({
+          error: { kind: 'failed', message: 'cache unavailable' },
+          kind: 'failure',
+        })
+      },
+    })
+
+    await expect(
+      readSelfUpdateMetadata({ cache: failingCache, facts, nowMs: NOW, signal: new AbortController().signal }),
+    ).resolves.toBeUndefined()
+    expect(requests).toEqual([getSelfUpdateMetadataCacheKey(facts)])
+  })
+
+  it('writes the typed record with the same expiry used by the cache port', async () => {
+    const writes: Array<{ expiresAtMs?: number; key: string; value: unknown }> = []
+    const cache = createFakeCache({
+      write: request => {
+        writes.push(request)
+        return Promise.resolve({ kind: 'success', value: undefined })
+      },
+    })
+
+    const metadata = createSelfUpdateMetadata({
+      expiresAtMs: NOW + 60_000,
+      facts,
+      fetchedAtMs: NOW,
+      targetVersion: '1.1.0',
+    })
+    await writeSelfUpdateMetadata({ cache, metadata, signal: new AbortController().signal })
+
+    expect(writes).toEqual([
+      {
+        expiresAtMs: metadata.expiresAtMs,
+        key: getSelfUpdateMetadataCacheKey(facts),
+        signal: expect.any(AbortSignal),
+        value: metadata,
+      },
+    ])
+  })
+
+  it('records metadata only when an explicit plan resolves an installable target', async () => {
+    const writes: Array<{ expiresAtMs?: number; key: string; value: unknown }> = []
+    const cache = createFakeCache({
+      write: request => {
+        writes.push(request)
+        return Promise.resolve({ kind: 'success', value: undefined })
+      },
+    })
+
+    await planSelfUpgrade({
+      facts,
+      metadataCache: cache,
+      metadataTtlMs: 60_000,
+      nowMs: NOW,
+      target: { packageTag: 'latest', targetVersion: '1.1.0' },
+    })
+
+    expect(writes).toHaveLength(1)
+    expect(writes[0]).toMatchObject({
+      expiresAtMs: NOW + 60_000,
+      key: getSelfUpdateMetadataCacheKey(facts),
+      value: { targetVersion: '1.1.0' },
+    })
+  })
+})
+
+describe('createVersionCachePort', () => {
+  const directories: string[] = []
+
+  afterEach(async () => {
+    const { rm } = await import('node:fs/promises')
+    await Promise.all(directories.splice(0).map(path => rm(path, { force: true, recursive: true })))
+  })
+
+  it('round-trips unknown values through the existing versions cache document', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'qtx-version-cache-'))
+    directories.push(directory)
+    const filePath = join(directory, 'versions.json')
+    const cache = createVersionCachePort({ filePath, getCacheMode: () => 'default', now: () => NOW })
+    const signal = new AbortController().signal
+
+    await expect(
+      cache.write({ expiresAtMs: NOW + 60_000, key: 'self:update', signal, value: { version: '1.1.0' } }),
+    ).resolves.toEqual({ kind: 'success', value: undefined })
+    await expect(cache.read({ key: 'self:update', signal })).resolves.toEqual({
+      kind: 'success',
+      value: { expiresAtMs: NOW + 60_000, kind: 'hit', value: { version: '1.1.0' } },
+    })
+
+    expect(JSON.parse(await readFile(filePath, 'utf8'))).toMatchObject({
+      entries: {
+        'self:update': {
+          body: '{"version":"1.1.0"}',
+          expiresAt: NOW + 60_000,
+        },
+      },
+    })
+  })
+
+  it('returns an expired entry as a miss without rewriting the cache file', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'qtx-version-cache-'))
+    directories.push(directory)
+    const filePath = join(directory, 'versions.json')
+    let now = NOW
+    const cache = createVersionCachePort({ filePath, getCacheMode: () => 'default', now: () => now })
+    const signal = new AbortController().signal
+    await cache.write({ expiresAtMs: NOW + 1, key: 'self:update', signal, value: { version: '1.1.0' } })
+    const before = await readFile(filePath, 'utf8')
+    now += 1
+
+    await expect(cache.read({ key: 'self:update', signal })).resolves.toEqual({
+      kind: 'success',
+      value: { kind: 'miss' },
+    })
+    expect(await readFile(filePath, 'utf8')).toBe(before)
+  })
+
+  it('does not read or create a cache document in no-cache mode', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'qtx-version-cache-'))
+    directories.push(directory)
+    const filePath = join(directory, 'versions.json')
+    const cache = createVersionCachePort({ filePath, getCacheMode: () => 'no-cache', now: () => NOW })
+    const signal = new AbortController().signal
+
+    await expect(cache.read({ key: 'self:update', signal })).resolves.toEqual({
+      kind: 'success',
+      value: { kind: 'miss' },
+    })
+    await expect(
+      cache.write({ expiresAtMs: NOW + 60_000, key: 'self:update', signal, value: { version: '1.1.0' } }),
+    ).resolves.toEqual({ kind: 'success', value: undefined })
+
+    await expect(readFile(filePath, 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})
+
+function createFakeCache(overrides: Partial<CachePort> = {}): CachePort {
+  return {
+    read: request => overrides.read?.(request) ?? success({ kind: 'miss' }),
+    remove: request => overrides.remove?.(request) ?? success(undefined),
+    write: request => overrides.write?.(request) ?? success(undefined),
+  }
+}
+
+function success<T>(value: T): Promise<RuntimeOutcome<T>> {
+  return Promise.resolve({ kind: 'success', value })
+}

--- a/test/self-update-notice.test.ts
+++ b/test/self-update-notice.test.ts
@@ -1,12 +1,23 @@
+import type { CacheLookup, CachePort } from '../src/runtime'
+import type { SelfInstallFacts } from '../src/self'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setCliContext } from '../src/cli-context'
 import * as selfModule from '../src/self'
+import { createSelfUpdateMetadata, getSelfUpdateMetadataCacheKey } from '../src/self/update-metadata'
 import { maybeRenderSelfUpdateNotice } from '../src/self/update-notice'
 import * as state from '../src/state'
 
 const inspectSelfSpy = vi.spyOn(selfModule, 'inspectSelfReadOnly')
-const getSelfStateSpy = vi.spyOn(state, 'getSelfState')
 const setSelfUpdateNoticeStateSpy = vi.spyOn(state, 'setSelfUpdateNoticeState')
+const NOW = Date.parse('2026-07-15T10:00:00.000Z')
+const facts: SelfInstallFacts = {
+  canAutoUpdate: true,
+  currentVersion: '0.15.0',
+  executablePath: '/Users/test/.bun/bin/qtx',
+  installSource: 'bun',
+  packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
+  updateChannel: 'stable',
+}
 
 describe('maybeRenderSelfUpdateNotice', () => {
   let stdoutWriteSpy: ReturnType<typeof vi.spyOn>
@@ -14,9 +25,7 @@ describe('maybeRenderSelfUpdateNotice', () => {
   beforeEach(() => {
     stdoutWriteSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
     inspectSelfSpy.mockClear()
-    getSelfStateSpy.mockClear()
     setSelfUpdateNoticeStateSpy.mockClear()
-    getSelfStateSpy.mockResolvedValue({})
     setCliContext({
       colorMode: 'never',
       interactive: true,
@@ -29,42 +38,70 @@ describe('maybeRenderSelfUpdateNotice', () => {
     stdoutWriteSpy.mockRestore()
   })
 
-  it('suppresses passive notices when latest version is lower than current', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '0.15.0',
-      executablePath: '/Users/test/.bun/bin/qtx',
-      installSource: 'bun',
-      latestVersion: '0.14.0',
-      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-    })
+  it('suppresses passive notices when cached latest version is lower than current', async () => {
+    const cache = createMetadataCache('0.14.0')
 
-    await maybeRenderSelfUpdateNotice({ action: 'list', ok: true })
+    await maybeRenderSelfUpdateNotice(
+      { action: 'list', ok: true },
+      { cache, getSelfState: async () => ({}), now: () => NOW, resolveFacts: async () => facts },
+    )
 
     expect(stdoutWriteSpy).not.toHaveBeenCalled()
+    expect(inspectSelfSpy).not.toHaveBeenCalled()
     expect(setSelfUpdateNoticeStateSpy).not.toHaveBeenCalled()
   })
 
-  it('renders the exact latest-version notice without persisting notice state', async () => {
-    inspectSelfSpy.mockResolvedValue({
-      canAutoUpdate: true,
-      currentVersion: '0.15.0',
-      executablePath: '/Users/test/.bun/bin/qtx',
-      installSource: 'bun',
-      latestVersion: '0.16.0',
-      packageRoot: '/Users/test/.bun/install/global/node_modules/quantex-cli',
-      recommendedUpgradeCommand: 'quantex upgrade',
-      updateChannel: 'stable',
-    })
+  it('renders the exact cached latest-version notice without fresh inspection or persistence', async () => {
+    const cache = createMetadataCache('0.16.0')
 
-    await maybeRenderSelfUpdateNotice({ action: 'list', ok: true })
+    await maybeRenderSelfUpdateNotice(
+      { action: 'list', ok: true },
+      { cache, getSelfState: async () => ({}), now: () => NOW, resolveFacts: async () => facts },
+    )
 
     expect(stdoutWriteSpy).toHaveBeenCalledOnce()
     expect(stdoutWriteSpy).toHaveBeenCalledWith(
       'Quantex CLI 0.16.0 is available (current 0.15.0). Run `quantex upgrade`.\n',
     )
+    expect(inspectSelfSpy).not.toHaveBeenCalled()
+    expect(setSelfUpdateNoticeStateSpy).not.toHaveBeenCalled()
+  })
+
+  it('stays silent on cache miss without attempting a fresh inspection', async () => {
+    const cache = createCache({ kind: 'miss' })
+
+    await maybeRenderSelfUpdateNotice(
+      { action: 'list', ok: true },
+      { cache, getSelfState: async () => ({}), now: () => NOW, resolveFacts: async () => facts },
+    )
+
+    expect(stdoutWriteSpy).not.toHaveBeenCalled()
+    expect(inspectSelfSpy).not.toHaveBeenCalled()
     expect(setSelfUpdateNoticeStateSpy).not.toHaveBeenCalled()
   })
 })
+
+function createMetadataCache(targetVersion: string): CachePort {
+  const metadata = createSelfUpdateMetadata({
+    expiresAtMs: NOW + 60_000,
+    facts,
+    fetchedAtMs: NOW,
+    targetVersion,
+  })
+  return createCache({ expiresAtMs: metadata.expiresAtMs, kind: 'hit', value: metadata })
+}
+
+function createCache(lookup: CacheLookup): CachePort {
+  return {
+    read: async request => {
+      expect(request.key).toBe(getSelfUpdateMetadataCacheKey(facts))
+      return { kind: 'success', value: lookup }
+    },
+    remove: async () => {
+      throw new Error('passive notice must not remove cache entries')
+    },
+    write: async () => {
+      throw new Error('passive notice must not write cache entries')
+    },
+  }
+}

--- a/test/self/application.test.ts
+++ b/test/self/application.test.ts
@@ -1,0 +1,145 @@
+import type { CacheLookup, RuntimeOutcome, RuntimePorts } from '../../src/runtime'
+import type { SelfUpgradePlan } from '../../src/self'
+import { describe, expect, it, vi } from 'vitest'
+import { createInvocationContext } from '../../src/runtime'
+import { runSelfUpgradeApplication } from '../../src/self/application'
+
+describe('runSelfUpgradeApplication', () => {
+  it.each([
+    ['check', { check: true, dryRun: false }, 'update-available'],
+    ['dry run', { check: false, dryRun: true }, 'update-available'],
+    ['up to date', { check: false, dryRun: false }, 'up-to-date'],
+    ['manual source', { check: false, dryRun: false }, 'manual-required'],
+    ['unavailable check', { check: false, dryRun: false }, 'check-unavailable'],
+  ] as const)('returns a plan without mutation for %s', async (_label, input, status) => {
+    const context = createInvocationContext({ ports: createFakeRuntimePorts() })
+    const plan = createPlan(status)
+    const upgrade = vi.fn()
+
+    await expect(
+      runSelfUpgradeApplication({ ...input, updateChannel: 'stable' }, context, { plan: async () => plan, upgrade }),
+    ).resolves.toEqual({ kind: 'planned', plan })
+    expect(upgrade).not.toHaveBeenCalled()
+  })
+
+  it('passes invocation cache, lock, signal, and timeout into planning and mutation in order', async () => {
+    const events: string[] = []
+    const runtimePorts = createFakeRuntimePorts()
+    const context = createInvocationContext({ ports: runtimePorts, timeoutMs: 1_500 })
+    const plan = createPlan('update-available')
+    const result = { installSource: 'npm' as const, newVersion: '1.1.0', success: true }
+
+    const outcome = await runSelfUpgradeApplication({ check: false, dryRun: false, updateChannel: 'stable' }, context, {
+      async plan(input) {
+        events.push('plan')
+        expect(input.context.signal).toBe(context.signal)
+        expect(input.context.timeoutMs).toBe(1_500)
+        expect(input.metadataCache).toBe(runtimePorts.cache)
+        expect(input.networkPort).toBe(runtimePorts.network)
+        expect(input.persistencePort).toBe(runtimePorts.persistence)
+        expect(input.updateChannel).toBe('stable')
+        return plan
+      },
+      async upgrade(receivedPlan, input) {
+        events.push('upgrade')
+        expect(receivedPlan).toBe(plan)
+        expect(input.lockPort).toBe(runtimePorts.locks)
+        expect(input.networkPort).toBe(runtimePorts.network)
+        expect(input.processPort).toBe(runtimePorts.process)
+        expect(input.signal).toBe(context.signal)
+        expect(input.stdio).toEqual(['inherit', 'inherit', 'inherit'])
+        expect(input.timeoutMs).toBe(1_500)
+        return result
+      },
+    })
+
+    expect(outcome).toEqual({ kind: 'executed', plan, result })
+    expect(events).toEqual(['plan', 'upgrade'])
+  })
+
+  it('returns typed interruption without planning when already cancelled', async () => {
+    const context = createInvocationContext({ ports: createFakeRuntimePorts() })
+    await context.cancel('test cancellation')
+    const plan = vi.fn()
+    const upgrade = vi.fn()
+
+    await expect(
+      runSelfUpgradeApplication({ check: false, dryRun: false, updateChannel: 'stable' }, context, { plan, upgrade }),
+    ).resolves.toEqual({
+      error: { kind: 'cancelled', message: 'Self-upgrade invocation was cancelled.' },
+      kind: 'interrupted',
+    })
+    expect(plan).not.toHaveBeenCalled()
+    expect(upgrade).not.toHaveBeenCalled()
+  })
+
+  it('does not mutate when cancellation arrives after planning', async () => {
+    const context = createInvocationContext({ ports: createFakeRuntimePorts() })
+    const plan = createPlan('update-available')
+    const upgrade = vi.fn()
+
+    const outcome = await runSelfUpgradeApplication({ check: false, dryRun: false, updateChannel: 'stable' }, context, {
+      async plan() {
+        await context.cancel('after-plan')
+        return plan
+      },
+      upgrade,
+    })
+
+    expect(outcome).toEqual({
+      error: { kind: 'cancelled', message: 'Self-upgrade invocation was cancelled.' },
+      kind: 'interrupted',
+      plan,
+    })
+    expect(upgrade).not.toHaveBeenCalled()
+  })
+})
+
+function createPlan(status: SelfUpgradePlan['status']): SelfUpgradePlan {
+  return {
+    facts: {
+      canAutoUpdate: status !== 'manual-required',
+      currentVersion: '1.0.0',
+      executablePath: '/tmp/qtx',
+      installSource: status === 'manual-required' ? 'source' : 'npm',
+      packageRoot: '/tmp/quantex-cli',
+      updateChannel: 'stable',
+    },
+    status,
+    target: { packageTag: 'latest', targetVersion: status === 'check-unavailable' ? undefined : '1.1.0' },
+    updateAvailable: status === 'update-available',
+  }
+}
+
+function createFakeRuntimePorts(): RuntimePorts {
+  return {
+    cache: {
+      read: async (): Promise<RuntimeOutcome<CacheLookup>> => success({ kind: 'miss' }),
+      remove: async () => success(undefined),
+      write: async () => success(undefined),
+    },
+    clock: { now: Date.now, sleep: unexpected },
+    fileSystem: {
+      makeDirectory: unexpected,
+      readFile: unexpected,
+      remove: unexpected,
+      rename: unexpected,
+      writeFile: unexpected,
+    },
+    locks: { acquire: unexpected },
+    network: { request: unexpected },
+    persistence: { load: unexpected, remove: unexpected, save: unexpected },
+    process: { run: unexpected },
+  }
+}
+
+async function unexpected(): Promise<RuntimeOutcome<never>> {
+  return {
+    error: { kind: 'failed', message: 'unexpected test port call' },
+    kind: 'failure',
+  }
+}
+
+function success<T>(value: T): RuntimeOutcome<T> {
+  return { kind: 'success', value }
+}

--- a/test/self/binary-ports.test.ts
+++ b/test/self/binary-ports.test.ts
@@ -1,0 +1,149 @@
+import type { NetworkPort, ProcessPort } from '../../src/runtime'
+import { createHash } from 'node:crypto'
+import { access, chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { upgradeStandaloneBinary } from '../../src/self/binary'
+
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(path => rm(path, { force: true, recursive: true })))
+})
+
+describe.skipIf(process.platform === 'win32')('standalone binary runtime ports', () => {
+  it('downloads and verifies through shared ports while preserving atomic replacement', async () => {
+    const directory = await createDirectory()
+    const executablePath = join(directory, 'qtx')
+    const nextBinary = new TextEncoder().encode('new binary')
+    await writeFile(executablePath, 'old binary')
+    await chmod(executablePath, 0o755)
+    const networkPort = createNetworkPort(nextBinary)
+    const run = vi.fn(async () => ({
+      kind: 'success' as const,
+      value: { exitCode: 0, stdout: new TextEncoder().encode('quantex 1.2.3\n') },
+    }))
+
+    await expect(
+      upgradeStandaloneBinary(
+        'https://releases.example/qtx',
+        executablePath,
+        checksum(nextBinary),
+        '1.2.3',
+        undefined,
+        {
+          networkPort,
+          processPort: { run },
+          signal: new AbortController().signal,
+          timeoutMs: 2_000,
+        },
+      ),
+    ).resolves.toEqual({ success: true })
+    expect(await readFile(executablePath, 'utf8')).toBe('new binary')
+    await expect(access(`${executablePath}.bak`)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(run).toHaveBeenCalledWith({
+      argv: [executablePath, '--version'],
+      signal: expect.any(AbortSignal),
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeoutMs: 2_000,
+    })
+  })
+
+  it('restores the original binary when port-driven verification fails', async () => {
+    const directory = await createDirectory()
+    const executablePath = join(directory, 'qtx')
+    const nextBinary = new TextEncoder().encode('new binary')
+    await writeFile(executablePath, 'old binary')
+    await chmod(executablePath, 0o755)
+    const processPort: ProcessPort = {
+      run: async () => ({
+        kind: 'success',
+        value: { exitCode: 0, stdout: new TextEncoder().encode('quantex 9.9.9\n') },
+      }),
+    }
+
+    await expect(
+      upgradeStandaloneBinary(
+        'https://releases.example/qtx',
+        executablePath,
+        checksum(nextBinary),
+        '1.2.3',
+        undefined,
+        {
+          networkPort: createNetworkPort(nextBinary),
+          processPort,
+          signal: new AbortController().signal,
+        },
+      ),
+    ).resolves.toMatchObject({ error: { kind: 'verify' }, success: false })
+    expect(await readFile(executablePath, 'utf8')).toBe('old binary')
+  })
+
+  it('preserves cancellation from the network port before filesystem mutation', async () => {
+    const directory = await createDirectory()
+    const executablePath = join(directory, 'qtx')
+    await writeFile(executablePath, 'old binary')
+    const networkPort: NetworkPort = {
+      request: async () => ({
+        error: { kind: 'cancelled', message: 'cancelled by caller' },
+        kind: 'failure',
+      }),
+    }
+
+    await expect(
+      upgradeStandaloneBinary('https://releases.example/qtx', executablePath, 'unused', '1.2.3', undefined, {
+        networkPort,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toMatchObject({ kind: 'cancelled' })
+    expect(await readFile(executablePath, 'utf8')).toBe('old binary')
+  })
+
+  it('restores the original binary and preserves verification timeout', async () => {
+    const directory = await createDirectory()
+    const executablePath = join(directory, 'qtx')
+    const nextBinary = new TextEncoder().encode('new binary')
+    await writeFile(executablePath, 'old binary')
+    await chmod(executablePath, 0o755)
+    const processPort: ProcessPort = {
+      run: async () => ({
+        error: { kind: 'timed-out', message: 'verification timed out' },
+        kind: 'failure',
+      }),
+    }
+
+    await expect(
+      upgradeStandaloneBinary(
+        'https://releases.example/qtx',
+        executablePath,
+        checksum(nextBinary),
+        '1.2.3',
+        undefined,
+        {
+          networkPort: createNetworkPort(nextBinary),
+          processPort,
+          signal: new AbortController().signal,
+          timeoutMs: 750,
+        },
+      ),
+    ).rejects.toMatchObject({ kind: 'timed-out', timeoutMs: 750 })
+    expect(await readFile(executablePath, 'utf8')).toBe('old binary')
+  })
+})
+
+function createNetworkPort(body: Uint8Array): NetworkPort {
+  return {
+    request: async () => ({ kind: 'success', value: { body, headers: {}, status: 200 } }),
+  }
+}
+
+async function createDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'qtx-binary-ports-'))
+  directories.push(directory)
+  return directory
+}
+
+function checksum(value: Uint8Array): string {
+  return createHash('sha256').update(value).digest('hex')
+}

--- a/test/self/managed-process.test.ts
+++ b/test/self/managed-process.test.ts
@@ -1,0 +1,185 @@
+import type { ProcessPort, RuntimeOutcome } from '../../src/runtime'
+import type { SelfUpgradePlan } from '../../src/self'
+import { describe, expect, it, vi } from 'vitest'
+import { verifySelfUpgradeResult } from '../../src/self/planning'
+import { bunSelfUpgradeProvider } from '../../src/self/providers/bun'
+import { npmSelfUpgradeProvider } from '../../src/self/providers/npm'
+import { ProcessInterruptionError } from '../../src/utils/child-process'
+
+describe('managed self-upgrade process ports', () => {
+  it('runs the exact npm global install argv through ProcessPort', async () => {
+    const run = vi.fn(async () => success({ exitCode: 0 }))
+    const processPort: ProcessPort = { run }
+    const plan = createPlan('npm')
+
+    await expect(
+      npmSelfUpgradeProvider.upgrade(plan, {
+        process: processPort,
+        signal: new AbortController().signal,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeoutMs: 2_000,
+      }),
+    ).resolves.toMatchObject({ installSource: 'npm', newVersion: '1.1.0', success: true })
+    expect(run).toHaveBeenCalledWith({
+      argv: ['npm', 'install', '-g', 'quantex-cli@beta', '--registry', 'https://registry.example'],
+      forwardPipedOutput: true,
+      signal: expect.any(AbortSignal),
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeoutMs: 2_000,
+    })
+  })
+
+  it('preserves Bun global trust checks after a successful install', async () => {
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce(success({ exitCode: 0 }))
+      .mockResolvedValueOnce(
+        success({ exitCode: 0, stdout: new TextEncoder().encode('./node_modules/quantex-cli @0.29.0\n') }),
+      )
+      .mockResolvedValueOnce(success({ exitCode: 0 }))
+
+    await expect(
+      bunSelfUpgradeProvider.upgrade(createPlan('bun'), {
+        process: { run },
+        signal: new AbortController().signal,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeoutMs: 2_000,
+      }),
+    ).resolves.toMatchObject({ installSource: 'bun', newVersion: '1.1.0', success: true })
+    expect(run.mock.calls.map(([request]) => request)).toEqual([
+      {
+        argv: ['bun', 'add', '-g', '--registry', 'https://registry.example', 'quantex-cli@beta'],
+        forwardPipedOutput: true,
+        signal: expect.any(AbortSignal),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeoutMs: 2_000,
+      },
+      {
+        argv: ['bun', 'pm', '-g', 'untrusted'],
+        forwardPipedOutput: false,
+        signal: expect.any(AbortSignal),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeoutMs: 2_000,
+      },
+      {
+        argv: ['bun', 'pm', '-g', 'trust', 'quantex-cli'],
+        forwardPipedOutput: true,
+        signal: expect.any(AbortSignal),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeoutMs: 2_000,
+      },
+    ])
+  })
+
+  it('rolls back the Bun global package when trust fails', async () => {
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce(success({ exitCode: 0 }))
+      .mockResolvedValueOnce(
+        success({ exitCode: 0, stdout: new TextEncoder().encode('./node_modules/quantex-cli @0.29.0\n') }),
+      )
+      .mockResolvedValueOnce(success({ exitCode: 1 }))
+      .mockResolvedValueOnce(success({ exitCode: 0 }))
+
+    await expect(
+      bunSelfUpgradeProvider.upgrade(createPlan('bun'), {
+        process: { run },
+        signal: new AbortController().signal,
+        stdio: ['inherit', 'inherit', 'inherit'],
+      }),
+    ).resolves.toMatchObject({ installSource: 'bun', success: false })
+    expect(run.mock.calls.at(-1)?.[0]).toMatchObject({
+      argv: ['bun', 'remove', '-g', 'quantex-cli'],
+      signal: expect.any(AbortSignal),
+    })
+    expect(run.mock.calls.at(-1)?.[0].signal.aborted).toBe(false)
+  })
+
+  it('maps a non-zero managed install exit to the existing provider failure', async () => {
+    const processPort: ProcessPort = { run: async () => success({ exitCode: 9 }) }
+
+    await expect(
+      npmSelfUpgradeProvider.upgrade(createPlan('npm'), {
+        process: processPort,
+        signal: new AbortController().signal,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }),
+    ).resolves.toMatchObject({ error: { kind: 'unknown' }, installSource: 'npm', success: false })
+  })
+
+  it('preserves cancellation as a process interruption', async () => {
+    const processPort: ProcessPort = {
+      run: async () => ({
+        error: { kind: 'cancelled', message: 'cancelled install' },
+        kind: 'failure',
+      }),
+    }
+
+    await expect(
+      bunSelfUpgradeProvider.upgrade(createPlan('bun'), {
+        process: processPort,
+        signal: new AbortController().signal,
+        stdio: ['inherit', 'inherit', 'inherit'],
+      }),
+    ).rejects.toMatchObject({ kind: 'cancelled' })
+  })
+
+  it('verifies the managed entry point then falls back to the executable through ProcessPort', async () => {
+    const run = vi
+      .fn()
+      .mockResolvedValueOnce(success({ exitCode: 1, stdout: new Uint8Array() }))
+      .mockResolvedValueOnce(success({ exitCode: 0, stdout: new TextEncoder().encode('quantex 1.1.0\n') }))
+    const plan = createPlan('npm')
+
+    await expect(
+      verifySelfUpgradeResult(
+        plan,
+        { installSource: 'npm', newVersion: '1.1.0', success: true },
+        { process: { run }, signal: new AbortController().signal, timeoutMs: 3_000 },
+      ),
+    ).resolves.toMatchObject({ newVersion: '1.1.0', success: true })
+    expect(run.mock.calls.map(([request]) => request.argv)).toEqual([
+      [process.execPath, '/tmp/quantex-cli/dist/cli.mjs', '--version'],
+      ['/tmp/qtx', '--version'],
+    ])
+  })
+
+  it('translates a timed-out verification into the existing interruption error', async () => {
+    const processPort: ProcessPort = {
+      run: async () => ({ error: { kind: 'timed-out', message: 'timed out' }, kind: 'failure' }),
+    }
+
+    await expect(
+      verifySelfUpgradeResult(
+        createPlan('npm'),
+        { installSource: 'npm', success: true },
+        { process: processPort, signal: new AbortController().signal, timeoutMs: 500 },
+      ),
+    ).rejects.toBeInstanceOf(ProcessInterruptionError)
+  })
+})
+
+function createPlan(installSource: 'bun' | 'npm'): SelfUpgradePlan {
+  return {
+    facts: {
+      canAutoUpdate: true,
+      currentVersion: '1.0.0',
+      executablePath: '/tmp/qtx',
+      installSource,
+      packageRoot: '/tmp/quantex-cli',
+      updateChannel: 'beta',
+    },
+    status: 'update-available',
+    target: {
+      managedRegistry: 'https://registry.example',
+      packageTag: 'beta',
+      targetVersion: '1.1.0',
+      verificationCommand: [process.execPath, '/tmp/quantex-cli/dist/cli.mjs', '--version'],
+    },
+    updateAvailable: true,
+  }
+}
+
+function success<T>(value: T): RuntimeOutcome<T> {
+  return { kind: 'success', value }
+}

--- a/test/self/network-port.test.ts
+++ b/test/self/network-port.test.ts
@@ -1,0 +1,51 @@
+import type { NetworkPort } from '../../src/runtime'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetCliContext, setCliContext } from '../../src/cli-context'
+import { fetchBinaryReleaseManifest } from '../../src/self/release'
+import { getLatestVersion } from '../../src/utils/version'
+
+describe('self-upgrade fresh checks through NetworkPort', () => {
+  beforeEach(() => {
+    setCliContext({ cacheMode: 'no-cache', interactive: false, outputMode: 'json', runId: 'self-network-port' })
+  })
+
+  afterEach(() => {
+    resetCliContext()
+  })
+
+  it('resolves registry metadata through the injected port', async () => {
+    const request = vi.fn(async () => ({
+      kind: 'success' as const,
+      value: {
+        body: new TextEncoder().encode('{"version":"1.2.3"}'),
+        headers: {},
+        status: 200,
+      },
+    }))
+
+    await expect(
+      getLatestVersion('quantex-cli', 'latest', {
+        networkPort: { request },
+        registry: 'https://registry.example',
+      }),
+    ).resolves.toBe('1.2.3')
+    expect(request).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+        url: 'https://registry.example/quantex-cli/latest',
+      }),
+    )
+  })
+
+  it('resolves a stable binary manifest through the injected port', async () => {
+    const manifest = { assets: [], channel: 'stable', version: '1.2.3' }
+    const port: NetworkPort = {
+      request: async () => ({
+        kind: 'success',
+        value: { body: new TextEncoder().encode(JSON.stringify(manifest)), headers: {}, status: 200 },
+      }),
+    }
+
+    await expect(fetchBinaryReleaseManifest('stable', undefined, port)).resolves.toEqual(manifest)
+  })
+})

--- a/test/self/persistence-port.test.ts
+++ b/test/self/persistence-port.test.ts
@@ -1,0 +1,133 @@
+import type { PersistencePort, RuntimeOutcome } from '../../src/runtime'
+import type { SelfInstallSource } from '../../src/self'
+import { describe, expect, it, vi } from 'vitest'
+import { reconcileSelfInstallSource, resolveSelfInstallFactsReadOnly } from '../../src/self/facts'
+import {
+  SELF_INSTALL_SOURCE_PERSISTENCE_KEY,
+  createSelfInstallSourcePersistencePort,
+} from '../../src/self/state-persistence'
+import { StateFileError } from '../../src/state'
+
+describe('self install-source persistence boundary', () => {
+  it('reconciles detected sources through the shared persistence port', async () => {
+    const save = vi.fn(async () => success({ revision: 'next' }))
+    const persistence = createFakePersistencePort({ save })
+
+    await expect(
+      reconcileSelfInstallSource(undefined, 'npm', {
+        persistence,
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toBe('npm')
+    expect(save).toHaveBeenCalledWith({
+      key: SELF_INSTALL_SOURCE_PERSISTENCE_KEY,
+      signal: expect.any(AbortSignal),
+      value: 'npm',
+    })
+  })
+
+  it('maps the legacy self state projection to load, save, and remove operations', async () => {
+    let installSource: SelfInstallSource | undefined = 'bun'
+    const persistence = createSelfInstallSourcePersistencePort({
+      clearInstallSource: async () => {
+        installSource = undefined
+      },
+      getSelfState: async () => ({ installSource }),
+      setInstallSource: async value => {
+        installSource = value
+      },
+    })
+    const signal = new AbortController().signal
+
+    await expect(persistence.load({ key: SELF_INSTALL_SOURCE_PERSISTENCE_KEY, signal })).resolves.toEqual(
+      success({ kind: 'found', snapshot: { value: 'bun' } }),
+    )
+    await expect(
+      persistence.save({ key: SELF_INSTALL_SOURCE_PERSISTENCE_KEY, signal, value: 'binary' }),
+    ).resolves.toEqual(success({}))
+    expect(installSource).toBe('binary')
+    await expect(persistence.remove({ key: SELF_INSTALL_SOURCE_PERSISTENCE_KEY, signal })).resolves.toEqual(
+      success(undefined),
+    )
+    expect(installSource).toBeUndefined()
+  })
+
+  it('rejects invalid keys and values without mutating state', async () => {
+    const setInstallSource = vi.fn()
+    const persistence = createSelfInstallSourcePersistencePort({
+      clearInstallSource: vi.fn(),
+      getSelfState: async () => ({}),
+      setInstallSource,
+    })
+    const signal = new AbortController().signal
+
+    await expect(persistence.load({ key: 'agent:codex', signal })).resolves.toMatchObject({
+      error: { kind: 'invalid-data' },
+      kind: 'failure',
+    })
+    await expect(
+      persistence.save({ key: SELF_INSTALL_SOURCE_PERSISTENCE_KEY, signal, value: 'brew' }),
+    ).resolves.toMatchObject({ error: { kind: 'invalid-data' }, kind: 'failure' })
+    expect(setInstallSource).not.toHaveBeenCalled()
+  })
+
+  it('preserves typed state failures across the persistence boundary', async () => {
+    const stateError = new StateFileError('Failed to write Quantex state file.')
+    const persistence = createFakePersistencePort({
+      save: async () => ({
+        error: {
+          details: { cause: stateError },
+          kind: 'failed',
+          message: 'Failed to persist the self install source.',
+        },
+        kind: 'failure',
+      }),
+    })
+
+    await expect(
+      reconcileSelfInstallSource(undefined, 'npm', {
+        persistence,
+        signal: new AbortController().signal,
+      }),
+    ).rejects.toBe(stateError)
+  })
+
+  it('rethrows typed state read failures from the production adapter', async () => {
+    const stateError = new StateFileError('Failed to read Quantex state file.')
+    const persistence = createSelfInstallSourcePersistencePort({
+      clearInstallSource: async () => undefined,
+      getSelfState: async () => {
+        throw stateError
+      },
+      setInstallSource: async () => undefined,
+    })
+
+    await expect(resolveSelfInstallFactsReadOnly({ persistence })).rejects.toBe(stateError)
+  })
+
+  it('preserves persistence cancellation as a process interruption', async () => {
+    const persistence = createFakePersistencePort({
+      save: async () => ({
+        error: { kind: 'cancelled', message: 'cancelled persistence' },
+        kind: 'failure',
+      }),
+    })
+
+    await expect(reconcileSelfInstallSource(undefined, 'npm', { persistence })).rejects.toMatchObject({
+      kind: 'cancelled',
+    })
+  })
+})
+
+function createFakePersistencePort(overrides: Partial<PersistencePort> = {}): PersistencePort {
+  return {
+    load: async () => success({ kind: 'missing' }),
+    remove: async () => success(undefined),
+    save: async () => success({}),
+    ...overrides,
+  }
+}
+
+function success<T>(value: T): RuntimeOutcome<T> {
+  return { kind: 'success', value }
+}

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -9,6 +9,7 @@ import {
   getStateFilePath,
   getStateLockPath,
   loadState,
+  removeSelfInstallSource,
   removeLifecycleReceipt,
   saveState,
   setLifecycleReceipt,
@@ -183,6 +184,10 @@ describe('state helpers', () => {
 
     const writtenState = JSON.parse(readFileSync(getStateFilePath(), 'utf8'))
     expect(writtenState.self?.installSource).toBe('binary')
+
+    await removeSelfInstallSource()
+
+    expect(await getSelfState()).toEqual({})
   })
 
   it('persists self update notice throttle metadata', async () => {


### PR DESCRIPTION
## Summary

Migrate the Quantex self-upgrade bounded context onto invocation-scoped cache, lock, network, process, persistence, result, and presentation boundaries while preserving the v1 command surface.

- make passive notices consume validated, unexpired cached metadata without implicit network I/O
- preserve npm and Bun registry/install behavior, including Bun global trust checks and rollback
- preserve checksum verification, atomic binary rollback, Windows delayed replacement, peer aliases, and cancellation semantics
- retain structured-mode installer diagnostics on stderr without polluting JSON/NDJSON stdout

## Linked Artifacts

- Issue: lifecycle redesign integration milestone
- ADR: `docs/adr/0002-keep-self-upgrade-and-agent-update-separate.md`, `docs/adr/0006-rebuild-lifecycle-core-behind-compatibility-shell.md`
- OpenSpec: `openspec/changes/redesign-lifecycle-engine` tasks 9.1-9.5 complete; umbrella remains active at 53/74
- Discussion: `docs/superpowers/plans/2026-07-15-self-upgrade-integration-milestone.md`

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (1544/1544)
- [x] `bun run openspec:validate`
- [x] `bun run build`
- [x] `bun run build:bin` (five targets)
- [x] `bun run package:check`
- [x] `bun run release:artifacts`
- [x] `bun run release:smoke`
- [x] isolated Bun-managed self-upgrade smoke (seeded install -> check -> upgrade -> up-to-date)
- [x] Initial PR head: Ubuntu, Windows, macOS, lint, classify, body validation, and Modal sandbox checks
- [ ] Final normalized PR head must repeat all required checks before merge.

## Release Intent

- Release: not applicable - intermediate milestone targets the non-release lifecycle integration branch; release remains deferred until final integration promotion to main.

## Docs Updated

- [ ] Not needed
- [x] `docs/superpowers/plans/2026-07-15-self-upgrade-integration-milestone.md`
- [x] `openspec/changes/redesign-lifecycle-engine` remains active at 53/74 after tasks 9.1-9.5 completed
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is active across milestone merges by design and is not archive-eligible.
- [x] Release is not applicable to the integration branch and no publish workflow is requested.

## Notes

- Independent OpenSpec and code-quality reviews found four Important issues; all were fixed and both reviewers confirmed no remaining Critical/Important findings.
- The granular recovery head is preserved under `refs/quantex/recovery/redesign-self-upgrade-granular`; this PR is normalized to one commit.
- Binary filesystem replacement and detached Windows PowerShell scheduling remain inside the self-upgrade compatibility implementation because OpenSpec 9.1 does not require `FileSystemPort`; broadening that shared port would expand this milestone into stable agent-lifecycle infrastructure.
- Do not merge until all required Ubuntu, Windows, macOS, sandbox, governance, and core CI checks pass. Rebase merge is required; squash is fallback only if rebase is unavailable or unsafe. Never use a merge commit or auto-merge.
