### PR TITLE
docs(release): repair historical release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This changelog is maintained by release-please Release PRs.
 
 ## [1.1.0](https://github.com/Drswith/quantex-cli/compare/v0.29.1...v1.1.0) (2026-07-16)
 
+### Release summary
+
+`v1.1.0` graduates Quantex onto its post-redesign release line. The generated breaking-change marker records that release-line transition; it does **not** intentionally remove the maintained v1 CLI commands and aliases, JSON/NDJSON envelopes and exit semantics, readable state/config projections, `qtx`/`quantex` binary entries, or maintained root-package exports.
+
+No migration is required for those maintained v1 surfaces. The underlying lifecycle-engine refactor was delivered in the `v0.29.0..v0.29.1` range; its implementation summary and compatibility boundary appear in the `v0.29.1` notes below.
 
 ### ⚠ BREAKING CHANGES
 
@@ -15,6 +20,19 @@ This changelog is maintained by release-please Release PRs.
 
 ## [0.29.1](https://github.com/Drswith/quantex-cli/compare/v0.29.0...v0.29.1) (2026-07-16)
 
+### Lifecycle-engine refactor
+
+This release completes the internal lifecycle-engine redesign delivered after `v0.29.0`:
+
+* lifecycle mutations now follow observation, planning, execution, postcondition verification, and receipt persistence stages;
+* provider capabilities and catalog installation data are typed, declarative adapters rather than duplicated command-specific metadata;
+* persisted state is versioned management evidence reconciled with the live environment, and idempotent replay requires the same request meaning plus a still-valid postcondition;
+* command registration, discovery, schemas, and presentation flow from a single command-contract registry; and
+* runtime dependencies use per-invocation context and ports, while Quantex self-upgrade remains a separate bounded context.
+
+### Compatibility
+
+The refactor preserves the maintained v1 external contract: stable command names and aliases, `qtx`/`quantex` entries, JSON/NDJSON envelopes, error and exit semantics, state/config projections, transparent agent process IO, and maintained root-package exports. Existing users do not need a migration for these surfaces.
 
 ### Bug Fixes
 

--- a/openspec/changes/repair-historical-release-notes/.openspec.yaml
+++ b/openspec/changes/repair-historical-release-notes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/repair-historical-release-notes/design.md
+++ b/openspec/changes/repair-historical-release-notes/design.md
@@ -1,0 +1,43 @@
+## Context
+
+`v0.29.1` contains the lifecycle-engine delivery range after `v0.29.0`, but release-please rendered only the two `fix` commits. `v1.1.0` was intentionally triggered by a one-shot `Release-As` footer on a `feat(release)!` commit; the generated entry therefore describes a version-line graduation as a breaking feature. The generated `CHANGELOG.md` sections were copied into both published GitHub Release bodies.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make the historical user-visible notes accurately state the scope of the lifecycle refactor and its preserved v1 compatibility boundary.
+- Keep the repository changelog and both GitHub Release pages semantically aligned.
+- Preserve the original generated commit index for traceability.
+
+**Non-Goals:**
+
+- Changing release-please configuration, commit classification, resolver logic, workflows, tags, package contents, npm publication, or future release-note automation.
+- Rewriting published tags or republishing either version.
+
+## Decisions
+
+### Correct both historical surfaces
+
+`CHANGELOG.md` remains the repository source artifact, while GitHub Release bodies are independent published copies. Both are corrected in the same delivery so a user sees the same explanation whether they browse the repository or the Releases page.
+
+### Preserve generated entries and add curated context
+
+The generated `Features`, `Bug Fixes`, and `Breaking Changes` entries remain as a commit index. Curated release summaries clarify that `v0.29.1` delivered the refactor and that `v1.1.0` graduates the release line without intentionally removing maintained v1 external contracts. This corrects meaning without falsifying release history.
+
+### Keep this repair isolated from future automation
+
+This change documents a historical correction only. A future proposal may change how release-please is triggered or how release summaries are generated, but neither is required to repair these two releases.
+
+## Risks / Trade-offs
+
+- [Repository and GitHub notes diverge] -> use identical compatibility language and verify both remote Release bodies after editing.
+- [Historical note is mistaken for a tag rewrite] -> state that tags, package versions, binaries, and npm artifacts remain untouched.
+- [A docs commit triggers a release] -> use a `docs` commit; the current resolver classifies it as non-release-worthy.
+
+## Migration Plan
+
+1. Add curated context to the two existing changelog sections.
+2. Validate the OpenSpec artifacts and documentation diff, then deliver the docs PR.
+3. Update the two existing GitHub Release bodies without moving tags or publishing packages.
+4. Verify the remote release bodies and repository source agree; archive the OpenSpec change after the implementation PR merges.

