### PR TITLE
ci: upgrade GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,14 @@ jobs:
       run_test_matrix: ${{ steps.classify.outputs.run_test_matrix }}
       scope: ${{ steps.classify.outputs.scope }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
 
       - name: List changed files
         id: changed-files
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             async function listChangedFiles() {
@@ -95,14 +95,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
 
       - name: List commits for trailer policy
         id: commits
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             async function listCommits() {
@@ -145,7 +145,7 @@ jobs:
 
             core.setOutput('commits_json', JSON.stringify(await listCommits()))
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: |
             .bun/install/cache
@@ -190,13 +190,13 @@ jobs:
           echo "Process-only change detected (${CHANGE_SCOPE}); running the minimal Ubuntu build guard while skipping the full test matrix."
 
       - if: ${{ needs.classify.outputs.run_test_matrix == 'true' || runner.os == 'Linux' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         if: ${{ needs.classify.outputs.run_test_matrix == 'true' || runner.os == 'Linux' }}
         with:
           bun-version: 1.3.11
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         if: ${{ needs.classify.outputs.run_test_matrix == 'true' || runner.os == 'Linux' }}
         with:
           path: |

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -16,14 +16,14 @@ jobs:
   validate-body:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
 
       - name: List changed files
         id: changed-files
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -37,7 +37,7 @@ jobs:
 
       - name: List pull request commits
         id: commits
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const commits = await github.paginate(github.rest.pulls.listCommits, {
@@ -63,7 +63,7 @@ jobs:
       - name: Read base package version for release PR validation
         id: base-version
         if: startsWith(github.event.pull_request.head.ref, 'release-please--branches--')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const packageJson = await github.rest.repos.getContent({

--- a/.github/workflows/release-pr-automerge.yml
+++ b/.github/workflows/release-pr-automerge.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository validation logic
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
           # Use the base ref, not the PR head: pull_request_target runs with elevated
@@ -32,7 +32,7 @@ jobs:
 
       - name: Validate Release PR scope
         id: validate-release-pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { validateReleasePrPolicy } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/release-pr-policy.js`)

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -16,7 +16,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: lts/*
 
@@ -48,7 +48,7 @@ jobs:
         run: bun run package:check
 
       - name: Upload release build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: quantex-release-build
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Checkout branch source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ steps.branch.outputs.target_branch }}
@@ -103,7 +103,7 @@ jobs:
       - name: Release Please PR
         id: release-pr
         if: ${{ steps.release-target.outputs.mode == 'pr' }}
-        uses: googleapis/release-please-action@v4.1.5
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.release-bot-token.outputs.token }}
           target-branch: ${{ steps.release-target.outputs.target_branch }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Checkout release commit
         if: ${{ steps.release-target.outputs.mode == 'publish' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ steps.release-target.outputs.target_sha }}
@@ -121,7 +121,7 @@ jobs:
       - name: Release Please GitHub Release
         id: release
         if: ${{ steps.release-target.outputs.mode == 'publish' }}
-        uses: googleapis/release-please-action@v4.1.5
+        uses: googleapis/release-please-action@v5
         with:
           token: ${{ steps.release-bot-token.outputs.token }}
           target-branch: ${{ steps.release-target.outputs.target_branch }}
@@ -131,14 +131,14 @@ jobs:
 
       - name: Checkout released source
         if: ${{ steps.release-target.outputs.mode == 'publish' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ steps.release-target.outputs.target_sha }}
 
       - name: Setup Node.js
         if: ${{ steps.release-target.outputs.mode == 'publish' }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -36,14 +36,14 @@ jobs:
       scope: ${{ steps.classify.outputs.scope }}
       trusted_pr: ${{ steps.pr-trust.outputs.trusted_pr }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
 
       - name: List changed files
         id: changed-files
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             async function listChangedFiles() {
@@ -98,7 +98,7 @@ jobs:
 
       - name: Detect PR trust
         id: pr-trust
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             if (context.eventName !== 'pull_request') {
@@ -138,7 +138,7 @@ jobs:
           echo "Modal secrets are not exposed to fork pull_request workflows."
           echo "Maintainers must rerun sandbox validation from a trusted repository branch before merging."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         if: >-
           ${{
             needs.classify.outputs.sandbox_relevant == 'true'
@@ -154,7 +154,7 @@ jobs:
         with:
           bun-version: 1.3.11
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         if: >-
           ${{
             needs.classify.outputs.sandbox_relevant == 'true'
@@ -163,7 +163,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         if: >-
           ${{
             needs.classify.outputs.sandbox_relevant == 'true'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions workflow pins to Node.js 24-compatible major versions so hosted runners stop emitting Node 20 deprecation warnings and remain compatible after the fall 2026 removal deadline.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec:
- Discussion: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Validation

- [ ] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [x] Not run, explained below

Workflow pin updates only; no CLI behavior changed. CI will validate the updated actions on this PR.

## Release Intent

- Release: not applicable - docs/process/test-only change
- Release: patch - bug fix
- Release: minor - user-facing feature
- Release: major - breaking change

## Release Summary

- Not applicable - this source PR does not produce a release entry.

## Docs Updated

- [x] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [ ] Working tree was clean after commit.
- [ ] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active until this merge, active across milestone merges by design, queued for agent-driven archive closure after completion, or already archived.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

Action bumps across all workflows:

- `actions/checkout@v4` → `@v7`
- `actions/cache@v4` → `@v6`
- `actions/github-script@v7` → `@v9`
- `actions/setup-node@v4` → `@v7`
- `actions/upload-artifact@v4` → `@v7`
- `actions/setup-python@v5` → `@v6`
- `googleapis/release-please-action@v4.1.5` → `@v5`

`oven-sh/setup-bun@v2` and `actions/create-github-app-token@v3` already run on Node 24 and were left unchanged.
