### PR TITLE
chore(release): improve generated release notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,12 @@ Describe the change and why it exists.
 - Release: minor - user-facing feature
 - Release: major - breaking change
 
+## Release Summary
+
+- Not applicable - this source PR does not produce a release entry.
+- For a release-worthy source PR, replace this with a non-empty release-please commit override written for users.
+- For a one-shot release, also declare the same `Release-As: <version>` footer that the merged commit carries.
+
 ## Docs Updated
 
 - [ ] Not needed

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Validate PR merge commit policy
         env:
+          PR_BODY: ${{ github.event.pull_request.body }}
           PR_COMMITS_JSON: ${{ steps.commits.outputs.commits_json }}
           PR_IS_VALIDATED_RELEASE_PR: ${{ steps.release-pr.outputs.validated == 'true' }}
         run: bun run scripts/pr-merge-commit-policy.ts

--- a/docs/runbooks/releasing-quantex.md
+++ b/docs/runbooks/releasing-quantex.md
@@ -98,6 +98,16 @@ Release PR creation uses conventional commits:
 - `BREAKING CHANGE:` footer or `!` => major release
 - `docs:`, `test:`, `ci:`, `chore:` => no release unless the metadata is intentionally changed
 
+Release-worthy source PRs MUST also provide a `## Release Summary` section with a non-empty release-please commit override. Use the override to write the changelog entry for users, rather than echoing incidental implementation wording:
+
+```text
+BEGIN_COMMIT_OVERRIDE
+refactor: make agent lifecycle operations safer and easier to diagnose
+END_COMMIT_OVERRIDE
+```
+
+`refactor:` entries appear in the generated `Internal Improvements` section but do not independently trigger a version bump. When an exact one-shot version is needed, carry `Release-As: <version>` in the merged commit and repeat the same footer in the source PR's Release Summary. The protected-branch resolver recognizes that footer as a Release PR trigger, so do not add `!` or a false `BREAKING CHANGE` marker merely to start release automation.
+
 The stable 0.x line ends at `0.29.1`. The completed lifecycle redesign graduates through the exact transition `0.29.1 -> 1.1.0`; `1.0.0` remains burned and MUST NOT be reused. The graduation implementation commit uses release-please's one-shot `Release-As: 1.1.0` footer, after which normal 1.x SemVer planning resumes. Do not persist `release-as` in release-please configuration and do not manually edit the version manifest, package version, changelog, or generated build metadata to imitate the generated Release PR.
 
 Both the graduation implementation PR and the generated `chore: release 1.1.0` PR use the normal protected-branch checks. The Release PR workflow MUST identify that exact generated PR from base version `0.29.1` and skip token creation and auto-merge enablement, leaving the PR fail-closed for a locked-head manual rebase merge. Squash remains the fallback only when rebase is unavailable or unsafe.

--- a/openspec/changes/improve-release-notes-workflow/.openspec.yaml
+++ b/openspec/changes/improve-release-notes-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-16

