### PR TITLE
docs(redesign): record final promotion PR

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,16 +1,16 @@
-# Lifecycle Final Promotion Readiness Progress
+# Lifecycle Final Promotion PR Record Progress
 
-Base: `origin/codex/redesign-lifecycle-integration@1d183699e6703ed126e8a9434175889d3b805471`
+Base: `origin/codex/redesign-lifecycle-integration@d91e1625e631ebe53e9fcd559b1014729cb49b6f`
 
-Plan: `docs/superpowers/plans/2026-07-16-lifecycle-final-promotion-readiness-milestone.md`
+Plan: `docs/superpowers/plans/2026-07-16-lifecycle-final-promotion-pr-record-milestone.md`
 
 | Task | State | Checkpoint | Evidence |
 | --- | --- | --- | --- |
-| 1. Review completed milestone runtime | complete | live-evidence checkpoint | all ordinary milestones are one-commit/six-context PRs; earned task progression reviewed; #447/#448 old contract and #449 prospective boundary recorded; Release runs empty; ruleset active; changes active |
-| 2. Prove final promotion eligibility | complete | content-readiness checkpoint | redesign 74/74 active; main `2ca25c3`; integration `1d18369`; merge-tree equals integration tree `4e065def`; 16 accepted commits/348 files reviewed; no open milestone/promotion PR |
-| 3. Validate process-only readiness diff | complete | validation checkpoint | locked install; lint/format/typecheck/OpenSpec 16/16/memory/diff green; redesign 74/74; support 21/30; Release PR/run empty; validated PR body |
-| 4. Independent review and integration PR | in progress | review checkpoint | both final reviews have no Critical/Important; one-commit normalization, push, Ready PR, six contexts, and manual rebase merge remain |
+| 1. Revalidate the promotion artifact | complete | live-promotion checkpoint | #468 is Ready, same-repository integration-to-main; main `2ca25c3`; integration `d91e162`; expected/source tree `15aaa2f5`; complete 17-commit/349-file comparison reviewed; validated release-worthy title/body; no integration Release run |
+| 2. Record earned OpenSpec progress | complete | task-4.3 checkpoint | support 4.3 marked only after #468 exists; support is 22/30; 4.4-5.6 remain pending and both changes active |
+| 3. Validate the process-only diff | complete | validation checkpoint | lint, format, typecheck, OpenSpec 16/16, memory, diff check green; redesign 74/74; support 22/30; no product test rerun for docs/checkbox-only diff |
+| 4. Review and integration PR | in progress | delivery checkpoint | tracked diff review, one commit, Ready PR, six contexts, PR Governance, manual rebase-first merge remain |
 
-Baseline: core redesign implementation and final validation are merged into integration. This milestone records only earned support tasks 3.1-4.2 and must not open the final promotion PR, trigger release, synchronize current specs, or archive either change.
+Baseline: #467 is rebase-merged into integration and #468 is the exact final promotion PR. This milestone records only the earned 4.3 task and must not merge promotion, trigger release, synchronize current specs, archive changes, or tear down integration.
 
-Recovery rule: resume the first non-complete row after refreshing refs, PRs, Release runs, OpenSpec counters, CodeGraph, and git state. Recompute content evidence on any tip drift; retry only interrupted network operations when tips are stable.
+Recovery rule: resume the first non-complete row after refreshing main, integration, #468, Release runs, OpenSpec counters, CodeGraph, and git state. Any tip drift requires a fresh comparison and validated #468 body; retry only interrupted network operations when tips are stable.

