### PR TITLE
fix(process): clean up orphaned lifecycle test trees

### DIFF
--- a/src/utils/child-process.ts
+++ b/src/utils/child-process.ts
@@ -278,13 +278,18 @@ export async function terminateProcessTree(proc: SpawnedProcessHandle, requested
 
   signalProcessTree(proc, 'SIGTERM')
 
-  const exited = proc.exited.then(() => true).catch(() => true)
   const graceMs = requestedGraceMs === undefined ? 2_000 : Math.max(10, Math.min(requestedGraceMs, 250))
-  const exitedDuringGrace = await Promise.race([
-    exited,
-    new Promise<false>(resolve => setTimeout(() => resolve(false), graceMs)),
-  ])
-  if (exitedDuringGrace) return
+  const hasPosixProcessGroup = process.platform !== 'win32' && proc.pid !== undefined
+  if (hasPosixProcessGroup) {
+    await new Promise(resolve => setTimeout(resolve, graceMs))
+  } else {
+    const exited = proc.exited.then(() => true).catch(() => true)
+    const exitedDuringGrace = await Promise.race([
+      exited,
+      new Promise<false>(resolve => setTimeout(() => resolve(false), graceMs)),
+    ])
+    if (exitedDuringGrace) return
+  }
 
   signalProcessTree(proc, 'SIGKILL')
   await runWithDeadline(

--- a/test/read-only-lifecycle-provider-signal.test.ts
+++ b/test/read-only-lifecycle-provider-signal.test.ts
@@ -21,6 +21,7 @@ describe('read-only lifecycle mixed signal cancellation', () => {
       const bin = join(root, 'bin')
       const providerPidLog = join(root, 'provider.pids.log')
       const agentPidLog = join(root, 'agent.pids.log')
+      const fixturePids: number[] = []
       const bun = resolveExecutable('bun')
       await mkdir(join(home, '.quantex'), { recursive: true })
       await mkdir(bin, { recursive: true })
@@ -46,8 +47,8 @@ describe('read-only lifecycle mixed signal cancellation', () => {
 
       try {
         await Promise.all([waitForFile(providerPidLog, 10_000), waitForFile(agentPidLog, 10_000)])
-        const pids = [...(await readPids(providerPidLog)), ...(await readPids(agentPidLog))]
-        expect(pids.length).toBe(4)
+        fixturePids.push(...(await readPids(providerPidLog)), ...(await readPids(agentPidLog)))
+        expect(fixturePids.length).toBe(4)
         const startedAt = Date.now()
         child.kill(signal)
         const [exitCode, stdout, stderr] = await Promise.all([
@@ -61,10 +62,11 @@ describe('read-only lifecycle mixed signal cancellation', () => {
 
         expect(exitCode).toBe(11)
         expect(result?.data ?? result).toMatchObject({ error: { code: 'CANCELLED', details: { signal } }, ok: false })
-        await waitForProcessesStopped(pids, 1_000)
+        await waitForProcessesStopped(fixturePids, 1_000)
         expect(Date.now() - startedAt).toBeLessThan(3_000)
-        expect(pids.filter(isProcessAlive)).toEqual([])
+        expect(fixturePids.filter(isProcessAlive)).toEqual([])
       } finally {
+        await killFixtureProcesses(fixturePids)
         if (child.pid && isProcessAlive(child.pid)) child.kill('SIGKILL')
         await rm(root, { force: true, recursive: true })
       }
@@ -98,6 +100,18 @@ async function readPids(path: string): Promise<number[]> {
 async function waitForProcessesStopped(pids: number[], timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs
   while (pids.some(isProcessAlive) && Date.now() < deadline) await new Promise(resolve => setTimeout(resolve, 5))
+}
+
+async function killFixtureProcesses(pids: number[]): Promise<void> {
+  for (const pid of new Set(pids)) {
+    if (!isProcessAlive(pid)) continue
+    try {
+      process.kill(pid, 'SIGKILL')
+    } catch {
+      // The fixture process may have exited between the liveness check and kill.
+    }
+  }
+  await waitForProcessesStopped(pids, 1_000)
 }
 
 function waitForExit(child: ReturnType<typeof spawn>, timeoutMs: number): Promise<number> {

--- a/test/utils/child-process.test.ts
+++ b/test/utils/child-process.test.ts
@@ -156,6 +156,39 @@ describe('context-aware process observations', () => {
     expect(signals).toEqual(['SIGTERM', 'SIGKILL'])
   })
 
+  it('kills a POSIX process group after its leader exits during the grace period', async () => {
+    if (process.platform === 'win32') return
+    let resolveExit!: (code: number) => void
+    const processKillSpy = vi.spyOn(process, 'kill').mockImplementation(((pid, signal) => {
+      if (pid === -42 && signal === 'SIGTERM') resolveExit(0)
+      return true
+    }) as typeof process.kill)
+    const proc = {
+      exitCode: null,
+      exited: new Promise<number>(resolve => {
+        resolveExit = resolve
+      }),
+      kill: vi.fn(),
+      pid: 42,
+      stderr: null,
+      stdout: null,
+      unref: () => undefined,
+    }
+
+    try {
+      await expect(
+        readProcessOutputWithContext(proc, {
+          signal: new AbortController().signal,
+          timeoutMs: 5,
+        }),
+      ).rejects.toMatchObject({ kind: 'timed-out', timeoutMs: 5 })
+      expect(processKillSpy).toHaveBeenNthCalledWith(1, -42, 'SIGTERM')
+      expect(processKillSpy).toHaveBeenNthCalledWith(2, -42, 'SIGKILL')
+    } finally {
+      processKillSpy.mockRestore()
+    }
+  })
+
   it('uses taskkill tree force flags for Windows cleanup', async () => {
     const calls: unknown[][] = []
     const spawnProcess = ((...args: unknown[]) => {


### PR DESCRIPTION
## Summary

Ensure POSIX lifecycle process groups receive `SIGKILL` after their grace period even when the leader exits first. The read-only provider signal fixture now force-cleans every recorded fixture PID in `finally`, preventing failed or interrupted tests from leaving CPU-bound Bun descendants behind.

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: `redesign-lifecycle-engine` (task 8.3 regression coverage)
- Discussion: N/A

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

## Release Intent

- Release: patch - bug fix

## Docs Updated

- [x] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is still active across milestone merges by design.
- [x] Release is delegated to final integration promotion automation.

## Notes

Review the POSIX process-group escalation and the fixture cleanup path. The regression test covers a leader that exits during the grace period while a descendant remains alive.