--- a/openspec/changes/improve-release-notes-workflow/design.md
+++ b/openspec/changes/improve-release-notes-workflow/design.md
@@ -1,0 +1,61 @@
+## Context
+
+Quantex uses release-please for version calculation, changelog generation, Release PRs, and GitHub Release creation. A repository-local resolver runs before release-please and currently only treats `feat`, `fix`, `perf`, and breaking markers as release-worthy. This made the supported one-shot `Release-As` footer ineffective on a neutral `chore(release)` commit and encouraged a misleading `feat(release)!` workaround.
+
+The node release strategy also suppresses `refactor` entries by default. The historical repair corrected the resulting published notes, but it deliberately did not change future automation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make a valid `Release-As` footer reach release-please without misclassifying the change as a breaking feature.
+- Show intentional `refactor` entries in generated stable and beta changelogs and their GitHub Release copies.
+- Make source PR authors provide release-please-supported, concise user-facing release text whenever they request a release.
+- Keep release-please responsible for version calculation and Release PR creation.
+
+**Non-Goals:**
+
+- Rewriting any existing changelog entry, tag, GitHub Release, or npm artifact.
+- Adding a separate release-note service, a custom Release PR creation command, or a dynamic provider of release text.
+- Treating every refactor as an automatic version bump.
+- Inferring a release summary from arbitrary implementation commits.
+
+## Decisions
+
+### Recognize `Release-As` at the repository gate
+
+The resolver will classify a commit containing a syntactically non-empty, case-insensitive `Release-As:` footer as release-worthy. The footer remains release-please's version instruction; the resolver only decides whether to enter Release PR mode. This removes the requirement to add `!` or a false breaking-change declaration solely as an automation trigger.
+
+The resolver will not derive or validate the requested version itself. Release-please and the existing Release PR policy remain the source of version calculation and version admission.
+
+### Expose refactors without promoting them
+
+Both manifest configurations will declare the `refactor` changelog type as visible under an `Internal Improvements` section. Visibility affects presentation only; it does not make a refactor commit release-worthy or change the SemVer bump selected by release-please.
+
+### Require a release-please commit override in release-source PRs
+
+The existing PR body governance adds a `## Release Summary` section. A release-worthy source PR MUST place a non-empty `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` block in that section, with conventional-commit entries written for users rather than implementation mechanics. Source PRs that intentionally trigger with `Release-As` MUST also declare the same footer in this section, while the merged commit remains responsible for carrying the authoritative footer.
+
+release-please natively consumes commit overrides on the repository's linear merge path. This avoids a second renderer or workflow: the override becomes the changelog entry, and the generated changelog remains the content copied to the GitHub Release.
+
+### Keep generated Release PR validation narrow
+
+Release-please generated version PRs remain exempt from source-PR summary validation and continue through the existing dedicated release-PR policy. Only ordinary source PRs create the release-note input.
+
+## Risks / Trade-offs
+
+- [A `Release-As` footer has a typo] -> resolver only requires a non-empty value; release-please and Release PR policy continue to reject invalid or disallowed versions.
+- [A refactor becomes noisy in release notes] -> only deliberately titled `refactor:` commits appear, and a source PR must provide an intentional override when it releases.
+- [PR body and merged footer diverge] -> the runbook requires the same `Release-As` value in both; release-please still reads the merged commit as authority.
+- [Commit override cannot be associated with a non-linear merge] -> preserve the repository's rebase-first policy; do not use plain merge commits for release-source PRs.
+
+## Migration Plan
+
+1. Add regression tests for resolver classification, changelog configuration, and PR body validation.
+2. Apply the minimal resolver/config/template/policy/runbook changes and run the repository validation suite.
+3. Deliver one process-only PR. It MUST NOT itself be release-worthy or create a Release PR.
+4. Subsequent release-source PRs use the new section and, when necessary, `Release-As`; no migration of historical notes is required.
+
+## Open Questions
+
+None.

--- a/openspec/changes/improve-release-notes-workflow/proposal.md
+++ b/openspec/changes/improve-release-notes-workflow/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Release-please correctly materializes versions, but the post-v0.29 lifecycle refactor exposed a release-note gap: `refactor` commits were hidden, and the repository-local resolver ignored a valid `Release-As` footer unless the commit was artificially marked as a breaking `feat!`. That made the generated release page sparse and misleading.
+
+Future releases need one durable, reviewable path that keeps release-please as the source of version calculation while making user-facing change summaries complete and accurate.
+
+## What Changes
+
+- Treat a one-shot `Release-As: <version>` footer as an explicit release-please trigger in the protected-branch resolver; it MUST NOT require a misleading `feat!` or `BREAKING CHANGE` marker solely to enter Release PR mode.
+- Configure release-please to show `refactor` entries in generated stable and beta changelogs, alongside its existing user-facing change categories.
+- Require release-worthy source PRs to provide a concise release summary through release-please's supported commit-override format, so the generated changelog and GitHub Release use intentional user-facing text rather than incidental implementation wording.
+- Update the PR template, local policy checks, release workflow contract, and release runbook. Historical version notes and already-published artifacts are out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+- `release-note-input`: Defines the validated source-PR metadata that release-please consumes as a user-facing release entry.
+
+### Modified Capabilities
+
+- `release-workflow`: Release trigger classification and generated changelog content gain explicit `Release-As` and visible-refactor behavior.
+- `release-governance`: Release-worthy source PRs gain required, validated release-note metadata.
+
+## Impact
+
+- Affected systems: `scripts/release-target-resolution.ts`, `scripts/pr-body-policy.ts`, release-please stable/beta configuration, PR template, release runbook, and release-policy tests.
+- No CLI command, package/binary identity, existing tag, npm artifact, or historical release page is changed.