--- a/docs/superpowers/plans/2026-07-16-lifecycle-final-promotion-pr-record-milestone.md
+++ b/docs/superpowers/plans/2026-07-16-lifecycle-final-promotion-pr-record-milestone.md
@@ -1,0 +1,51 @@
+# Lifecycle Final Promotion PR Record Milestone
+
+## Goal
+
+Record the exact final promotion pull request after it exists and only after its complete integration-to-`main` comparison and body have been reviewed. This process-only milestone may complete `support-integration-branch-delivery` task 4.3 and no later task.
+
+Base: `origin/codex/redesign-lifecycle-integration@d91e1625e631ebe53e9fcd559b1014729cb49b6f`
+
+Delivery target: `codex/redesign-lifecycle-integration`
+
+## Entry evidence
+
+- Final promotion PR #468 is an open Ready same-repository PR from `codex/redesign-lifecycle-integration` to `main`.
+- Refreshed base is `main@2ca25c3cfebae5b2db568827677fde9fe40f88a0` and source is `codex/redesign-lifecycle-integration@d91e1625e631ebe53e9fcd559b1014729cb49b6f`.
+- `git merge-tree --write-tree origin/main origin/codex/redesign-lifecycle-integration` and the source tree both equal `15aaa2f5c8498296f3ff3923661057a76c5dc23c`.
+- The complete comparison contains 17 accepted commits and 349 files (+46,616/-5,982), mapped to reviewed lifecycle/integration PRs #443, #445, #447-#451, #453, #458-#462, and #464-#467.
+- The PR body passed the repo-native policy locally. Its initial `refactor:` title was rejected remotely because product-impacting PRs require a release-worthy title; the title was corrected to `feat(lifecycle): promote redesigned lifecycle engine` and release intent to a backward-compatible minor release.
+- `redesign-lifecycle-engine` is 74/74 and active. `support-integration-branch-delivery` is 21/30 before this milestone. Neither change is archived or synchronized into current specs early.
+- Integration has no Release workflow run and no lifecycle milestone PR remains open.
+
+## Scope boundaries
+
+- Change only this plan, `.superpowers/sdd/progress.md`, and the task 4.3 checkbox.
+- Do not modify product code, workflows, current specs, release configuration, or archive state.
+- Do not mark task 4.4 until the final PR's required `main` contexts and final review approve the exact refreshed tips and the final-promotion ledger has been persisted and revalidated.
+- Do not mark task 4.5 until promotion is merged and normal `main` release automation has been classified and reported.
+- Do not use auto-merge or merge commits. This milestone uses manual rebase merge first and squash only as a documented fallback.
+
+## Task 1: Revalidate the promotion artifact
+
+Refresh the PR and remote refs. Confirm #468 remains the exact same-repository integration-to-`main` PR, its title/body pass policy, its base/source tips match the reviewed comparison, no integration milestone is open, and no Release workflow has run for integration. Stop and recompute on tip drift.
+
+## Task 2: Record earned OpenSpec progress
+
+Mark only support task 4.3 complete. Leave 4.4-5.6 unchecked and keep both OpenSpec changes active and unarchived. Update `.superpowers/sdd/progress.md` with resumable evidence and next conditions.
+
+## Task 3: Validate the process-only diff
+
+Run `bun run lint`, `bun run format:check`, `bun run typecheck`, `bun run openspec:validate`, `bun run memory:check`, `git diff --check`, and the OpenSpec apply progress commands. A local full product test rerun is not required because this tracked diff is documentation/OpenSpec-checkbox only; the integration PR must still receive all six remote required contexts.
+
+## Task 4: Review and deliver to integration
+
+Review the complete tracked diff for scope and evidence accuracy. Prepare a PR body from `.github/pull_request_template.md`, validate it with `bun run pr:body:check`, commit one conventional process-only commit, push, and create a Ready PR to integration. Wait for all six integration contexts and PR Governance. Merge manually with rebase first or squash only after recording a concrete fallback reason.
+
+## Next milestone after merge
+
+Refresh #468 and both remote tips because merging this milestone advances integration and therefore updates the final PR head. Recompute the expected tree, update #468's exact source/tree and task count in its validated body, wait for every required `main` context plus final review, then persist and reload the final-promotion ledger. Stop on any base/source drift. Attempt manual rebase merge with `--match-head-commit` first; use squash only if rebase is rejected or unsafe for a recorded concrete reason.
+
+## Recovery rule
+
+Resume the first incomplete row in `.superpowers/sdd/progress.md`. Network failures retry only the interrupted read/push/PR operation. Any main, integration, or #468 head drift invalidates the current content evidence and requires a fresh comparison and PR-body update before continuing.

--- a/openspec/changes/support-integration-branch-delivery/tasks.md
+++ b/openspec/changes/support-integration-branch-delivery/tasks.md
@@ -30,7 +30,7 @@
 
 - [x] 4.1 Complete the other 73 `redesign-lifecycle-engine` tasks on their existing terms and satisfy clarified task `11.6` post-promotion follow-up readiness so the unchanged 74-checkbox denominator reports exactly `74/74`; run its final test, build, binary, package, and release-artifact gates, but defer actual current-spec synchronization and archive execution to tasks 5.4 and 5.5.
 - [x] 4.2 Perform a final verified same-repository main sync, refresh both remote refs, prove through expected-tree and content-comparison evidence that integration includes the latest `main` content alongside only the accepted redesign delta, and confirm no lifecycle milestone pull request remains open.
