### PR TITLE
docs(integration): record external teardown

### DIFF
--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,15 +1,16 @@
 # Lifecycle Integration Teardown Progress
 
-Base: `origin/main@fedea8d8b1efe65b3481607256309d3a0af731dd`
+Base: `origin/main@79a4d098404337f5fea8ea5a442264fbc9b93486`
 
-Plan: `docs/superpowers/plans/2026-07-16-lifecycle-integration-teardown.md`
+Plan: `docs/superpowers/plans/2026-07-16-lifecycle-external-teardown.md`
 
 | Task | State | Checkpoint | Evidence |
 | --- | --- | --- | --- |
 | 1. Complete release closure | complete | release checkpoint | Recovery PR #470 and release PR #471 were manually rebase-merged; main CI runs 29492269104 and 29492768675 passed all platforms; Release run 29492987375 published GitHub Release and npm `quantex-cli@0.29.1` with `latest` pointing to 0.29.1 |
 | 2. Add steady-state regressions | complete | red/green checkpoint | Focused tests first failed on six temporary integration behaviors, then passed 3 files/30 tests after the cleanup implementation |
 | 3. Implement process-only cleanup | complete | local cleanup checkpoint | CI and Sandbox PR targets restored to `main`/`beta`; temporary multi-commit exceptions and topology inputs removed; runtime/collaboration guidance returned to steady state; temporary runbook removed; support tasks 4.5 and 5.1 recorded complete |
-| 4. Validate and deliver cleanup | in progress | cleanup PR checkpoint | Static validation is green; full `--maxWorkers=2` suite passed 129 files/1577 tests with one skip and left zero Bun processes; independent review findings were incorporated; commit, push, Ready PR, required checks, and manual rebase-first merge remain |
-| 5. Perform external teardown and archive closure | pending | post-merge checkpoint | After task 5.2 is earned by the cleanup merge, remove the live ruleset/ref under 5.3, synchronize current specs under 5.4, and complete archive/readiness verification under 5.5–5.6 |
+| 4. Validate and deliver cleanup | complete | cleanup merge checkpoint | PR #472 rebase-merged at `main@79a4d098404337f5fea8ea5a442264fbc9b93486`; main CI run 29494534512 and Sandbox Tests run 29494534450 passed; Release run 29494738238 skipped GitHub Release, npm publish, and artifact upload; task 5.2 is complete |
+| 5. Remove external integration infrastructure | complete | live teardown checkpoint | Deleted only ruleset `protect-lifecycle-integration` id 18789571 and remote ref `codex/redesign-lifecycle-integration`; live ruleset inventory retains active `protect-main` id 15433431, `git ls-remote` returns no integration head, no open PR targets the deleted base, and `origin/main` remains `79a4d098404337f5fea8ea5a442264fbc9b93486`; task 5.3 is complete |
+| 6. Synchronize specs and archive | pending | archive checkpoint | After task 5.3 is delivered, synchronize current specs under 5.4 and complete archive/readiness verification under 5.5–5.6 |
 
 Recovery rule: resume the first incomplete row only after refreshing `main`, active OpenSpec counters, PR/check state, and git state. Never repeat the completed release recovery; retry only interrupted network operations.

--- a/docs/superpowers/plans/2026-07-16-lifecycle-external-teardown.md
+++ b/docs/superpowers/plans/2026-07-16-lifecycle-external-teardown.md
@@ -1,0 +1,38 @@
+# Lifecycle External Teardown Plan
+
+Base: `origin/main@79a4d098404337f5fea8ea5a442264fbc9b93486`
+
+## Goal
+
+Retire the live delivery infrastructure that existed only for the completed lifecycle integration phase. Remove the exact temporary ruleset and remote integration ref without changing `main`, the steady-state `main` ruleset, release allowlists, product code, or published artifacts.
+
+## Earned state and live baseline
+
+Cleanup PR #472 rebase-merged at `main@79a4d098404337f5fea8ea5a442264fbc9b93486`. Main CI run 29494534512 and Sandbox Tests run 29494534450 passed. Release run 29494738238 classified the commit without publishing; GitHub Release and npm remain at `v0.29.1`.
+
+The live temporary resources are:
+
+- repository ruleset `protect-lifecycle-integration` with id `18789571`, active only for `refs/heads/codex/redesign-lifecycle-integration`; its rules were pull-request enforcement, non-fast-forward protection, and required contexts `classify`, `lint`, `test (ubuntu-latest)`, `test (windows-latest)`, `test (macos-latest)`, and `sandbox-tests`
+- remote ref `refs/heads/codex/redesign-lifecycle-integration` at `d1f76f6a4d055c9b14a25ddb3f30ac965d549216`
+
+## Task 1: Record the teardown boundary
+
+- Mark support task 5.2 complete from the merged cleanup evidence.
+- Preserve the exact ruleset id, condition, required contexts, and remote ref tip in this plan before deletion.
+- Confirm `origin/main` and the `protect-main` ruleset are out of scope.
+
+## Task 2: Remove and verify live temporary resources
+
+- Delete only repository ruleset id `18789571` through the GitHub API.
+- Verify the exact ruleset is absent while `protect-main` remains active.
+- Delete only remote branch `codex/redesign-lifecycle-integration`.
+- Verify `git ls-remote` returns no matching head and `origin/main` remains at the accepted cleanup tip.
+- Mark support task 5.3 complete only after all live-state checks pass.
+
+## Task 3: Validate and deliver the evidence ledger
+
+Run the focused steady-state workflow/governance tests with at most two workers, lint, format check, typecheck, OpenSpec validation, memory check, and diff check. Obtain independent review, create one conventional process-only commit, validate a template-based PR body, push, and create a Ready PR to `main`. Keep auto-merge disabled and use manual rebase-first merge after required checks pass.
+
+## Closure boundary
+
+This milestone removes only temporary external delivery infrastructure and records evidence. It must not publish a release or archive either active OpenSpec change. Current-spec synchronization and archive readiness remain tasks 5.4–5.6.