--- a/openspec/changes/improve-release-notes-workflow/specs/release-governance/spec.md
+++ b/openspec/changes/improve-release-notes-workflow/specs/release-governance/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: PR governance MUST validate release-summary input
+
+PR Governance SHALL use the shared locally executable body-policy command to validate the release-summary metadata required from release-source PRs.
+
+#### Scenario: Contributor validates release-source metadata locally
+
+- **WHEN** a contributor prepares a release-worthy source PR body
+- **THEN** the local body-policy command MUST report missing or malformed release-summary metadata before PR delivery
+
+#### Scenario: Remote governance validates release-source metadata
+
+- **WHEN** GitHub PR Governance evaluates a release-worthy source PR
+- **THEN** it MUST invoke the same body-policy validation
+- **AND** it MUST reject the PR if the release-summary requirement is not met

--- a/openspec/changes/improve-release-notes-workflow/specs/release-note-input/spec.md
+++ b/openspec/changes/improve-release-notes-workflow/specs/release-note-input/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Release-source PRs MUST provide release-please consumable summaries
+
+Every non-generated pull request with release-worthy metadata SHALL include a `## Release Summary` section containing a non-empty `BEGIN_COMMIT_OVERRIDE` / `END_COMMIT_OVERRIDE` block. The override MUST contain at least one conventional-commit entry with a meaningful description suitable for user-facing release notes.
+
+#### Scenario: Feature PR provides a summary
+
+- **WHEN** a product-impacting PR uses release-worthy feature, fix, performance, refactor-breaking, or breaking-change metadata
+- **THEN** local and remote PR governance MUST accept it only when its Release Summary contains a valid non-empty commit override
+
+#### Scenario: Release source omits the summary
+
+- **WHEN** a non-generated PR uses release-worthy metadata
+- **AND** its Release Summary is missing, blank, malformed, or contains only a placeholder override
+- **THEN** PR governance MUST reject the PR before merge with guidance to provide a release-please commit override
+
+#### Scenario: Generated Release PR is validated separately
+
+- **WHEN** a release-please generated version PR is validated
+- **THEN** it MUST remain subject to dedicated Release PR policy
+- **AND** it MUST NOT be rejected for omitting a source-PR Release Summary
+
+### Requirement: Release-As source metadata MUST be explicit
+
+A source PR that requests a one-shot release through `Release-As` SHALL declare the same non-empty `Release-As: <version>` footer in its Release Summary and in the merged commit.
+
+#### Scenario: Neutral release trigger is documented
+
+- **WHEN** a source PR uses `Release-As` without feature or breaking conventional metadata
+- **THEN** PR governance MUST treat the declared footer as release-worthy metadata
+- **AND** it MUST require both the release summary override and the visible Release-As declaration