--- a/openspec/changes/repair-historical-release-notes/proposal.md
+++ b/openspec/changes/repair-historical-release-notes/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The generated `v0.29.1` and `v1.1.0` release notes omit the lifecycle redesign delivered after `v0.29.0`. The latter also exposes a release-line graduation marker as a public breaking change even though the redesign preserved the documented v1 CLI and machine-readable contracts. Users therefore cannot determine the upgrade impact from either the repository changelog or the published GitHub Release pages.
+
+## What Changes
+
+- Add a curated historical summary of the post-`v0.29.0` lifecycle redesign and its compatibility boundary to the existing `v0.29.1` and `v1.1.0` changelog sections.
+- Update the already-published `v0.29.1` and `v1.1.0` GitHub Release bodies to match those corrected historical notes.
+- Preserve generated commit entries, tags, package versions, release-please configuration, resolver behavior, and publication workflows unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `release-workflow`: record the one-time correction of the published release-note copies without changing release planning or publication behavior.
+
+## Impact
+
+- Affected repository artifact: `CHANGELOG.md`.
+- Affected external presentation: GitHub Release pages for `v0.29.1` and `v1.1.0`.
+- No CLI, package, binary, tag, npm, release-please, resolver, or workflow behavior changes.

--- a/openspec/changes/repair-historical-release-notes/specs/release-workflow/spec.md
+++ b/openspec/changes/repair-historical-release-notes/specs/release-workflow/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Post-redesign historical release notes MUST state the compatibility boundary
+
+The maintained historical notes for `v0.29.1` and `v1.1.0` SHALL explain that the lifecycle-engine refactor was delivered after `v0.29.0`, and that the `v1.1.0` graduation does not intentionally remove the maintained v1 CLI, structured-output, state/config, binary-entry, or root-export contracts.
+
+#### Scenario: User reads the repository changelog
+
+- **WHEN** a user reads the `v0.29.1` or `v1.1.0` section of `CHANGELOG.md`
+- **THEN** the section MUST provide a concise lifecycle-refactor and compatibility summary alongside the generated commit index
+
+#### Scenario: User reads a published GitHub Release
+
+- **WHEN** a user reads the published GitHub Release body for `v0.29.1` or `v1.1.0`
+- **THEN** the body MUST provide the same compatibility interpretation as the corresponding changelog section
+
+#### Scenario: Historical correction is delivered
+
+- **WHEN** the historical-note correction is merged
+- **THEN** it MUST NOT move a release tag, publish an npm package, or change release automation behavior

--- a/openspec/changes/repair-historical-release-notes/tasks.md
+++ b/openspec/changes/repair-historical-release-notes/tasks.md
@@ -1,0 +1,9 @@
+## 1. Historical documentation repair
+
+- [x] 1.1 Add the post-`v0.29.0` lifecycle-refactor and compatibility summaries to the existing `v0.29.1` and `v1.1.0` changelog sections while preserving generated entries.
+- [x] 1.2 Update the published GitHub Release bodies for `v0.29.1` and `v1.1.0` with matching curated summaries, without changing tags or packages.
+
+## 2. Validation and delivery
+
+- [x] 2.1 Run OpenSpec and repository documentation validation, inspect the diff, and confirm the change remains non-release-worthy.
+- [ ] 2.2 Commit, push, and open a validated docs PR; after it merges, archive this change and verify the repository changelog and GitHub Release bodies remain aligned.


### PR DESCRIPTION
## Summary

- repair the incomplete historical changelog entries for `v0.29.1` and `v1.1.0`
- align both published GitHub Release bodies with the corrected lifecycle-refactor and compatibility context
- preserve release-please configuration, resolver/workflow behavior, tags, package versions, and npm artifacts

## Linked Artifacts

- Issue: N/A
- ADR: N/A
- OpenSpec: `repair-historical-release-notes`
- Discussion: historical release-note correction requested in the active Codex task

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test -- test/release-target-resolution.test.ts` (confirms a `docs` change remains non-release-worthy)
- [ ] Not run, explained below

## Release Intent

- [x] Release: not applicable - docs/process/test-only change
- [ ] Release: patch - bug fix
- [ ] Release: minor - user-facing feature
- [ ] Release: major - breaking change

## Docs Updated

- [ ] Not needed
- [x] `CHANGELOG.md`
- [x] `openspec/changes/repair-historical-release-notes/`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is active until this implementation PR merges, then requires agent-driven archive closure.
- [x] Release is not applicable; this repair does not change release automation or publish artifacts.

## Notes

The two existing GitHub Release bodies were updated directly and re-read before this PR. The repository changelog remains the reviewed source artifact; neither published tag nor npm package was changed.
