### PR TITLE
feat(release)!: graduate post-redesign line

### DIFF
--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -31,6 +31,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Validate Release PR scope
+        id: validate-release-pr
         uses: actions/github-script@v7
         with:
           script: |
@@ -72,9 +73,17 @@ jobs:
 
             if (issues.length > 0) {
               core.setFailed(issues.join('\n'))
+              return
             }
 
+            const manualMergeRequired =
+              baseBranch === 'main' &&
+              basePackageJson.version === '0.29.1' &&
+              title === 'chore: release 1.1.0'
+            core.setOutput('manual_merge_required', manualMergeRequired ? 'true' : 'false')
+
       - name: Create release bot token
+        if: steps.validate-release-pr.outputs.manual_merge_required != 'true'
         id: release-bot-token
         uses: actions/create-github-app-token@v3
         with:
@@ -82,6 +91,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Enable Release PR auto-merge
+        if: steps.validate-release-pr.outputs.manual_merge_required != 'true'
         env:
           GH_TOKEN: ${{ steps.release-bot-token.outputs.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,8 +1,8 @@
-# Lifecycle Integration Teardown Progress
+# Post-Redesign Release Graduation Progress
 
-Base: `origin/main@79a4d098404337f5fea8ea5a442264fbc9b93486`
+Base: `origin/main@970328970b716e6761a18494c7e4c29055d7a83f`
 
-Plan: `docs/superpowers/plans/2026-07-16-lifecycle-spec-archive-closure.md`
+Plan: `docs/superpowers/plans/2026-07-16-post-redesign-1-1-release.md`
 
 | Task | State | Checkpoint | Evidence |
 | --- | --- | --- | --- |
@@ -12,7 +12,7 @@ Plan: `docs/superpowers/plans/2026-07-16-lifecycle-spec-archive-closure.md`
 | 4. Validate and deliver cleanup | complete | cleanup merge checkpoint | PR #472 rebase-merged at `main@79a4d098404337f5fea8ea5a442264fbc9b93486`; main CI run 29494534512 and Sandbox Tests run 29494534450 passed; Release run 29494738238 skipped GitHub Release, npm publish, and artifact upload; task 5.2 is complete |
 | 5. Remove external integration infrastructure | complete | live teardown checkpoint | Deleted only ruleset `protect-lifecycle-integration` id 18789571 and remote ref `codex/redesign-lifecycle-integration`; live ruleset inventory retains active `protect-main` id 15433431, `git ls-remote` returns no integration head, no open PR targets the deleted base, and `origin/main` remains `79a4d098404337f5fea8ea5a442264fbc9b93486`; task 5.3 is complete |
 | 6. Synchronize durable current specs | complete | spec-sync checkpoint | Added three new lifecycle current specs, merged accepted deltas into nine existing capabilities, retained only durable delivery rules, and passed OpenSpec 19/19, memory, lint, format, and typecheck; task 5.4 is complete |
-| 7. Prepare and execute archive closure | in progress | archive PR checkpoint | Tasks 5.5–5.6 reached genuine readiness; the repo-native wrapper verified `74/74` and `30/30`, archived both changes with already-synchronized specs, and generated a validated body; commit, push, Ready PR, required checks, and manual rebase merge remain |
-| 8. Start post-redesign release line | pending | release graduation checkpoint | After lifecycle archive closure, use an independent OpenSpec change to make `0.29.1` the final 0.x baseline and deliver the first post-redesign release as `1.1.0` |
+| 7. Prepare and execute archive closure | complete | archive merge checkpoint | PR #474 rebase-merged at `main@970328970b716e6761a18494c7e4c29055d7a83f`; both lifecycle changes are absent from active state and present under dated archives; main CI run 29498553576 passed after one failed Windows cancellation-E2E job rerun; Sandbox run 29498553696 passed; Release run 29499015464 published nothing |
+| 8. Start post-redesign release line | in progress | release graduation checkpoint | Active change `graduate-post-redesign-release-line` fixes `0.29.1` as the final 0.x baseline and `1.1.0` as the only allowed first post-redesign release; focused tests pass 23/23, full bounded tests pass 1582 with one skip, static/OpenSpec/memory validation is green, and implementation review/delivery remains |
 
 Recovery rule: resume the first incomplete row only after refreshing `main`, active OpenSpec counters, PR/check state, and git state. Never repeat the completed release recovery; retry only interrupted network operations.

--- a/docs/github-collaboration.md
+++ b/docs/github-collaboration.md
@@ -121,6 +121,10 @@ Release PR creation relies on merged commit metadata. In practice that means:
 - `BREAKING CHANGE:` or `!` produces a major release
 - `docs:`, `test:`, `ci:`, and `chore:` do not create a release unless the commit metadata is explicitly changed to do so later
 
+The stable 0.x line is closed at `0.29.1`. The first post-redesign stable release is exactly `1.1.0`; burned `1.0.0`, later 0.x releases, and other pre-major graduation targets are rejected. The one-time graduation commit carries `Release-As: 1.1.0`, allowing release-please to generate the ordinary trusted Release PR without a permanent override or manual edits to version-controlled release outputs. After `1.1.0`, normal SemVer planning applies.
+
+Ordinary Release PR automation may request auto-merge, but the exact `main@0.29.1 -> chore: release 1.1.0` graduation PR MUST skip release-bot token creation and auto-merge enablement. Required checks must finish before an operator locks the reviewed head and manually selects rebase merge first, with squash as the only documented fallback.
+
 For PRs that only touch workflow, documentation, project-memory, or release-please configuration files, use `ci:`, `chore:`, or `docs:` titles. PR Governance blocks release-worthy metadata for those scopes so release-process changes do not accidentally create stable product Release PRs.
 
 Protected-branch release automation now keys off successful push-side CI completion rather than racing the raw `push` event. A failed `main` or `beta` CI run therefore blocks automated Release PR creation and publication until the branch is green again.

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -98,6 +98,10 @@ Release PR creation uses conventional commits:
 - `BREAKING CHANGE:` footer or `!` => major release
 - `docs:`, `test:`, `ci:`, `chore:` => no release unless the metadata is intentionally changed
 
+The stable 0.x line ends at `0.29.1`. The completed lifecycle redesign graduates through the exact transition `0.29.1 -> 1.1.0`; `1.0.0` remains burned and MUST NOT be reused. The graduation implementation commit uses release-please's one-shot `Release-As: 1.1.0` footer, after which normal 1.x SemVer planning resumes. Do not persist `release-as` in release-please configuration and do not manually edit the version manifest, package version, changelog, or generated build metadata to imitate the generated Release PR.
+
+Both the graduation implementation PR and the generated `chore: release 1.1.0` PR use the normal protected-branch checks. The Release PR workflow MUST identify that exact generated PR from base version `0.29.1` and skip token creation and auto-merge enablement, leaving the PR fail-closed for a locked-head manual rebase merge. Squash remains the fallback only when rebase is unavailable or unsafe.
+
 Release automation, documentation, and project-memory-only PRs must use non-release-worthy titles such as `ci:`, `chore:`, or `docs:`. PR Governance rejects release-worthy titles for PRs that only change `.github/`, `docs/`, `openspec/`, or release-please configuration files, because those changes should not create stable product releases by themselves.
 
 The stable release-please config currently includes a temporary `last-release-sha` anchor to exclude a historical release-process `feat(release)` commit from stable release calculation. Remove or advance that anchor after the next intentional stable Release PR is merged, because release-please treats `last-release-sha` as an explicit scan boundary until it is changed.

--- a/docs/superpowers/plans/2026-07-16-post-redesign-1-1-release.md
+++ b/docs/superpowers/plans/2026-07-16-post-redesign-1-1-release.md
@@ -1,0 +1,45 @@
+# Post-Redesign 1.1 Release Plan
+
+Base: `origin/main@970328970b716e6761a18494c7e4c29055d7a83f`
+
+OpenSpec: `graduate-post-redesign-release-line`
+
+## Goal
+
+Keep `0.29.1` as the final 0.x baseline and publish the completed lifecycle redesign as `1.1.0` through Quantex's protected release-please path. Do not rewrite `v0.29.1`, reuse `1.0.0`, or manually edit generated release version files.
+
+## Task 1: Lock the graduation boundary
+
+- Add red tests that accept only `0.29.1 -> 1.1.0` across the 0.x-to-1.x boundary.
+- Reject any later 0.x proposal from `0.29.1`, burned `1.0.0`, `1.1.0` from another 0.x base, and any other 1.x graduation target.
+- Prove stable release-please exits pre-major planning and contains no persistent `release-as` configuration.
+- Preserve ordinary pre-`0.29.1` recovery comparisons and post-`1.1.0` SemVer progression.
+
+## Task 2: Implement and validate
+
+- Update only stable Release PR policy, stable release-please configuration, focused tests, OpenSpec artifacts, and canonical release guidance.
+- Do not change `package.json`, `.release-please-manifest.json`, `CHANGELOG.md`, or generated build metadata in this implementation PR.
+- Run the focused release/governance tests, full `--maxWorkers=2` suite, lint, format check, typecheck, OpenSpec validation, memory check, diff check, and Bun process check.
+- Obtain independent review and deliver one commit with subject `feat(release)!: graduate post-redesign line` and the exact body footer:
+
+```text
+Release-As: 1.1.0
+```
+
+## Task 3: Deliver the implementation and generated release
+
+- Validate a template-based Ready PR to `main`; keep auto-merge disabled.
+- After checks pass, lock its head SHA and manually rebase-merge.
+- Refresh `main` and verify the merged commit body retains exactly `Release-As: 1.1.0`.
+- Require release-please to create the trusted branch PR titled `chore: release 1.1.0`; stop on any other version or file scope.
+- Verify the exact graduation Release PR workflow skipped release-bot token creation and auto-merge enablement, wait for all checks, lock the release head, and manually rebase-merge.
+
+## Task 4: Verify publication and archive closure
+
+- Require green post-release main CI and successful formal Release workflow.
+- Verify tag and GitHub Release `v1.1.0` point at the release commit, expected binaries/checksums are attached, npm exposes `quantex-cli@1.1.0`, and npm `latest` is `1.1.0`.
+- Only then synchronize the accepted OpenSpec delta, run repo-native archive closure, deliver its Ready PR, manually rebase-merge, and verify archive-only workflows publish nothing further.
+
+## Recovery
+
+If network or quota interruption occurs, resume from the first incomplete OpenSpec task after refreshing `origin/main`, open PRs, workflow runs, GitHub Releases, npm metadata, and the local clean-tree state. Never recreate a merged implementation or Release PR, never republish an existing version, and never enable automatic merge as a recovery shortcut.

--- a/openspec/changes/graduate-post-redesign-release-line/.openspec.yaml
+++ b/openspec/changes/graduate-post-redesign-release-line/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/graduate-post-redesign-release-line/design.md
+++ b/openspec/changes/graduate-post-redesign-release-line/design.md
@@ -1,0 +1,65 @@
+## Context
+
+`quantex-cli@0.29.1` is the published stable version and the lifecycle redesign has completed promotion, release verification, teardown, current-spec synchronization, and archive closure. The repository already treats `1.0.0` as burned and configures release-please to keep breaking changes on the 0.x line. The new product decision is that no version after `0.29.1` may remain on 0.x and the first post-redesign release is `1.1.0`.
+
+The normal release path must remain protected: a main commit triggers release-please Release PR mode after green CI; the generated Release PR materializes version files; its merge triggers GitHub Release, npm trusted publishing, and binary upload. Manually editing the manifest or publishing outside this path would bypass established review and recovery controls.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make `0.29.1` the final accepted stable 0.x base.
+- Permit exactly `0.29.1 -> 1.1.0` and reject other pre-major graduation shapes.
+- Use the normal generated Release PR and publication workflows.
+- Keep the graduation trigger one-shot and resumable across network or quota interruption.
+- Return to ordinary SemVer after `1.1.0`.
+
+**Non-Goals:**
+
+- Reusing or republishing burned version `1.0.0`.
+- Rewriting the already published `0.29.1` tag, GitHub Release, or npm package.
+- Manually changing `package.json`, the release manifest, changelog, or generated build metadata in the graduation PR.
+- Changing package/binary identity, v1 protocol compatibility, lifecycle implementation, or beta release semantics.
+
+## Decisions
+
+### Use the official Release-As commit footer
+
+The graduation implementation commit carries `Release-As: 1.1.0` in its body. release-please officially interprets that footer as an exact next-version request and generates the ordinary Release PR. The override exists only in the merged commit; it is not stored as permanent release configuration.
+
+A permanent `release-as` workflow input was rejected because later reconciliation could repeatedly force the same version. Direct version-file edits were rejected because they imitate a trusted generated Release PR and bypass the existing release source of truth.
+
+### Guard the transition in Release PR policy
+
+Stable Release PR policy accepts a major transition from a 0.x base only when the base is exactly `0.29.1` and the proposed version is exactly `1.1.0`. While the base remains `0.29.1`, later 0.x proposals are rejected. `1.0.0` remains independently rejected as burned. Once the base is `1.1.0` or newer, normal version comparison and SemVer release planning apply.
+
+### End pre-major release-please planning
+
+The stable release-please config sets `bump-minor-pre-major` to `false` because the repository is deliberately leaving the zero-major line. The exact first version still comes from `Release-As: 1.1.0`, which avoids release-please selecting burned `1.0.0`. After publication, the setting is inert for a 1.x base and documents the graduated state.
+
+### Keep release delivery manual and rebase-first
+
+The graduation implementation PR uses the exact release-worthy subject `feat(release)!: graduate post-redesign line`, ensuring the repository resolver reaches release-please after green main CI. The exact generated `chore: release 1.1.0` PR from base version `0.29.1` is validated normally, but the Release PR workflow skips bot-token creation and auto-merge enablement before any merge request can be queued. The operator locks the approved head SHA and uses manual rebase merge first, squash only if rebase is unavailable or unsafe. Publication closure is reported only after GitHub Release, npm `latest`, tag, package version, and binary assets all agree on `1.1.0`.
+
+## Risks / Trade-offs
+
+- [The footer is lost or the resolver skips the commit] -> Use the exact tested release-worthy subject plus one footer-bearing implementation commit, rebase merge, and verify the merged main commit body before expecting the Release PR.
+- [release-please proposes `1.0.0` or a later 0.x version] -> Stable Release PR policy rejects both and focused tests cover every boundary.
+- [Automation creates an unexpected version] -> Do not merge the generated Release PR unless its title and version files are exactly `1.1.0`.
+- [Release bot races manual delivery] -> The workflow skips token creation and auto-merge enablement for the exact graduation PR before any auto-merge request exists; verify `autoMergeRequest` is null before manual rebase merge.
+- [Publication partially succeeds] -> Reuse the existing resolver's tag/npm recovery path and never publish an older missing package automatically.
+
+## Migration Plan
+
+1. Add focused policy/config regressions and implement the exact graduation guard.
+2. Update the release spec and operator documentation, then validate the complete process-only diff.
+3. Commit once with `Release-As: 1.1.0`, push, and merge the Ready implementation PR manually after checks.
+4. Verify release-please creates exactly `chore: release 1.1.0`; disable auto-merge, validate generated files/checks, and manually rebase merge it.
+5. Verify main CI, GitHub Release `v1.1.0`, npm `quantex-cli@1.1.0` with `latest`, and all release assets.
+6. Synchronize the accepted release-workflow delta and complete agent-driven OpenSpec archive closure in a follow-up PR.
+
+Rollback before the Release PR merge is to stop and correct the policy/footer through another reviewed PR. After `1.1.0` is published, use the normal forward-fix release process; never delete or reuse the version.
+
+## Open Questions
+
+None. The final 0.x version, first post-redesign version, one-shot trigger, merge order, and closure evidence are fixed.

--- a/openspec/changes/graduate-post-redesign-release-line/proposal.md
+++ b/openspec/changes/graduate-post-redesign-release-line/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The lifecycle redesign and its archive closure are complete, but the stable package still reports `0.29.1`. Quantex needs one explicit, reviewable release-line graduation so `0.29.1` remains the final 0.x baseline and the redesigned product starts at `1.1.0` without reusing the burned `1.0.0` version.
+
+## What Changes
+
+- **BREAKING**: Graduate the stable release line exactly once from `0.29.1` to `1.1.0`.
+- Treat `0.29.1` as the final publishable 0.x version; reject later 0.x stable Release PRs.
+- Keep `1.0.0` burned and reject any pre-major-to-major graduation except the exact `0.29.1 -> 1.1.0` transition.
+- Use release-please's official one-shot `Release-As: 1.1.0` commit footer so the protected workflow generates the normal Release PR instead of manually editing version files.
+- After `1.1.0`, resume ordinary SemVer planning on the 1.x line; the one-shot override MUST NOT become permanent release configuration.
+- Deliver the graduation through normal CI, Ready PR review, manual rebase-first merge, generated Release PR review, publication validation, and agent-driven OpenSpec archive closure.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `release-workflow`: Replace the indefinite pre-major hold with the exact post-redesign graduation contract, guard the final 0.x boundary, and retain ordinary protected release-please publication after the one-shot transition.
+
+## Impact
+
+- Affected repository surfaces: stable release-please configuration, Release PR policy and focused tests, release runbooks/collaboration guidance, and the merge commit metadata that triggers the generated `1.1.0` Release PR.
+- Affected external systems: the normal `main` Release workflow, GitHub Release `v1.1.0`, npm `quantex-cli@1.1.0`, and release binary artifacts.
+- No CLI command, package name, binary name, stable v1 machine protocol, runtime dependency, or lifecycle implementation behavior changes.

--- a/openspec/changes/graduate-post-redesign-release-line/specs/release-workflow/spec.md
+++ b/openspec/changes/graduate-post-redesign-release-line/specs/release-workflow/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Stable release planning MUST keep pre-major breaking changes on the zero-major line
+
+The stable Release workflow SHALL treat `0.29.1` as the final publishable 0.x version and SHALL permit graduation from a stable 0.x base only for the exact transition `0.29.1 -> 1.1.0`. It MUST reject later 0.x proposals while `0.29.1` is the current base, MUST reject every other pre-major-to-major transition, and SHALL resume ordinary SemVer planning after `1.1.0` is published.
+
+#### Scenario: Release planning proposes another 0.x version after the final baseline
+
+- **GIVEN** the current stable version is `0.29.1`
+- **WHEN** release automation proposes `0.29.2`, `0.30.0`, or any other stable 0.x version
+- **THEN** Release PR validation MUST reject the proposal
+- **AND** `0.29.1` MUST remain the final 0.x release
+
+#### Scenario: Exact post-redesign graduation is requested
+
+- **GIVEN** the current stable version is `0.29.1`
+- **AND** the accepted main commit carries the one-shot footer `Release-As: 1.1.0`
+- **WHEN** release-please prepares the stable Release PR
+- **THEN** it MUST propose exactly `1.1.0`
+- **AND** the generated Release PR MUST remain subject to normal protected-branch validation and manual rebase-first merge
+- **AND** the Release PR workflow MUST skip bot-token creation and auto-merge enablement for that exact graduation PR
+
+#### Scenario: A different pre-major graduation is proposed
+
+- **GIVEN** the current stable version is below `1.0.0`
+- **WHEN** a stable Release PR proposes `1.0.0`, proposes a 1.x version other than `1.1.0`, or proposes `1.1.0` from a base other than `0.29.1`
+- **THEN** Release PR validation MUST reject the proposal
+- **AND** burned version `1.0.0` MUST remain unpublished
+
+#### Scenario: Stable releases continue after graduation
+
+- **GIVEN** `1.1.0` or a newer stable 1.x version is the current base
+- **WHEN** release-worthy changes reach `main`
+- **THEN** release-please SHALL apply ordinary SemVer planning
+- **AND** the one-shot `Release-As: 1.1.0` override MUST NOT remain in workflow or manifest configuration

--- a/openspec/changes/graduate-post-redesign-release-line/tasks.md
+++ b/openspec/changes/graduate-post-redesign-release-line/tasks.md
@@ -1,0 +1,24 @@
+## 1. Graduation Contract
+
+- [x] 1.1 Add focused Release PR policy tests for the exact `0.29.1 -> 1.1.0` transition, the final-0.x boundary, burned `1.0.0`, wrong-base/wrong-target near misses, and ordinary post-`1.1.0` SemVer progression.
+- [x] 1.2 Add a stable release configuration regression proving the repository has left pre-major planning and does not persist a `release-as` override in workflow or manifest configuration.
+- [x] 1.3 Add resolver and workflow regressions proving the graduation implementation subject is release-worthy and the generated exact `1.1.0` Release PR cannot enter automatic squash merge.
+
+## 2. Policy and Documentation
+
+- [x] 2.1 Update stable Release PR policy so later 0.x versions and every pre-major graduation except exact `0.29.1 -> 1.1.0` fail closed while post-`1.1.0` releases continue normally.
+- [x] 2.2 End the stable `bump-minor-pre-major` mode and update canonical release guidance with the final `0.29.1` baseline, one-shot `Release-As: 1.1.0` trigger, generated Release PR boundary, and manual rebase-first merge requirement.
+- [x] 2.3 Record an independently resumable implementation, publication, verification, and archive-closure plan without manually changing source-controlled version files.
+- [x] 2.4 Make the exact `main@0.29.1 -> chore: release 1.1.0` generated PR skip release-bot auto-merge before a token or merge request is created, while leaving ordinary Release PR automation unchanged.
+
+## 3. Validation and Release Delivery
+
+- [x] 3.1 Run focused release/governance tests, the full test suite with bounded local workers, lint, format check, typecheck, OpenSpec validation, memory check, and diff check; confirm zero local Bun fixture processes remain.
+- [ ] 3.2 Obtain independent review, validate a template-based PR body, create one commit carrying `Release-As: 1.1.0`, push, and open a Ready implementation PR to `main` with auto-merge disabled.
+- [ ] 3.3 After every required check passes, manually rebase-merge the locked implementation head, verify the merged commit retained the exact footer, and require release-please to create exactly the generated `chore: release 1.1.0` PR.
+- [ ] 3.4 Validate the generated Release PR scope and checks, disable any bot-created auto-merge request, manually rebase-merge its locked head, then verify green main CI, GitHub Release/tag/assets, npm `quantex-cli@1.1.0`, and npm `latest=1.1.0`.
+
+## 4. Archive Closure
+
+- [ ] 4.1 Synchronize the accepted graduation delta into the current `release-workflow` spec only after publication succeeds, then prepare and execute the repo-native OpenSpec archive follow-up through a protected-main PR.
+- [ ] 4.2 After the archive PR merges, verify the change is absent from active state, present under the dated archive, the working tree is clean, archive-only CI is green, and no additional release is published.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,7 @@
       "include-component-in-tag": false,
       "include-v-in-tag": true,
       "include-v-in-release-name": true,
-      "bump-minor-pre-major": true,
+      "bump-minor-pre-major": false,
       "extra-files": [
         "src/generated/build-meta.ts"
       ],

--- a/scripts/release-pr-policy.js
+++ b/scripts/release-pr-policy.js
@@ -4,6 +4,8 @@ import process from 'node:process'
 const stableTitlePattern = /^chore: release (\d+\.\d+\.\d+)$/
 const betaTitlePattern = /^chore: release (\d+\.\d+\.\d+-beta(?:\.\d+)?)$/
 const generatedMarker = 'This PR was generated with [Release Please]'
+const finalZeroMajorVersion = '0.29.1'
+const firstPostRedesignVersion = '1.1.0'
 const burnedStableReleaseVersions = new Set(['1.0.0'])
 
 const allowedFiles = new Set([
@@ -65,6 +67,18 @@ export function validateReleasePrPolicy(input) {
         ].join(' '),
       )
     }
+
+    if (baseBranch === 'main' && isLaterZeroMajorRelease(proposedVersion, baseVersion)) {
+      issues.push(
+        `Release PR version "${proposedVersion}" is not allowed because ${finalZeroMajorVersion} is the final stable 0.x release.`,
+      )
+    }
+
+    if (baseBranch === 'main' && isUnapprovedStableGraduation(proposedVersion, baseVersion)) {
+      issues.push(
+        `Release PR version "${proposedVersion}" is not allowed from "${baseVersion}"; the only allowed stable graduation is "${finalZeroMajorVersion}" to "${firstPostRedesignVersion}".`,
+      )
+    }
   }
 
   if (versionMatch && baseBranch === 'main') {
@@ -77,6 +91,30 @@ export function validateReleasePrPolicy(input) {
   }
 
   return issues
+}
+
+export function isLaterZeroMajorRelease(proposedRaw, baseRaw) {
+  const proposed = parseReleaseVersion(proposedRaw)
+  const base = parseReleaseVersion(baseRaw)
+
+  return (
+    baseRaw === finalZeroMajorVersion &&
+    base.prerelease === null &&
+    proposed.prerelease === null &&
+    proposed.major === 0 &&
+    compareReleaseVersions(proposedRaw, baseRaw) > 0
+  )
+}
+
+export function isUnapprovedStableGraduation(proposedRaw, baseRaw) {
+  const proposed = parseReleaseVersion(proposedRaw)
+  const base = parseReleaseVersion(baseRaw)
+
+  if (base.prerelease !== null || proposed.prerelease !== null || base.major !== 0 || proposed.major < 1) {
+    return false
+  }
+
+  return !(baseRaw === finalZeroMajorVersion && proposedRaw === firstPostRedesignVersion)
 }
 
 export function isAccidentalPreMajorGraduation(proposedRaw, baseRaw) {

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -42,16 +42,18 @@ describe('pr governance release intent', () => {
     }
   })
 
-  it('keeps stable release-please on the zero-major line for pre-1.0 breaking changes', () => {
+  it('keeps stable release-please graduated without a persistent release override', () => {
     const config = JSON.parse(readFileSync('release-please-config.json', 'utf8')) as {
       packages: {
         '.': {
           'bump-minor-pre-major'?: boolean
+          'release-as'?: string
         }
       }
     }
 
-    expect(config.packages['.']['bump-minor-pre-major']).toBe(true)
+    expect(config.packages['.']['bump-minor-pre-major']).toBe(false)
+    expect(config.packages['.']['release-as']).toBeUndefined()
   })
 
   it('keeps PR template compatible with agent-driven OpenSpec archive closure', () => {

--- a/test/release-pr-policy.test.ts
+++ b/test/release-pr-policy.test.ts
@@ -82,15 +82,67 @@ describe('release PR policy', () => {
     expect(issues.join('\n')).toContain('version "1.0.0" is a burned stable release version')
   })
 
+  it('accepts the exact post-redesign graduation from 0.29.1 to 1.1.0', () => {
+    expect(
+      validateReleasePrPolicy({
+        baseBranch: 'main',
+        baseVersion: '0.29.1',
+        body: validBody,
+        changedFiles: validChangedFiles,
+        headBranch: 'release-please--branches--main--components--quantex-cli',
+        title: 'chore: release 1.1.0',
+      }),
+    ).toEqual([])
+  })
+
+  it.each(['0.29.2', '0.30.0'])('rejects later zero-major release %s after final baseline 0.29.1', proposed => {
+    const issues = validateReleasePrPolicy({
+      baseBranch: 'main',
+      baseVersion: '0.29.1',
+      body: validBody,
+      changedFiles: validChangedFiles,
+      headBranch: 'release-please--branches--main--components--quantex-cli',
+      title: `chore: release ${proposed}`,
+    })
+
+    expect(issues.join('\n')).toContain('0.29.1 is the final stable 0.x release')
+  })
+
+  it('rejects 1.1.0 graduation from the wrong zero-major base', () => {
+    const issues = validateReleasePrPolicy({
+      baseBranch: 'main',
+      baseVersion: '0.28.0',
+      body: validBody,
+      changedFiles: validChangedFiles,
+      headBranch: 'release-please--branches--main--components--quantex-cli',
+      title: 'chore: release 1.1.0',
+    })
+
+    expect(issues.join('\n')).toContain('only allowed stable graduation is "0.29.1" to "1.1.0"')
+  })
+
+  it('rejects a different 1.x graduation target from 0.29.1', () => {
+    const issues = validateReleasePrPolicy({
+      baseBranch: 'main',
+      baseVersion: '0.29.1',
+      body: validBody,
+      changedFiles: validChangedFiles,
+      headBranch: 'release-please--branches--main--components--quantex-cli',
+      title: 'chore: release 1.2.0',
+    })
+
+    expect(issues.join('\n')).toContain('only allowed stable graduation is "0.29.1" to "1.1.0"')
+  })
+
   it('allows post-1.0 stable releases to advance normally', () => {
     expect(
       validateReleasePrPolicy({
         baseBranch: 'main',
-        baseVersion: '1.0.0',
+        baseVersion: '1.1.0',
         body: validBody,
         changedFiles: validChangedFiles,
         headBranch: 'release-please--branches--main--components--quantex-cli',
-        title: 'chore: release 1.0.1',
+        title: 'chore: release 1.1.1',
       }),
     ).toEqual([])
   })

--- a/test/release-target-resolution.test.ts
+++ b/test/release-target-resolution.test.ts
@@ -19,6 +19,27 @@ function run(databaseId: number, headSha: string, updatedAt: string): Successful
 }
 
 describe('release target resolution', () => {
+  it('recognizes the exact graduation commit subject as release-worthy while preserving Release-As metadata', () => {
+    const intent = commit('feat(release)!: graduate post-redesign line\n\nRelease-As: 1.1.0')
+    const resolution = selectReleaseCandidate({
+      commitsBySha: { graduation: intent },
+      publishedNpmVersions: new Set<string>(),
+      publishedReleaseShas: new Set<string>(),
+      publishedTags: new Set<string>(),
+      runs: [run(10, 'graduation', '2026-07-16T12:00:00Z')],
+    })
+
+    expect(intent.firstLine).toBe('feat(release)!: graduate post-redesign line')
+    expect(intent.isReleaseWorthy).toBe(true)
+    expect(intent.isReleaseCommit).toBe(false)
+    expect(resolution.mode).toBe('pr')
+    expect(resolution.targetSha).toBe('graduation')
+  })
+
+  it('does not mistake Release-As metadata on a chore commit for a release-worthy resolver input', () => {
+    expect(commit('chore(release): graduate post-redesign line\n\nRelease-As: 1.1.0').isReleaseWorthy).toBe(false)
+  })
+
   it('publishes a pending untagged release commit before creating another release PR', () => {
     const resolution = selectReleaseCandidate({
       commitsBySha: {

--- a/test/workflow-classification.test.ts
+++ b/test/workflow-classification.test.ts
@@ -138,4 +138,16 @@ describe('workflow classification integration', () => {
     expect(releaseWorkflow).toContain('echo "npm_tag=beta"')
     expect(releaseWorkflow).toContain('echo "npm_tag=latest"')
   })
+
+  it('keeps the exact 1.1.0 graduation Release PR on manual rebase-first delivery', () => {
+    expect(releaseAutomergeWorkflow).toContain('id: validate-release-pr')
+    expect(releaseAutomergeWorkflow).toContain("basePackageJson.version === '0.29.1'")
+    expect(releaseAutomergeWorkflow).toContain("title === 'chore: release 1.1.0'")
+    expect(releaseAutomergeWorkflow).toContain(
+      "core.setOutput('manual_merge_required', manualMergeRequired ? 'true' : 'false')",
+    )
+    expect(
+      releaseAutomergeWorkflow.match(/if: steps\.validate-release-pr\.outputs\.manual_merge_required != 'true'/g),
+    ).toHaveLength(2)
+  })
 })


### PR DESCRIPTION
## Summary

Establish the exact post-redesign stable release-line graduation without manually changing generated version files.

- keep `0.29.1` as the final stable 0.x release
- allow only the exact `0.29.1 -> 1.1.0` graduation and retain burned `1.0.0` rejection
- end stable pre-major planning while keeping the `Release-As: 1.1.0` override one-shot in commit metadata
- document protected, manual rebase-first delivery and publication verification

## Linked Artifacts

- Issue: none
- ADR: none
- OpenSpec: `graduate-post-redesign-release-line`
- Discussion: none

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (if behavior changed)
- [ ] Not run, explained below

Additional validation:

- focused release/governance suite: 4 files, 43 tests passed
- full bounded suite: 129 files, 1585 passed, 1 skipped with `--maxWorkers=2`
- `bun run openspec:validate`: 18 passed, 0 failed
- `git diff --check`
- zero local Bun processes after validation

## Release Intent

- Release: major - request the exact post-redesign `1.1.0` Release PR through the one-shot `Release-As: 1.1.0` commit footer

## Docs Updated

- [ ] Not needed
- [x] `docs/...`
- [x] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

Updated the canonical release runbook, collaboration guide, resumable delivery plan, and active graduation contract.

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean before implementation started.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec remains active through generated Release PR merge, publication verification, spec sync, and archive closure.
- [x] Release is delegated to the protected release-please workflow after this implementation merges.

## Notes

- This PR does not edit `package.json`, `.release-please-manifest.json`, `CHANGELOG.md`, or `src/generated/build-meta.ts`.
- The implementation commit body must retain exactly `Release-As: 1.1.0` after merge.
- Commit subject is `feat(release)!: graduate post-redesign line`; the generated exact `1.1.0` Release PR skips auto-merge enablement and uses manual rebase merge first after required checks pass.