--- a/openspec/changes/improve-release-notes-workflow/specs/release-workflow/spec.md
+++ b/openspec/changes/improve-release-notes-workflow/specs/release-workflow/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Release-As footer MUST enter Release PR reconciliation
+
+The protected-branch release resolver SHALL treat a commit with a syntactically non-empty, case-insensitive `Release-As: <version>` footer as release-worthy input for Release PR reconciliation. It MUST NOT require a feature, fix, performance, or breaking-change marker in addition to that footer.
+
+#### Scenario: Neutral commit requests an exact release
+
+- **WHEN** a successful protected-branch CI run covers a commit with `Release-As: <version>` and no other release-worthy conventional marker
+- **THEN** the resolver MUST select Release PR mode for that commit
+- **AND** release-please MUST remain responsible for interpreting the requested version
+
+#### Scenario: Neutral commit has no Release-As footer
+
+- **WHEN** a successful protected-branch CI run covers a `chore` or `docs` commit without a release-worthy conventional marker or a non-empty Release-As footer
+- **THEN** the resolver MUST continue to skip Release PR creation
+
+### Requirement: Generated changelogs MUST show intentional refactors
+
+Stable and beta release-please configuration SHALL render `refactor` conventional commits in a visible `Internal Improvements` changelog section. This presentation rule MUST NOT independently cause a version bump or Release PR.
+
+#### Scenario: Release includes a refactor entry
+
+- **WHEN** release-please generates notes for a release range containing an intentional `refactor` entry
+- **THEN** the generated changelog and GitHub Release body MUST include that entry under `Internal Improvements`
+
+#### Scenario: Refactor alone does not release
+
+- **WHEN** the newest successful protected-branch CI run covers only a non-breaking `refactor` commit without Release-As
+- **THEN** the repository resolver MUST NOT create a Release PR solely because the changelog type is visible

--- a/openspec/changes/improve-release-notes-workflow/tasks.md
+++ b/openspec/changes/improve-release-notes-workflow/tasks.md
@@ -1,0 +1,17 @@
+## 1. Contract and regression coverage
+
+- [x] 1.1 Add failing resolver tests for neutral `Release-As` commits and non-release neutral commits.
+- [x] 1.2 Add failing PR-body policy tests for required release-summary commit overrides and explicit Release-As metadata.
+- [x] 1.3 Add failing configuration tests that require visible `refactor` changelog types in both release channels.
+
+## 2. Release-note automation
+
+- [x] 2.1 Classify non-empty Release-As footers as release-worthy without changing version ownership.
+- [x] 2.2 Configure visible `Internal Improvements` refactor entries for stable and beta release-please output.
+- [x] 2.3 Add Release Summary template guidance and shared body-policy validation while preserving dedicated generated Release PR validation.
+
+## 3. Durable documentation and verification
+
+- [x] 3.1 Update the release runbook with the Release-As and commit-override workflow, including the no-false-breaking-marker rule.
+- [x] 3.2 Run focused regression tests, lint, format check, typecheck, full tests, OpenSpec validation, and memory validation.
+- [x] 3.3 Validate the PR body, commit, push, and open a Ready PR; report release and archive follow-up state.

--- a/release-please-config.beta.json
+++ b/release-please-config.beta.json
@@ -10,11 +10,33 @@
       "versioning": "prerelease",
       "prerelease": true,
       "prerelease-type": "beta",
+      "changelog-types": [
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "Internal Improvements",
+          "hidden": false
+        }
+      ],
       "extra-files": [
         "src/generated/build-meta.ts"
       ],
       "pull-request-title-pattern": "chore: release ${version}",
-      "pull-request-header": "## Summary\n- materialize the next Quantex beta release version in source-controlled files\n- update the repository changelog for the pending beta release\n\n## Linked Artifacts\n- Release automation: release-please beta channel\n\n## Validation\n- CI must pass before merging this beta Release PR\n\n## Release Intent\n- Release: beta - release-please generated prerelease version PR\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Beta Release PR only; merge this PR to publish the prepared beta version\n\n## Closure Check\n- OpenSpec: release-workflow\n- Delivery state: Beta Release PR pending merge and publication\n"
+      "pull-request-header": "## Summary\n- materialize the next Quantex beta release version in source-controlled files\n- update the repository changelog for the pending beta release\n\n## Linked Artifacts\n- Release automation: release-please beta channel\n\n## Validation\n- CI must pass before merging this beta Release PR\n\n## Release Intent\n- Release: beta - release-please generated prerelease version PR\n\n## Release Summary\n- Not applicable - generated beta Release PR; source PR commit overrides provide release entries.\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Beta Release PR only; merge this PR to publish the prepared beta version\n\n## Closure Check\n- OpenSpec: release-workflow\n- Delivery state: Beta Release PR pending merge and publication\n"
     }
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,11 +8,33 @@
       "include-v-in-tag": true,
       "include-v-in-release-name": true,
       "bump-minor-pre-major": false,