--- a/openspec/changes/support-integration-branch-delivery/tasks.md
+++ b/openspec/changes/support-integration-branch-delivery/tasks.md
@@ -37,8 +37,8 @@
 ## 5. Post-Promotion Teardown
 
 - [x] 5.1 Add or update focused steady-state tests, then prepare a process-only cleanup that removes the integration pull-request target from CI and Sandbox Tests, temporary multi-commit policy exceptions, and temporary runtime/runbook instructions while retaining release rejection for unknown branches.
-- [ ] 5.2 Run the focused tests, full test suite, lint, format check, typecheck, OpenSpec validation, and memory check; validate the cleanup PR body and merge the cleanup to `main` without treating it as a release.
-- [ ] 5.3 Remove the temporary integration ruleset, delete `codex/redesign-lifecycle-integration`, and verify both are absent from live repository state after recovery use is no longer required.
+- [x] 5.2 Run the focused tests, full test suite, lint, format check, typecheck, OpenSpec validation, and memory check; validate the cleanup PR body and merge the cleanup to `main` without treating it as a release.
+- [x] 5.3 Remove the temporary integration ruleset, delete `codex/redesign-lifecycle-integration`, and verify both are absent from live repository state after recovery use is no longer required.
 - [ ] 5.4 Synchronize the accepted final deltas from `redesign-lifecycle-engine` and `support-integration-branch-delivery` into current specs, retaining only durable conditional and closure rules.
 - [ ] 5.5 After current specs are synchronized, run `bun run openspec:validate` and `bun run memory:check`, then prepare exact separately resumable repo-native archive commands, a validated PR body, and the normal protected-branch delivery path for both active changes; completing this readiness task earns its existing credit, while actual archive execution and PR merge remain mandatory external closure actions.
 - [ ] 5.6 Prepare the owner, commands, expected active/archive state checks, clean-tree verification, and explicit promotion/release/teardown/archive report for the post-archive-PR-merge verification; completing this readiness task earns its existing credit, while the prepared verification MUST run and be reported after the archive follow-up merges.


### PR DESCRIPTION
## Summary

Record the completed live teardown of the temporary lifecycle integration delivery infrastructure.

- mark cleanup delivery task 5.2 complete from merged PR #472 and green post-merge/no-release evidence
- record deletion and absence verification for integration ruleset `18789571`
- record deletion and absence verification for remote ref `codex/redesign-lifecycle-integration`
- preserve evidence that `protect-main` and `main@79a4d098404337f5fea8ea5a442264fbc9b93486` were unchanged

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `support-integration-branch-delivery` tasks 5.2 and 5.3
- Discussion: none

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Additional validation:

- focused governance/workflow suite: 3 files, 30 tests passed with `--maxWorkers=2`
- `bun run openspec:validate` — 16 passed, 0 failed
- `git diff --check`
- independent review: Go, no blocking Critical/Important findings
- live ruleset inventory contains only active `protect-main` id 15433431
- `git ls-remote` returns no integration head; no open PR targets the removed base
- `origin/main` remains `79a4d098404337f5fea8ea5a442264fbc9b93486`
- zero `/Users/drs/.bun/bin/bun` processes after focused validation

## Release Intent

- Release: not applicable - docs/process/test-only change

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

Added the independently resumable external teardown plan and updated the OpenSpec/progress evidence ledger.

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active until this merge, active across milestone merges by design, queued for agent-driven archive closure after completion, or already archived.
- [x] Release is not applicable, delegated to release automation, or verified.

Both lifecycle OpenSpec changes remain active. Current-spec synchronization and archive readiness remain tasks 5.4–5.6.

## Notes

The live deletions are already complete and independently verified; this PR records their evidence in repository-native artifacts. Keep auto-merge disabled and merge manually with rebase first after required checks pass.