-- [ ] 4.3 Review the complete integration-to-`main` comparison for only accepted redesign work, validate the PR body, and open the exact same-repository final-promotion pull request.
+- [x] 4.3 Review the complete integration-to-`main` comparison for only accepted redesign work, validate the PR body, and open the exact same-repository final-promotion pull request.
 - [ ] 4.4 After every required `main` context succeeds, atomically persist the approved final-promotion tips and expected tree under the worktree Git metadata path, reload and revalidate them after a final fetch, stop on drift, use rebase merge or squash only as the fallback, then reload the ledger and refresh `main` to verify its tree matches the expected promotion result and contains all approved integration content without requiring source ancestry or a two-parent commit.
 - [ ] 4.5 Let normal post-merge `main` release automation classify the promoted product delta and report promotion, release, and still-pending archive closure separately.
 


### PR DESCRIPTION
## Summary

Record that the exact final lifecycle promotion pull request now exists and advance `support-integration-branch-delivery` from 21/30 to 22/30 by completing task 4.3 from live evidence.

This process-only milestone changes no product, test, workflow, release, current-spec, or archive behavior. It adds the independently resumable plan, records final promotion PR #468 and its reviewed comparison evidence, and leaves task 4.4 plus every promotion/release/teardown/archive task incomplete until their external conditions are real.

## Linked Artifacts

- Issue: Not applicable - existing lifecycle redesign program
- ADR: `docs/adr/0006-rebuild-lifecycle-core-behind-compatibility-shell.md`
- OpenSpec: `support-integration-branch-delivery` task 4.3
- Discussion: Not applicable

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [x] Not run, explained below

Additional validation:

- [x] `bun run openspec:validate` (16 passed)
- [x] `git diff --check`
- [x] `redesign-lifecycle-engine` apply progress is 74/74 with zero remaining
- [x] `support-integration-branch-delivery` apply progress is 22/30 with tasks 4.4-5.6 still incomplete
- [x] Final promotion PR #468 is the exact Ready same-repository `codex/redesign-lifecycle-integration -> main` PR
- [x] Refreshed `merge-tree(main, integration)` equals the reviewed integration tree before this bookkeeping milestone
- [x] Integration has no Release workflow run and both OpenSpec changes remain active and unarchived
- [x] Independent complete-diff review found no Critical or Important issue

The tracked diff contains only a milestone plan, resumable progress evidence, and the earned OpenSpec task 4.3 checkbox. Product and test code are identical to integration, so the full local product suite was not rerun. This integration-target PR must still pass all six remote required contexts.

## Release Intent

- Release: not applicable - process-only OpenSpec progress record targeting the non-release integration branch

## Docs Updated

- [ ] Not needed
- [x] `docs/superpowers/plans/2026-07-16-lifecycle-final-promotion-pr-record-milestone.md`
- [x] `.superpowers/sdd/progress.md`
- [x] `openspec/changes/support-integration-branch-delivery/tasks.md`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] Both OpenSpec changes remain active and unarchived; task 4.4 and all post-promotion tasks remain incomplete.
- [x] Release is not applicable for this integration-only milestone; no Release workflow trigger includes integration.

## Notes

- Base: `codex/redesign-lifecycle-integration@d91e1625e631ebe53e9fcd559b1014729cb49b6f`
- Promotion PR: #468, `codex/redesign-lifecycle-integration -> main`
- Delivery: one conventional commit; manual rebase merge preferred, squash only if rebase is unavailable or unsafe; never merge commit or auto-merge.
- Merging this milestone advances integration and therefore updates #468's head. The next step must refresh both tips, recompute the expected tree, update #468's exact source/tree and task count, and wait for fresh required-main checks before persisting the final ledger.

Closure state at delivery:

- Local implementation: complete when the process-only validation and review pass.
- Repository delivery: complete after one conventional commit and clean working tree.
- PR delivery: complete when this validated body is attached to the pushed Ready PR.
- Merge delivery: pending required integration checks, review, and manual rebase merge.
- Release closure: not applicable for this milestone; final promotion and stable release remain pending.
- OpenSpec archive closure: pending by design until promotion, release/recovery, teardown, current-spec synchronization, and protected-main archive follow-up.