+      "changelog-types": [
+        {
+          "type": "feat",
+          "section": "Features",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes",
+          "hidden": false
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "Internal Improvements",
+          "hidden": false
+        }
+      ],
       "extra-files": [
         "src/generated/build-meta.ts"
       ],
       "pull-request-title-pattern": "chore: release ${version}",
-      "pull-request-header": "## Summary\n- materialize the next Quantex release version in source-controlled files\n- update the repository changelog for the pending release\n\n## Linked Artifacts\n- Release automation: release-please\n\n## Validation\n- CI must pass before merging this Release PR\n\n## Release Intent\n- Release: patch/minor/major - release-please generated version PR\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Release PR only; merge this PR to publish the prepared version\n\n## Closure Check\n- OpenSpec: release-workflow\n- Delivery state: Release PR pending merge and publication\n"
+      "pull-request-header": "## Summary\n- materialize the next Quantex release version in source-controlled files\n- update the repository changelog for the pending release\n\n## Linked Artifacts\n- Release automation: release-please\n\n## Validation\n- CI must pass before merging this Release PR\n\n## Release Intent\n- Release: patch/minor/major - release-please generated version PR\n\n## Release Summary\n- Not applicable - generated Release PR; source PR commit overrides provide release entries.\n\n## Docs Updated\n- CHANGELOG.md\n- package.json\n- src/generated/build-meta.ts\n- .release-please-manifest.json\n\n## Scope Check\n- Release PR only; merge this PR to publish the prepared version\n\n## Closure Check\n- OpenSpec: release-workflow\n- Delivery state: Release PR pending merge and publication\n"
     }
   }
 }

--- a/scripts/openspec-archive-closure.ts
+++ b/scripts/openspec-archive-closure.ts
@@ -53,6 +53,10 @@ Archive completed OpenSpec changes ${openSpecList} after their implementation PR
 
 - Release: not applicable - OpenSpec archive closure only
 
+## Release Summary
+
+- Not applicable - OpenSpec archive closure does not produce a release entry.
+
 ## Docs Updated
 
 - [ ] Not needed

--- a/scripts/pr-body-policy.ts
+++ b/scripts/pr-body-policy.ts
@@ -15,6 +15,7 @@ export const requiredPrBodyHeadings = [
   '## Linked Artifacts',
   '## Validation',
   '## Release Intent',
+  '## Release Summary',
   '## Docs Updated',
   '## Scope Check',
   '## Closure Check',
@@ -43,10 +44,12 @@ export function validatePrBodyPolicy(input: PrBodyPolicyInput): string[] {
     )
   }
 
+  const releaseWorthyMetadata = hasReleaseWorthyMetadata(title, body)
+  if (!validatedReleasePr && releaseWorthyMetadata) issues.push(...validateReleaseSummary(body))
+
   if (!input.changedFiles || input.changedFiles.length === 0) return issues
 
   const classification = classifyChangedFiles(input.changedFiles)
-  const releaseWorthyMetadata = hasReleaseWorthyMetadata(title, body)
 
   if (classification.processOnly && releaseWorthyMetadata) {
     issues.push(
@@ -82,8 +85,36 @@ export function hasReleaseWorthyMetadata(title: string, body: string): boolean {
   return (
     /^(feat|fix|perf)(\(.+\))?!?:/.test(title) ||
     /^[a-z]+(\(.+\))?!:/.test(title) ||
-    /\nBREAKING CHANGE:/.test(`\n${body}`)
+    /\nBREAKING CHANGE:/.test(`\n${body}`) ||
+    hasReleaseAsFooter(body)
   )
+}
+
+function validateReleaseSummary(body: string): string[] {
+  const summary = extractSection(body, 'Release Summary')
+  const override = summary.match(/BEGIN_COMMIT_OVERRIDE\s*\n([\s\S]*?)\nEND_COMMIT_OVERRIDE/)
+
+  if (!override) {
+    return [
+      'Release-worthy source PRs must include a non-empty BEGIN_COMMIT_OVERRIDE / END_COMMIT_OVERRIDE block under "## Release Summary".',
+    ]
+  }
+
+  if (!/^[a-z]+(?:\([^\n)]+\))?!?:\s+\S/m.test(override[1])) {
+    return [
+      'Release Summary commit override must include a conventional-commit entry with a meaningful user-facing description.',
+    ]
+  }
+
+  if (hasReleaseAsFooter(body) && !hasReleaseAsFooter(summary)) {
+    return ['Release-As source PRs must declare the same non-empty Release-As footer under "## Release Summary".']
+  }
+
+  return []
+}
+
+function hasReleaseAsFooter(value: string): boolean {
+  return /^release-as:\s*\S+\s*$/im.test(value)
 }
 
 function hasMeaningfulNoReleaseReason(body: string): boolean {

--- a/scripts/pr-merge-commit-policy.ts
+++ b/scripts/pr-merge-commit-policy.ts
@@ -8,6 +8,7 @@ export interface PullRequestCommitMetadata {
 }
 
 export interface PullRequestMergeCommitPolicyInput {
+  body?: string
   commits: PullRequestCommitMetadata[]
   validatedReleasePr?: boolean
 }
@@ -19,6 +20,7 @@ const trustedReleaseBotNamePattern = /^quantex-cli-release-bot\[bot\]$/i
 
 export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeCommitPolicyInput): string[] {
   const commits = input.commits
+  const releaseAsVersion = getReleaseAsVersion(input.body ?? '')
   const validatedReleasePr = input.validatedReleasePr === true
   const issues: string[] = []
 
@@ -41,6 +43,12 @@ export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeComm
     for (const line of offendingLines) {
       issues.push(`Commit ${formatSha(commit.sha)} contains prohibited trailer: ${line}`)
     }
+  }
+
+  if (releaseAsVersion && !commits.some(commit => getReleaseAsVersion(commit.message) === releaseAsVersion)) {
+    issues.push(
+      `Release-As source PR declares ${releaseAsVersion}, but no pull request commit carries the same Release-As footer.`,
+    )
   }
 
   if (commits.length > 1) {
@@ -73,7 +81,7 @@ export function validatePullRequestMergeCommitPolicy(input: PullRequestMergeComm
 if (import.meta.main) {
   const commits = parseCommits(process.argv.slice(2), process.env.PR_COMMITS_JSON)
   const validatedReleasePr = parseBooleanFlag(process.env.PR_IS_VALIDATED_RELEASE_PR)
-  const policyInput = { commits, validatedReleasePr }
+  const policyInput = { body: process.env.PR_BODY, commits, validatedReleasePr }
   const issues = validatePullRequestMergeCommitPolicy(policyInput)
 
   if (issues.length > 0) {
@@ -146,4 +154,8 @@ function isTrustedReleaseBotAuthor(commit: PullRequestCommitMetadata): boolean {
 function parseBooleanFlag(rawValue: string | undefined): boolean {
   if (!rawValue) return false
   return ['1', 'true', 'yes'].includes(rawValue.trim().toLowerCase())
+}
+
+function getReleaseAsVersion(value: string): string | undefined {
+  return value.match(/^release-as:\s*(\S+)\s*$/im)?.[1]
 }

--- a/scripts/release-target-resolution.ts
+++ b/scripts/release-target-resolution.ts
@@ -44,6 +44,7 @@ export interface SelectReleaseCandidateOptions {
 const releaseTagPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 const releaseCommitPattern = /^chore: release (?<version>\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$/
 const releaseWorthyPattern = /^(feat|fix|perf)(\(.+\))?!?:/
+const releaseAsPattern = /^release-as:\s*\S+\s*$/im
 
 export function classifyCommitReleaseIntent(message: string): CommitReleaseIntent {
   const firstLine = message.split('\n')[0] ?? ''
@@ -52,7 +53,8 @@ export function classifyCommitReleaseIntent(message: string): CommitReleaseInten
   return {
     firstLine,
     isReleaseCommit: Boolean(releaseMatch),
-    isReleaseWorthy: releaseWorthyPattern.test(firstLine) || message.includes('\nBREAKING CHANGE:'),
+    isReleaseWorthy:
+      releaseWorthyPattern.test(firstLine) || message.includes('\nBREAKING CHANGE:') || releaseAsPattern.test(message),
     releaseVersion: releaseMatch?.groups?.version ?? null,
   }
 }

--- a/test/pr-body-policy.test.ts
+++ b/test/pr-body-policy.test.ts
@@ -20,6 +20,10 @@ Describe the change.
 
 - Release: not applicable - docs/process/test-only change
 
+## Release Summary
+
+- Not applicable - this change does not produce a release entry.
+
 ## Docs Updated
 
 - [x] \`openspec/...\`
@@ -51,7 +55,7 @@ describe('PR body policy', () => {
         title: 'docs: incomplete body',
       }),
     ).toEqual([
-      'PR body is missing required sections: ## Linked Artifacts, ## Validation, ## Release Intent, ## Docs Updated, ## Scope Check, ## Closure Check',
+      'PR body is missing required sections: ## Linked Artifacts, ## Validation, ## Release Intent, ## Release Summary, ## Docs Updated, ## Scope Check, ## Closure Check',
     ])
   })
 
@@ -119,5 +123,60 @@ describe('PR body policy', () => {
     })
 
     expect(issues.join('\n')).toContain('Product-impacting PRs must not silently skip release automation.')
+  })
+
+  it('requires a release-please commit override for release-worthy source PRs', () => {
+    const body = validBody.replace(
+      'Release: not applicable - docs/process/test-only change',
+      'Release: minor - user-facing lifecycle behavior',
+    )
+
+    const issues = validatePrBodyPolicy({
+      body,
+      changedFiles: ['src/cli.ts'],
+      title: 'feat: improve lifecycle reporting',
+    })
+
+    expect(issues.join('\n')).toContain('BEGIN_COMMIT_OVERRIDE')
+  })
+
+  it('accepts a user-facing commit override for release-worthy source PRs', () => {
+    const body = validBody
+      .replace(
+        'Release: not applicable - docs/process/test-only change',
+        'Release: minor - user-facing lifecycle behavior',
+      )
+      .replace(
+        '- Not applicable - this change does not produce a release entry.',
+        'BEGIN_COMMIT_OVERRIDE\nfeat: improve lifecycle reporting for managed agents\nEND_COMMIT_OVERRIDE',
+      )
+
+    expect(
+      validatePrBodyPolicy({
+        body,
+        changedFiles: ['src/cli.ts'],
+        title: 'feat: improve lifecycle reporting',
+      }),
+    ).toEqual([])
+  })
+
+  it('treats Release-As source metadata as release-worthy and requires it in the summary', () => {
+    const body = validBody
+      .replace(
+        'Release: not applicable - docs/process/test-only change',
+        'Release: major - planned protocol graduation',
+      )
+      .replace(
+        '- Not applicable - this change does not produce a release entry.',
+        'BEGIN_COMMIT_OVERRIDE\nrefactor: consolidate the lifecycle engine\nEND_COMMIT_OVERRIDE\n\nRelease-As: 2.0.0',
+      )
+
+    expect(
+      validatePrBodyPolicy({
+        body,
+        changedFiles: ['src/cli.ts'],
+        title: 'chore(release): graduate lifecycle engine',
+      }),
+    ).toEqual([])
   })
 })

--- a/test/pr-governance.test.ts
+++ b/test/pr-governance.test.ts
@@ -18,6 +18,11 @@ describe('pr governance release intent', () => {
     expect(prTemplate).toContain('## Release Intent')
   })
 
+  it('requires a release-summary section in PR bodies', () => {
+    expect(prBodyPolicyScript).toContain("'## Release Summary'")
+    expect(prTemplate).toContain('## Release Summary')
+  })
+
   it('guards product-impacting files from silently skipping release automation', () => {
     expect(prGovernanceWorkflow).toContain('bun run pr:body:check')
     expect(prGovernanceWorkflow).toContain('PR_BODY')
@@ -31,6 +36,7 @@ describe('pr governance release intent', () => {
       const config = JSON.parse(readFileSync(fileName, 'utf8')) as {
         packages: {
           '.': {
+            'changelog-types'?: Array<{ hidden?: boolean; section?: string; type?: string }>
             'pull-request-header': string
           }
         }
@@ -38,7 +44,13 @@ describe('pr governance release intent', () => {
       const header = config.packages['.']['pull-request-header']
 
       expect(header).toContain('## Release Intent')
+      expect(header).toContain('## Release Summary')
       expect(header).toContain('## Closure Check')
+      expect(config.packages['.']['changelog-types']).toContainEqual({
+        hidden: false,
+        section: 'Internal Improvements',
+        type: 'refactor',
+      })
     }
   })
 

--- a/test/pr-merge-commit-policy.test.ts
+++ b/test/pr-merge-commit-policy.test.ts
@@ -117,10 +117,30 @@ describe('pr merge commit policy', () => {
     expect(issues).toContainEqual(expect.stringContaining('Co-authored-by:'))
   })
 
+  it('requires a Release-As source PR commit to carry the declared footer', () => {
+    const body = '## Release Summary\n\nRelease-As: 2.0.0'
+    const issues = validatePullRequestMergeCommitPolicy({ body, commits: [cleanCommits[0]!] })
+
+    expect(issues).toContainEqual(expect.stringContaining('no pull request commit carries the same Release-As footer'))
+  })
+
+  it('accepts a Release-As source PR when its commit carries the same footer', () => {
+    const body = '## Release Summary\n\nRelease-As: 2.0.0'
+    const commits = [
+      {
+        ...cleanCommits[0]!,
+        message: 'chore(release): graduate lifecycle engine\n\nRelease-As: 2.0.0',
+      },
+    ]
+
+    expect(validatePullRequestMergeCommitPolicy({ body, commits })).toEqual([])
+  })
+
   it('removes temporary topology inputs from the workflow policy step', () => {
     const policyStep = extractNamedStep(prGovernanceWorkflow, 'Validate PR merge commit policy')
 
     expect(policyStep).toContain('PR_COMMITS_JSON')
+    expect(policyStep).toContain('PR_BODY')
     expect(policyStep).toContain('PR_IS_VALIDATED_RELEASE_PR')
     expect(policyStep).not.toContain('PR_BASE_BRANCH')
     expect(policyStep).not.toContain('PR_HEAD_BRANCH')

--- a/test/release-target-resolution.test.ts
+++ b/test/release-target-resolution.test.ts
@@ -36,8 +36,12 @@ describe('release target resolution', () => {
     expect(resolution.targetSha).toBe('graduation')
   })
 
-  it('does not mistake Release-As metadata on a chore commit for a release-worthy resolver input', () => {
-    expect(commit('chore(release): graduate post-redesign line\n\nRelease-As: 1.1.0').isReleaseWorthy).toBe(false)
+  it('recognizes Release-As metadata on a neutral commit as release-worthy resolver input', () => {
+    expect(commit('chore(release): graduate post-redesign line\n\nRelease-As: 2.0.0').isReleaseWorthy).toBe(true)
+  })
+
+  it('keeps neutral commits without Release-As out of release reconciliation', () => {
+    expect(commit('chore(release): prepare release governance').isReleaseWorthy).toBe(false)
   })
 
   it('publishes a pending untagged release commit before creating another release PR', () => {


### PR DESCRIPTION
## Summary

- make `Release-As` a neutral release-please trigger without a false breaking marker
- render intentional refactors in generated release notes and require source-PR summaries

## Linked Artifacts

- OpenSpec: `improve-release-notes-workflow`

## Validation

- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run openspec:validate`
- [x] `bun run memory:check`
- [x] `bun run build`
- [x] `bun run build:bin`
- [x] `bun run release:artifacts`
- [x] `bun run release:smoke`
- [x] `bun run package:check`

## Release Intent

- Release: not applicable - this process-only change improves future release-note generation but must not publish a version itself.

## Release Summary

- Not applicable - this source PR does not produce a release entry.

## Docs Updated

- [x] `docs/runbooks/releasing-quantex.md`
- [x] `openspec/...`

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change remains active until this implementation PR merges, then requires agent-driven archive closure.
- [x] Release is not applicable - this PR must not trigger release automation.
