### PR TITLE
fix(update): reconcile tracked and absent agents

### DIFF
--- a/openspec/changes/fix-agent-update-reconciliation/.openspec.yaml
+++ b/openspec/changes/fix-agent-update-reconciliation/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/fix-agent-update-reconciliation/design.md
+++ b/openspec/changes/fix-agent-update-reconciliation/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The lifecycle update service currently plans every catalog entry, then suppresses only one exact absent observation shape. Candidate-provider uncertainty therefore turns a never-installed agent into a failed batch target. The same service also requires the recorded provider to resolve a target version before planning any update, so it bypasses the existing `AgentDefinition.selfUpdate` strategy for tracked script and binary installs.
+
+The command layer then projects similar blocked outcomes differently for single and batch execution. Existing state reconciliation already recognizes `recorded-absent` observations and `qtx uninstall <agent>` can safely clear conclusive ghost evidence.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make batch eligibility depend on installed/executable evidence rather than candidate-provider availability.
+- Preserve recorded install provenance while executing declared self-update commands.
+- Verify self-update results from fresh version observations.
+- Keep stale state non-fatal during batch update and provide explicit reconciliation guidance.
+- Use one command projection for equivalent single and batch outcomes.
+
+**Non-Goals:**
+
+- Automatically adopt or manage PATH-only agents.
+- Silently delete stale state during `update`.
+- Add an ignore list, daemon, workflow engine, or new top-level command.
+- Reclassify script installs as package-manager-managed installs.
+
+## Decisions
+
+### Filter catalog-only absence from observed facts
+
+The batch planner will suppress an agent whenever no executable, installed state, or lifecycle receipt exists. Provider drift does not override those absence facts. This retains catalog scanning for PATH-only discovery while preventing unavailable candidate installers from creating false failures.
+
+Alternative considered: list only persisted state names. Rejected because existing behavior intentionally reports untracked PATH executables without mutating them.
+
+### Model provider and self-update execution separately
+
+The update plan will distinguish managed-provider execution from self-update execution. A self-update plan carries the declared command and pre-update version but leaves the recorded script or binary binding unchanged. It does not require `resolveLatestVersion`, because upstream self-updaters often choose their own target.
+
+Alternative considered: call the legacy `updateAgentOutcome` service. Rejected because it also performs install-method fallback and state mutation outside the new lifecycle planning and verification boundary.
+
+### Verify self-update by fresh observation
+
+After a successful self-update command, Quantex will observe the agent again. A changed comparable version is `updated`; an unchanged comparable version is `up-to-date`; disappearance, source drift, or an unobservable post-update version is a verification failure. Successful verification may write a lifecycle receipt while retaining installed-state provenance.
+
+### Keep ghost cleanup explicit
+
+A conclusively absent agent with recorded evidence is excluded from update execution and reported as a non-fatal stale-state warning with `qtx uninstall <agent>` remediation. `update` will not delete evidence because temporary PATH/provider failures must fail closed.
+
+### Share outcome projection
+
+Single and batch handlers will use the same conversion from lifecycle planning/execution outcomes to `UpdateResultItem`. No new update status enum value is required; stale targets use structured warnings instead of failed result entries.
+
+## Risks / Trade-offs
+
+- [A self-updater exits successfully without changing a version] → Report `up-to-date`, matching the existing agent-update contract.
+- [A self-updater cannot be version-probed afterward] → Fail verification instead of claiming success.
+- [A stale state warning remains until the user reconciles it] → Provide a precise `qtx uninstall <agent>` command and keep the update batch successful.
+- [Provider uncertainty could hide a catalog-only installation outside PATH] → Without executable or persisted evidence Quantex has no ownership proof and must not treat the agent as installed.
+
+## Migration Plan
+
+1. Add contract and focused regression tests.
+2. Introduce the self-update execution plan and typed executor port.
+3. Apply batch filtering, stale warnings, and shared projection.
+4. Validate stable JSON/NDJSON fixtures and the full repository suite.
+5. Release as a patch; rollback is a normal revert because no state schema migration is introduced.
+
+## Open Questions
+
+None.

--- a/openspec/changes/fix-agent-update-reconciliation/proposal.md
+++ b/openspec/changes/fix-agent-update-reconciliation/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Work intake classification: this fixes observable `update` behavior, structured batch outcomes, lifecycle source selection, and stale state diagnostics, so it requires an OpenSpec-backed change.
+
+The lifecycle update integration introduced regressions where `update --all` reports never-installed catalog entries as failures, tracked script installs ignore declared self-update commands, and stale install records are presented as provider failures. These outcomes make a healthy update run fail and contradict the existing agent-update contract.
+
+## What Changes
+
+- Exclude catalog-only absent agents from batch update results even when an unavailable candidate provider makes observation inconclusive.
+- Route tracked script or binary installs through their declared self-update command without rewriting their recorded install source.
+- Treat conclusively absent tracked agents as stale lifecycle evidence instead of update execution failures, with an explicit reconciliation hint.
+- Project the same lifecycle planning outcome consistently for single-agent and batch updates.
+- Keep untracked executables such as PATH-only agents non-mutating and manual-required.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `agent-update`: clarify batch eligibility, self-update execution and verification, stale-state outcomes, and single/batch projection consistency.
+
+## Impact
+
+- Affected update planning and execution: `src/services/lifecycle-updates.ts` and `src/services/lifecycle-updates-production.ts`.
+- Affected command projection: `src/commands/update.ts`.
+- Affected tests and v1 compatibility fixtures for lifecycle update behavior.
+- No new dependency, command, configuration key, or workflow-orchestration surface.

--- a/openspec/changes/fix-agent-update-reconciliation/specs/agent-update/spec.md
+++ b/openspec/changes/fix-agent-update-reconciliation/specs/agent-update/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Batch update eligibility MUST follow live and persisted installation evidence
+
+`quantex update --all` MUST exclude a catalog entry when no executable, installed-agent state, or lifecycle receipt exists, even if a candidate provider is unavailable or cannot conclusively report package absence. A recorded-absent target MUST NOT be executed as an update or counted as an update failure.
+
+#### Scenario: Never-installed agent has an unavailable candidate provider
+
+- **GIVEN** an agent exists in the catalog
+- **AND** its executable, installed-agent state, and lifecycle receipt are absent
+- **AND** a candidate provider is unavailable or inconclusive
+- **WHEN** the user runs `quantex update --all`
+- **THEN** the agent is omitted from update results
+- **AND** the batch is not failed because of that catalog entry
+
+#### Scenario: Recorded agent is conclusively absent
+
+- **GIVEN** an agent has persisted lifecycle evidence
+- **AND** fresh observation conclusively reports the provider target and executable absent
+- **WHEN** the user runs `quantex update --all`
+- **THEN** Quantex does not execute an update for that agent
+- **AND** it does not count the stale target as an update failure
+- **AND** it emits reconciliation guidance without silently deleting the evidence
+
+### Requirement: Lifecycle updates MUST execute declared self-update commands for tracked unmanaged sources
+
+When an installed agent has recorded script or binary provenance and declares a self-update command, Quantex MUST execute that command instead of requiring the install-source provider to resolve a target version. Quantex MUST retain the recorded install provenance and verify the result from a fresh observation.
+
+#### Scenario: Tracked script install supports self-update
+
+- **GIVEN** an installed agent has recorded `script` install state
+- **AND** its catalog definition declares a self-update command
+- **WHEN** the user runs a single or batch update
+- **THEN** Quantex executes the declared self-update command
+- **AND** it does not invoke a candidate managed installer
+- **AND** it does not rewrite the recorded script provenance
+
+#### Scenario: Self-update changes the installed version
+
+- **GIVEN** a tracked agent executes its self-update command successfully
+- **AND** a fresh observation reports a newer comparable version with matching source evidence
+- **WHEN** Quantex verifies the update
+- **THEN** the result is `updated`
+
+#### Scenario: Self-update leaves the installed version unchanged
+
+- **GIVEN** a tracked agent executes its self-update command successfully
+- **AND** fresh observation reports the same comparable version with matching source evidence
+- **WHEN** Quantex verifies the update
+- **THEN** the result is `up-to-date`
+
+#### Scenario: Self-update cannot be verified
+
+- **GIVEN** a self-update command exits successfully
+- **AND** fresh observation cannot confirm a present executable, matching source, or comparable installed version
+- **WHEN** Quantex verifies the update
+- **THEN** it reports a verification failure
+- **AND** it does not claim the agent was updated
+
+### Requirement: Single and batch update projections MUST remain consistent
+
+Equivalent lifecycle planning and execution outcomes MUST use the same update status and explanation in single-agent and batch update modes.
+
+#### Scenario: Equivalent blocked outcome in both scopes
+
+- **GIVEN** the same installed agent produces the same blocked lifecycle update outcome
+- **WHEN** it is updated once by name and once through `--all`
+- **THEN** both result items use the same status and explanation
+- **AND** only genuine failed outcomes contribute to update failure exit semantics

--- a/openspec/changes/fix-agent-update-reconciliation/tasks.md
+++ b/openspec/changes/fix-agent-update-reconciliation/tasks.md
@@ -1,0 +1,16 @@
+## 1. Contract and Regression Coverage
+
+- [x] 1.1 Add lifecycle service tests for catalog-only absence, recorded-absent state, tracked self-update success/no-change/failure, and untracked PATH preservation.
+- [x] 1.2 Add command tests proving consistent single/batch projection and non-fatal stale-state guidance.
+
+## 2. Lifecycle Update Implementation
+
+- [x] 2.1 Filter batch targets from executable and persisted lifecycle evidence rather than provider drift.
+- [x] 2.2 Add a typed self-update plan and executor with fresh version/source verification and receipt persistence.
+- [x] 2.3 Project stale and blocked outcomes consistently in single and batch command modes.
+
+## 3. Validation and Delivery
+
+- [x] 3.1 Run focused tests, lint, format check, typecheck, full tests, OpenSpec validation, and memory validation.
+- [x] 3.2 Reproduce the corrected local `update --all` and Cursor dry-run behavior from the source CLI.
+- [x] 3.3 Commit the intended files, push the branch, validate the PR body, open the PR, and verify remote checks/state.

--- a/src/agent-update/index.ts
+++ b/src/agent-update/index.ts
@@ -1,4 +1,5 @@
 export { getAgentUpdateFailureHint, getManualAgentUpdateMessage, getUntrackedPathAgentUpdateMessage } from './messages'
+export { executeAgentSelfUpdate } from './self-update'
 export {
   agentUpdateProviders,
   canResolveAgentUpdate,

--- a/src/agent-update/self-update.ts
+++ b/src/agent-update/self-update.ts
@@ -1,0 +1,33 @@
+import type { ProviderMutationEvidence, ProviderOperationContext, ProviderOutcome, ProviderTarget } from '../providers'
+import { runPackageMutationOutcome } from '../package-manager/mutation-outcome'
+
+export async function executeAgentSelfUpdate(request: {
+  readonly commands: readonly (readonly string[])[]
+  readonly context: ProviderOperationContext
+  readonly target: ProviderTarget
+}): Promise<ProviderOutcome<ProviderMutationEvidence>> {
+  let lastFailure: Exclude<ProviderOutcome<void>, { readonly kind: 'success' }> | undefined
+
+  for (const command of request.commands) {
+    const outcome = await runPackageMutationOutcome(command, request.context, 'agent self-update failed')
+    if (outcome.kind === 'success') {
+      return {
+        kind: 'success',
+        value: {
+          evidence: [{ kind: 'command', value: command.join(' ') }],
+          target: request.target,
+        },
+      }
+    }
+    if (outcome.kind === 'cancelled' || outcome.kind === 'timed-out') return outcome
+    lastFailure = outcome
+  }
+
+  return (
+    lastFailure ?? {
+      kind: 'unsupported',
+      operation: 'update',
+      reason: 'No self-update command is configured.',
+    }
+  )
+}

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -1,6 +1,6 @@
 import type { AgentDefinition } from '../agents'
 import type { CommandIdempotencyPolicyFactory } from '../command-runtime'
-import type { CommandResult } from '../output/types'
+import type { CommandResult, CommandWarning } from '../output/types'
 import type {
   LifecycleUpdateBatchCancellationRemainder,
   LifecycleUpdateBatchTargetOutcome,
@@ -155,6 +155,7 @@ async function updateAllAgents(dependencies: UpdateCommandDependencies): Promise
 
   const outcome = await dependencies.runBatch()
   const results = projectLifecycleUpdateBatch(outcome)
+  const warnings = projectLifecycleUpdateWarnings(outcome)
 
   if (hasBatchCancellation(outcome)) {
     return emitCommandResult(
@@ -171,6 +172,7 @@ async function updateAllAgents(dependencies: UpdateCommandDependencies): Promise
         target: {
           kind: 'agent',
         },
+        warnings,
       }),
       renderUpdateHuman,
     )
@@ -191,6 +193,7 @@ async function updateAllAgents(dependencies: UpdateCommandDependencies): Promise
         target: {
           kind: 'agent',
         },
+        warnings,
       }),
       renderUpdateHuman,
     )
@@ -206,6 +209,7 @@ async function updateAllAgents(dependencies: UpdateCommandDependencies): Promise
       target: {
         kind: 'agent',
       },
+      warnings,
     }),
     renderUpdateHuman,
   )
@@ -273,11 +277,13 @@ async function updateSingleAgent(
     )
   }
   if (before?.observation.kind === 'absent') {
+    const warnings = before.observation.drift.kind === 'recorded-absent' ? [staleStateWarning(agent)] : []
     return emitCommandResult(
       createErrorResult<UpdateCommandData>({
         action: 'update',
         error: { code: 'AGENT_NOT_INSTALLED', message: `${agent.displayName} is not installed.` },
         target: { kind: 'agent', name: agent.name },
+        warnings,
       }),
       renderUpdateHuman,
     )
@@ -337,8 +343,8 @@ function toSingleUpdateResult(agent: AgentDefinition, outcome: RunSingleAgentLif
   const before = getSingleUpdateBefore(outcome)
   const plan = 'plan' in outcome ? outcome.plan : undefined
   const installedVersion = before?.observation.kind === 'present' ? before.observation.version : undefined
-  const latestVersion = plan?.plannedTargetVersion
-  const strategy = plan ? `managed/${plan.binding.providerId}` : before?.binding?.providerId
+  const latestVersion = planLatestVersion(plan)
+  const strategy = planStrategy(plan) ?? before?.binding?.providerId
 
   switch (outcome.kind) {
     case 'updated':
@@ -348,6 +354,14 @@ function toSingleUpdateResult(agent: AgentDefinition, outcome: RunSingleAgentLif
         latestVersion: outcome.receipt.version ?? latestVersion,
         name: agent.name,
         status: 'updated',
+        strategy,
+      }
+    case 'up-to-date':
+      return {
+        displayName: agent.displayName,
+        installedVersion: outcome.receipt.version ?? installedVersion,
+        name: agent.name,
+        status: 'up-to-date',
         strategy,
       }
     case 'dry-run':
@@ -379,6 +393,24 @@ function toSingleUpdateResult(agent: AgentDefinition, outcome: RunSingleAgentLif
         status: 'manual-required',
       }
     case 'blocked':
+      if (outcome.category === 'untracked') {
+        return {
+          displayName: agent.displayName,
+          installedVersion,
+          message: getUntrackedPathAgentUpdateMessage(agent),
+          name: agent.name,
+          status: 'manual-required',
+        }
+      }
+      if (outcome.category === 'manual-required') {
+        return {
+          displayName: agent.displayName,
+          installedVersion,
+          message: getManualAgentUpdateMessage(agent),
+          name: agent.name,
+          status: 'manual-required',
+        }
+      }
       return {
         displayName: agent.displayName,
         installedVersion,
@@ -447,14 +479,16 @@ function projectLifecycleUpdateBatch(outcome: LifecycleUpdateBatchCommandOutcome
   for (const target of outcome.plan.targets) {
     const completed = completedById.get(target.id)
     const remainder = remainderById.get(target.id)
-    if (completed) pushUpdateResult(results, toBatchUpdateResult(completed))
-    else if (remainder) pushUpdateResult(results, toCancellationRemainderResult(remainder))
+    if (completed) {
+      const result = toBatchUpdateResult(completed)
+      if (result) pushUpdateResult(results, result)
+    } else if (remainder) pushUpdateResult(results, toCancellationRemainderResult(remainder))
   }
 
   return results
 }
 
-function toBatchUpdateResult(target: LifecycleUpdateBatchTargetOutcome): UpdateResultItem {
+function toBatchUpdateResult(target: LifecycleUpdateBatchTargetOutcome): UpdateResultItem | undefined {
   const before =
     target.planning.kind === 'unknown-agent'
       ? undefined
@@ -471,37 +505,18 @@ function toBatchUpdateResult(target: LifecycleUpdateBatchTargetOutcome): UpdateR
   }
 
   const execution = target.execution
-  if (target.planning.kind === 'blocked' && target.planning.category === 'untracked') {
-    return {
-      displayName: agent.displayName,
-      installedVersion:
-        target.planning.before.observation.kind === 'present' ? target.planning.before.observation.version : undefined,
-      message: getUntrackedPathAgentUpdateMessage(agent),
-      name: agent.name,
-      status: 'manual-required',
-    }
-  }
-  if (target.planning.kind === 'blocked' && target.planning.category === 'manual-required') {
-    return {
-      displayName: agent.displayName,
-      installedVersion:
-        target.planning.before.observation.kind === 'present' ? target.planning.before.observation.version : undefined,
-      message: getManualAgentUpdateMessage(agent),
-      name: agent.name,
-      status: 'manual-required',
-    }
-  }
+  if (target.planning.kind === 'blocked' && target.planning.category === 'stale-state') return undefined
   if (execution?.kind === 'locked') {
     return {
       displayName: agent.displayName,
       installedVersion:
         execution.plan.before.observation.kind === 'present' ? execution.plan.before.observation.version : undefined,
-      latestVersion: execution.plan.plannedTargetVersion,
+      latestVersion: planLatestVersion(execution.plan),
       message: execution.reason,
       name: agent.name,
       resource: execution.resource,
       status: 'locked',
-      strategy: `managed/${execution.plan.binding.providerId}`,
+      strategy: planStrategy(execution.plan),
     }
   }
   if (execution?.kind === 'unexpected-failure') {
@@ -509,11 +524,11 @@ function toBatchUpdateResult(target: LifecycleUpdateBatchTargetOutcome): UpdateR
       displayName: agent.displayName,
       installedVersion:
         execution.plan.before.observation.kind === 'present' ? execution.plan.before.observation.version : undefined,
-      latestVersion: execution.plan.plannedTargetVersion,
+      latestVersion: planLatestVersion(execution.plan),
       message: execution.reason,
       name: agent.name,
       status: 'failed',
-      strategy: `managed/${execution.plan.binding.providerId}`,
+      strategy: planStrategy(execution.plan),
     }
   }
 
@@ -540,12 +555,41 @@ function toCancellationRemainderResult(target: LifecycleUpdateBatchCancellationR
   return {
     displayName: agent?.displayName ?? before.agent.displayName,
     installedVersion: before.observation.kind === 'present' ? before.observation.version : undefined,
-    latestVersion: target.planning.planned.plannedTargetVersion,
+    latestVersion: planLatestVersion(target.planning.planned),
     message: target.reason ?? 'Update was cancelled before it could start.',
     name: agent?.name ?? target.agentName,
     status: 'failed',
-    strategy: `managed/${target.planning.planned.binding.providerId}`,
+    strategy: planStrategy(target.planning.planned),
   }
+}
+
+function projectLifecycleUpdateWarnings(outcome: LifecycleUpdateBatchCommandOutcome): CommandWarning[] {
+  return outcome.plan.targets.flatMap(target => {
+    if (target.outcome.kind !== 'blocked' || target.outcome.category !== 'stale-state') return []
+    const agent = resolveAgent(target.agentName) ?? target.outcome.before.agent
+    return [staleStateWarning(agent)]
+  })
+}
+
+function staleStateWarning(agent: Pick<AgentDefinition, 'displayName' | 'name'>): CommandWarning {
+  return {
+    code: 'AGENT_STALE_STATE',
+    details: {
+      agentName: agent.name,
+      suggestedAction: 'reconcile-agent-state',
+      suggestedCommands: [`quantex uninstall ${agent.name}`],
+    },
+    message: `${agent.displayName} is not installed but has stale lifecycle evidence. Run \`quantex uninstall ${agent.name}\` to reconcile it.`,
+  }
+}
+
+function planLatestVersion(plan: import('../services/lifecycle-updates').SingleAgentLifecycleUpdatePlan | undefined) {
+  return plan?.strategy === 'managed-provider' ? plan.plannedTargetVersion : undefined
+}
+
+function planStrategy(plan: import('../services/lifecycle-updates').SingleAgentLifecycleUpdatePlan | undefined) {
+  if (!plan) return undefined
+  return plan.strategy === 'self-update' ? 'self-update' : `managed/${plan.binding.providerId}`
 }
 
 function hasBatchCancellation(outcome: LifecycleUpdateBatchCommandOutcome): boolean {
@@ -572,11 +616,14 @@ function pushUpdateResult(results: UpdateResultItem[], result: UpdateResultItem)
 function renderUpdateHuman(result: {
   data?: UpdateCommandData
   error: { code: string; message: string } | null
+  warnings: CommandWarning[]
 }): void {
   if (!result.data) {
     if (result.error) printError(pc.red(result.error.message))
     return
   }
+
+  for (const warning of result.warnings) printWarn(pc.yellow(warning.message))
 
   for (const item of result.data.results) {
     switch (item.status) {

--- a/src/idempotency/lifecycle-policy.ts
+++ b/src/idempotency/lifecycle-policy.ts
@@ -96,7 +96,7 @@ export async function createAgentUpdateIdempotencyPolicy(
     async captureEvidence() {
       const outcome = invocation.getOutcome()
       if (!outcome) return undefined
-      if (outcome.kind === 'updated') {
+      if (outcome.kind === 'updated' || outcome.kind === 'up-to-date') {
         const classified = classifyUpdateObservation(outcome.after, outcome.plan, outcome.receipt)
         return classified.kind === 'compatible' ? classified.evidence : undefined
       }
@@ -145,7 +145,7 @@ export async function createAgentBatchUpdateIdempotencyPolicy(
         if (target.outcome.kind !== 'planned') return undefined
         const execution = results.get(target.id)?.execution
         let classified: UpdateObservationClassification
-        if (execution?.kind === 'updated') {
+        if (execution?.kind === 'updated' || execution?.kind === 'up-to-date') {
           classified = classifyUpdateObservation(execution.after, execution.plan, execution.receipt)
         } else if (execution?.kind === 'not-executed' && execution.plan.planning.decision === 'up-to-date') {
           const current = await safelyObserveUpdate(invocation.observe, target.agentName)
@@ -643,9 +643,16 @@ function classifyUpdateObservation(
   plan: SingleAgentLifecycleUpdatePlan,
   receipt: LifecycleReceipt | undefined = current.receipt,
 ): UpdateObservationClassification {
+  const expectedVersion =
+    plan.strategy === 'managed-provider'
+      ? plan.plannedTargetVersion
+      : (receipt?.version ??
+        (current.observation.kind === 'present' ? current.observation.version : undefined) ??
+        current.executable.version)
+  if (!expectedVersion) return { kind: 'inconclusive' }
   const expected: StoredUpdateEvidence = {
     agentTargetId: plan.before.agent.name,
-    expectedVersion: plan.plannedTargetVersion,
+    expectedVersion,
     providerId: plan.binding.providerId,
     providerTargetId: plan.binding.target.id,
     providerTargetKind: plan.binding.target.kind,

--- a/src/services/lifecycle-updates-production.ts
+++ b/src/services/lifecycle-updates-production.ts
@@ -7,6 +7,7 @@ import type {
   SingleAgentLifecycleUpdateExecutionOutcome,
   SingleAgentLifecycleUpdatePlanningOutcome,
 } from './lifecycle-updates'
+import { executeAgentSelfUpdate } from '../agent-update'
 import { getAllAgents } from '../agents'
 import { loadConfig } from '../config'
 import { planLifecycleUpdate } from '../lifecycle'
@@ -90,6 +91,7 @@ export function createLifecycleUpdateBatchInvocation(): LifecycleUpdateBatchInvo
           isResourceLockError(error) ? { reason: error.message, resource: error.resource } : undefined,
         clock: () => new Date().toISOString(),
         dryRun: isDryRunEnabled(),
+        executeSelfUpdate: executeAgentSelfUpdate,
         listRegisteredAgentNames: () => getAllAgents().map(agent => agent.name),
         observe: observationService.resolveAgentObservation,
         planLifecycleUpdate,
@@ -179,6 +181,7 @@ export function createSingleAgentLifecycleUpdateInvocation(agentName: string): S
       return {
         clock: () => new Date().toISOString(),
         dryRun: isDryRunEnabled(),
+        executeSelfUpdate: executeAgentSelfUpdate,
         observe: observationService.resolveAgentObservation,
         planLifecycleUpdate,
         providerRegistry: firstPartyProviderRegistry,

--- a/src/services/lifecycle-updates.ts
+++ b/src/services/lifecycle-updates.ts
@@ -1,4 +1,4 @@
-import type { InstallMethod } from '../agents'
+import type { AgentSelfUpdate, InstallMethod } from '../agents'
 import type {
   LifecycleObservation,
   LifecyclePlanningProvider,
@@ -28,6 +28,7 @@ export interface LifecycleUpdateObservedAgent {
     readonly binaryName: string
     readonly displayName: string
     readonly name: string
+    readonly selfUpdate?: AgentSelfUpdate
   }
   readonly binding?: {
     readonly providerId: ProviderId
@@ -57,6 +58,11 @@ export interface LifecycleUpdateProviderRegistryPort {
 export interface LifecycleUpdateServicePorts {
   readonly clock: () => string
   readonly dryRun: boolean
+  readonly executeSelfUpdate?: (request: {
+    readonly commands: readonly (readonly string[])[]
+    readonly context: ProviderOperationContext
+    readonly target: ProviderTarget
+  }) => Promise<ProviderOutcome<ProviderMutationEvidence>>
   readonly observe: (agentName: string) => Promise<LifecycleUpdateObservedAgent | undefined>
   readonly planLifecycleUpdate: (input: LifecycleUpdatePlanningInput) => LifecycleUpdatePlanningResult
   readonly providerRegistry: LifecycleUpdateProviderRegistryPort
@@ -92,18 +98,30 @@ export interface LifecycleUpdateBatchPlan {
   readonly targets: readonly LifecycleUpdateBatchTargetPlan[]
 }
 
-export interface SingleAgentLifecycleUpdatePlan {
+interface SingleAgentLifecycleUpdatePlanBase {
   readonly before: LifecycleUpdateObservedAgent
   readonly binding: {
     readonly providerId: ProviderId
     readonly target: ProviderTarget
   }
-  readonly plannedTargetVersion: string
   readonly planning: LifecycleUpdatePlanningResult
-  readonly providerOptions?: RegistryPackageOperationOptions
 }
 
-export type LifecycleUpdateBlockedCategory = 'manual-required' | 'unsafe-source' | 'untracked'
+export interface ManagedAgentLifecycleUpdatePlan extends SingleAgentLifecycleUpdatePlanBase {
+  readonly plannedTargetVersion: string
+  readonly providerOptions?: RegistryPackageOperationOptions
+  readonly strategy: 'managed-provider'
+}
+
+export interface SelfAgentLifecycleUpdatePlan extends SingleAgentLifecycleUpdatePlanBase {
+  readonly beforeVersion: string
+  readonly commands: readonly (readonly string[])[]
+  readonly strategy: 'self-update'
+}
+
+export type SingleAgentLifecycleUpdatePlan = ManagedAgentLifecycleUpdatePlan | SelfAgentLifecycleUpdatePlan
+
+export type LifecycleUpdateBlockedCategory = 'manual-required' | 'stale-state' | 'unsafe-source' | 'untracked'
 
 export type SingleAgentLifecycleUpdatePlanningOutcome =
   | { readonly kind: 'unknown-agent'; readonly agentName: string }
@@ -174,6 +192,14 @@ export type SingleAgentLifecycleUpdateExecutionOutcome =
       readonly after: LifecycleUpdateObservedAgent
       readonly kind: 'updated'
       readonly plan: SingleAgentLifecycleUpdatePlan
+      readonly providerOutcome: Extract<ProviderOutcome<ProviderMutationEvidence>, { readonly kind: 'success' }>
+      readonly receipt: LifecycleReceipt
+      readonly verification: Extract<LifecycleVerification, { readonly kind: 'satisfied' }>
+    }
+  | {
+      readonly after: LifecycleUpdateObservedAgent
+      readonly kind: 'up-to-date'
+      readonly plan: SelfAgentLifecycleUpdatePlan
       readonly providerOutcome: Extract<ProviderOutcome<ProviderMutationEvidence>, { readonly kind: 'success' }>
       readonly receipt: LifecycleReceipt
       readonly verification: Extract<LifecycleVerification, { readonly kind: 'satisfied' }>
@@ -273,7 +299,14 @@ export async function executeLifecycleUpdateBatch(
 
 function isSuccessfulBatchTarget(target: LifecycleUpdateBatchTargetOutcome): boolean {
   const kind = target.execution?.kind
-  return kind === 'dry-run' || kind === 'not-executed' || kind === 'updated'
+  return (
+    kind === 'dry-run' ||
+    kind === 'not-executed' ||
+    kind === 'up-to-date' ||
+    kind === 'updated' ||
+    (target.planning.kind === 'blocked' &&
+      ['manual-required', 'stale-state', 'untracked'].includes(target.planning.category))
+  )
 }
 
 export async function planRegisteredAgentUpdates(
@@ -284,7 +317,7 @@ export async function planRegisteredAgentUpdates(
 
   for (const agentName of agentNames) {
     const outcome = await planSingleAgentLifecycleUpdate(agentName, ports)
-    if (isNormallyAbsentCatalogTarget(outcome)) continue
+    if (isCatalogOnlyAbsentTarget(outcome)) continue
     targets.push({ agentName, id: getSingleAgentLifecycleUpdateResolvedPlanId(agentName, outcome), outcome })
   }
 
@@ -321,18 +354,10 @@ export async function planRegisteredAgentUpdates(
   }
 }
 
-function isNormallyAbsentCatalogTarget(outcome: SingleAgentLifecycleUpdatePlanningOutcome): boolean {
-  if (outcome.kind !== 'blocked' || outcome.category !== 'unsafe-source') return false
-  const before = outcome.before
-  return (
-    before.observation.kind === 'absent' &&
-    before.observation.drift.kind === 'none' &&
-    !before.executable.present &&
-    before.binding === undefined &&
-    before.persistedBinding === undefined &&
-    before.installedState === undefined &&
-    before.receipt === undefined
-  )
+function isCatalogOnlyAbsentTarget(outcome: SingleAgentLifecycleUpdatePlanningOutcome): boolean {
+  if (outcome.kind === 'unknown-agent') return false
+  const before = outcome.kind === 'planned' ? outcome.planned.before : outcome.before
+  return !before.executable.present && before.installedState === undefined && before.receipt === undefined
 }
 
 export async function planSingleAgentLifecycleUpdate(
@@ -345,11 +370,41 @@ export async function planSingleAgentLifecycleUpdate(
 
   const binding = confirmedBinding(before)
   if (!binding) {
+    const staleState = before.observation.kind === 'absent' && before.observation.drift.kind === 'recorded-absent'
     return {
       before,
-      category: before.observation.drift.kind === 'untracked' ? 'untracked' : 'unsafe-source',
+      category: staleState
+        ? 'stale-state'
+        : before.observation.drift.kind === 'untracked'
+          ? 'untracked'
+          : 'unsafe-source',
       kind: 'blocked',
-      reason: 'The recorded update source does not match live provider evidence.',
+      reason: staleState
+        ? `${before.agent.displayName} has stale lifecycle evidence. Run \`quantex uninstall ${before.agent.name}\` to reconcile it.`
+        : 'The recorded update source does not match live provider evidence.',
+    }
+  }
+
+  if (isTrackedUnmanagedInstall(before.installedState) && before.agent.selfUpdate) {
+    const beforeVersion = consistentObservedVersion(before)
+    if (!beforeVersion) {
+      return {
+        before,
+        category: 'manual-required',
+        kind: 'blocked',
+        reason: `Cannot verify ${before.agent.displayName} self-update because its installed version is unknown.`,
+      }
+    }
+    return {
+      kind: 'planned',
+      planned: {
+        before,
+        beforeVersion,
+        binding,
+        commands: [before.agent.selfUpdate.command, ...(before.agent.selfUpdate.fallbackCommands ?? [])],
+        planning: createSelfUpdatePlanning(before),
+        strategy: 'self-update',
+      },
     }
   }
 
@@ -393,6 +448,7 @@ export async function planSingleAgentLifecycleUpdate(
       plannedTargetVersion: resolved.value.version,
       planning,
       providerOptions: ports.updateOptions,
+      strategy: 'managed-provider',
     },
   }
 }
@@ -415,6 +471,8 @@ async function executeLockedSingleAgentLifecycleUpdate(
   planned: SingleAgentLifecycleUpdatePlan,
   ports: LifecycleUpdateServicePorts,
 ): Promise<SingleAgentLifecycleUpdateExecutionOutcome> {
+  if (planned.strategy === 'self-update') return executeLockedSelfUpdate(planned, ports)
+
   const adapter = ports.providerRegistry.get(planned.binding.providerId)
   if (!adapter?.update) {
     return {
@@ -472,6 +530,71 @@ async function executeLockedSingleAgentLifecycleUpdate(
   return { after: after!, kind: 'updated', plan: planned, providerOutcome, receipt, verification }
 }
 
+async function executeLockedSelfUpdate(
+  planned: SelfAgentLifecycleUpdatePlan,
+  ports: LifecycleUpdateServicePorts,
+): Promise<SingleAgentLifecycleUpdateExecutionOutcome> {
+  if (!ports.executeSelfUpdate) {
+    return {
+      kind: 'provider-failed',
+      plan: planned,
+      providerOutcome: {
+        kind: 'unsupported',
+        operation: 'update',
+        reason: 'Self-update execution is unavailable.',
+      },
+    }
+  }
+
+  const providerOutcome = await ports.executeSelfUpdate({
+    commands: planned.commands,
+    context: operationContext(ports),
+    target: planned.binding.target,
+  })
+  if (providerOutcome.kind === 'timed-out') {
+    return { kind: 'timed-out', plan: planned, providerOutcome, timeoutMs: providerOutcome.timeoutMs }
+  }
+  if (providerOutcome.kind === 'cancelled') {
+    return { kind: 'cancelled', plan: planned, providerOutcome, reason: providerOutcome.reason }
+  }
+  if (providerOutcome.kind !== 'success') return { kind: 'provider-failed', plan: planned, providerOutcome }
+  if (ports.signal.aborted) {
+    return { kind: 'cancelled', plan: planned, providerOutcome, reason: abortReason(ports.signal) }
+  }
+
+  const after = await ports.observe(planned.before.agent.name)
+  if (ports.signal.aborted) {
+    return { after, kind: 'cancelled', plan: planned, providerOutcome, reason: abortReason(ports.signal) }
+  }
+  const verified = verifySelfUpdatedObservation(planned, after)
+  if (verified.verification.kind !== 'satisfied') {
+    return { after, kind: 'verification-failed', plan: planned, providerOutcome, verification: verified.verification }
+  }
+
+  const receipt = createReceipt(planned, after!, ports.clock())
+  try {
+    await ports.writeReceipt(receipt)
+  } catch (error) {
+    return {
+      after: after!,
+      kind: 'receipt-failed',
+      plan: planned,
+      providerOutcome,
+      reason: safeErrorReason(error),
+      verification: verified.verification,
+    }
+  }
+
+  return {
+    after: after!,
+    kind: verified.changed ? 'updated' : 'up-to-date',
+    plan: planned,
+    providerOutcome,
+    receipt,
+    verification: verified.verification,
+  }
+}
+
 function confirmedBinding(
   observed: LifecycleUpdateObservedAgent,
 ): SingleAgentLifecycleUpdatePlan['binding'] | undefined {
@@ -493,7 +616,7 @@ function confirmedBinding(
 }
 
 function verifyUpdatedObservation(
-  planned: SingleAgentLifecycleUpdatePlan,
+  planned: ManagedAgentLifecycleUpdatePlan,
   after: LifecycleUpdateObservedAgent | undefined,
 ): LifecycleVerification {
   const postcondition: LifecyclePostcondition = {
@@ -552,6 +675,98 @@ function verifyUpdatedObservation(
   return { kind: 'satisfied', observation: after.observation, postcondition }
 }
 
+function verifySelfUpdatedObservation(
+  planned: SelfAgentLifecycleUpdatePlan,
+  after: LifecycleUpdateObservedAgent | undefined,
+): { readonly changed: boolean; readonly verification: LifecycleVerification } {
+  const fallbackPostcondition: LifecyclePostcondition = {
+    expectedVersion: planned.beforeVersion,
+    kind: 'version-satisfies',
+    targetId: planned.binding.target.id,
+  }
+  if (!after) {
+    return {
+      changed: false,
+      verification: { kind: 'indeterminate', postcondition: fallbackPostcondition, reason: 'The agent disappeared.' },
+    }
+  }
+  if (!sameBinding(planned.binding, after.binding) || after.observation.drift.kind !== 'none') {
+    return {
+      changed: false,
+      verification: {
+        kind: 'unsatisfied',
+        observation: after.observation,
+        postcondition: fallbackPostcondition,
+        reason: 'Fresh observation no longer matches the recorded self-update source.',
+      },
+    }
+  }
+  if (after.observation.kind !== 'present' || !after.executable.present) {
+    return {
+      changed: false,
+      verification: {
+        kind: 'unsatisfied',
+        observation: after.observation,
+        postcondition: fallbackPostcondition,
+        reason: 'The executable is not present after self-update.',
+      },
+    }
+  }
+
+  const afterVersion = consistentObservedVersion(after)
+  const order = afterVersion ? compareVersions(afterVersion, planned.beforeVersion) : undefined
+  if (!afterVersion || order === undefined || order < 0) {
+    return {
+      changed: false,
+      verification: {
+        kind: 'unsatisfied',
+        observation: after.observation,
+        postcondition: fallbackPostcondition,
+        reason: `Observed version ${afterVersion ?? 'unknown'} cannot verify self-update from ${planned.beforeVersion}.`,
+      },
+    }
+  }
+
+  return {
+    changed: order > 0,
+    verification: {
+      kind: 'satisfied',
+      observation: after.observation,
+      postcondition: {
+        expectedVersion: afterVersion,
+        kind: 'version-satisfies',
+        targetId: planned.binding.target.id,
+      },
+    },
+  }
+}
+
+function consistentObservedVersion(observed: LifecycleUpdateObservedAgent): string | undefined {
+  const versions = [
+    observed.observation.kind === 'present' ? observed.observation.version : undefined,
+    observed.executable.version,
+  ].filter((version): version is string => version !== undefined)
+  const version = versions[0]
+  return version && versions.every(candidate => compareVersions(candidate, version) === 0) ? version : undefined
+}
+
+function isTrackedUnmanagedInstall(state: InstalledAgentState | undefined): boolean {
+  return state?.installType === 'script' || state?.installType === 'binary'
+}
+
+function createSelfUpdatePlanning(before: LifecycleUpdateObservedAgent): LifecycleUpdatePlanningResult {
+  return {
+    decision: 'upgrade',
+    plan: {
+      id: `self-update-${before.agent.name}`,
+      intent: { kind: 'update', targetId: before.agent.name },
+      kind: 'lifecycle-plan',
+      observation: before.observation,
+      steps: [],
+    },
+  }
+}
+
 function createReceipt(
   planned: SingleAgentLifecycleUpdatePlan,
   after: LifecycleUpdateObservedAgent,
@@ -591,7 +806,17 @@ export function getSingleAgentLifecycleUpdateResolvedPlanId(
 ): string {
   const prefix = `update-target:agent=${identityPart(agentName)};outcome=${outcome.kind}`
   if (outcome.kind === 'planned') {
-    const { binding, plannedTargetVersion, planning, providerOptions } = outcome.planned
+    const { binding, planning } = outcome.planned
+    if (outcome.planned.strategy === 'self-update') {
+      return `${prefix};strategy=self-update;provider=${identityPart(binding.providerId)};providerTargetKind=${identityPart(
+        binding.target.kind,
+      )};providerTarget=${identityPart(binding.target.id)};binary=${identityPart(
+        binding.target.binaryName,
+      )};beforeVersion=${identityPart(outcome.planned.beforeVersion)};commands=${outcome.planned.commands
+        .map(commandIdentity)
+        .join('|')};plan=${identityPart(planning.plan.id)}`
+    }
+    const { plannedTargetVersion, providerOptions } = outcome.planned
     return `${prefix};provider=${identityPart(binding.providerId)};providerTargetKind=${identityPart(
       binding.target.kind,
     )};providerTarget=${identityPart(binding.target.id)};binary=${identityPart(
@@ -647,6 +872,7 @@ function evidenceIdentity(evidence: readonly ProviderEvidence[] | undefined): st
 function automaticProviderCompatibilityId(target: LifecycleUpdateBatchTargetPlan): string | undefined {
   if (target.outcome.kind !== 'planned' || target.outcome.planned.planning.decision !== 'upgrade') return undefined
   const planned = target.outcome.planned
+  if (planned.strategy !== 'managed-provider') return undefined
   return `provider=${identityPart(planned.binding.providerId)};${providerOptionsIdentity(planned.providerOptions)}`
 }
 

--- a/test/commands/update.test.ts
+++ b/test/commands/update.test.ts
@@ -182,6 +182,7 @@ describe('updateCommand', () => {
         },
         binding: { providerId: 'bun', target: { id: 'test-pkg', kind: 'package' } },
         plannedTargetVersion: '2.0.0',
+        strategy: 'managed-provider',
         planning: {
           decision: 'upgrade',
           plan: {
@@ -524,6 +525,71 @@ describe('updateCommand', () => {
       }
     },
   )
+
+  it('projects the same blocked untracked PATH outcome as manual-required in single scope', async () => {
+    const alpha = createBatchCommandUntrackedTarget('alpha')
+    agentSpy.mockReturnValue(alpha.agent)
+    lifecycleUpdateSpy.mockResolvedValue(alpha.target.outcome as never)
+
+    const result = await updateCommand('alpha', false)
+
+    expect(result.ok).toBe(true)
+    expect(result.data?.results).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining('detected in PATH but not tracked'),
+        name: 'alpha',
+        status: 'manual-required',
+      }),
+    ])
+  })
+
+  it('omits stale installed-state entries from update --all results and emits reconciliation guidance', async () => {
+    mockBatchCommandAgents(['jcode'])
+    const jcode = createBatchCommandStaleTarget('jcode')
+    const batchRoot = requireLifecycleBatchRoot()
+    const batchSpy = vi.spyOn(lifecycleUpdateProduction, batchRoot).mockResolvedValue({
+      cancellationRemainder: [],
+      kind: 'lifecycle-update-batch-outcome',
+      plan: createBatchCommandPlan([jcode.target]),
+      results: [jcode.result],
+      success: true,
+    } as never)
+
+    try {
+      const result = await updateCommand(undefined, true)
+
+      expect(result.ok).toBe(true)
+      expect(result.data?.results).toEqual([])
+      expect(result.warnings).toEqual([
+        expect.objectContaining({
+          code: 'AGENT_STALE_STATE',
+          details: expect.objectContaining({ suggestedCommands: ['quantex uninstall jcode'] }),
+        }),
+      ])
+      const output = stdoutWriteSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('\n')
+      expect(output).toContain('stale lifecycle evidence')
+      expect(output).toContain('quantex uninstall jcode')
+    } finally {
+      batchSpy.mockRestore()
+    }
+  })
+
+  it('returns the same stale-state guidance for a single-agent update', async () => {
+    const jcode = createBatchCommandStaleTarget('jcode')
+    agentSpy.mockReturnValue(jcode.agent)
+    lifecycleUpdateSpy.mockResolvedValue(jcode.target.outcome as never)
+
+    const result = await updateCommand('jcode', false)
+
+    expect(result.ok).toBe(false)
+    expect(result.error?.code).toBe('AGENT_NOT_INSTALLED')
+    expect(result.warnings).toEqual([
+      expect.objectContaining({
+        code: 'AGENT_STALE_STATE',
+        details: expect.objectContaining({ suggestedCommands: ['quantex uninstall jcode'] }),
+      }),
+    ])
+  })
 
   it.each(['human', 'json', 'ndjson'] as const)(
     'projects a typed manual planning block as manual-required in %s mode',
@@ -974,6 +1040,7 @@ function mockSingleLifecycleOutcome(options: {
     before,
     binding: { providerId, target },
     plannedTargetVersion: options.latestVersion ?? options.installedVersion,
+    strategy: 'managed-provider' as const,
     planning: {
       decision: options.decision,
       plan: {
@@ -1078,6 +1145,7 @@ function createBatchCommandTarget(
     before,
     binding: { providerId: 'npm' as const, target },
     plannedTargetVersion: '2.0.0',
+    strategy: 'managed-provider' as const,
     planning: {
       decision,
       plan: {
@@ -1147,7 +1215,35 @@ function createBatchCommandUntrackedTarget(name: string) {
     reason: `Cannot infer the update source for ${name}.`,
   }
   const target = { agentName: name, id: `target-${name}`, outcome: planning }
-  return { result: { agentName: name, id: target.id, planning }, target }
+  return { agent, result: { agentName: name, id: target.id, planning }, target }
+}
+
+function createBatchCommandStaleTarget(name: string) {
+  const agent = { ...testAgent, binaryName: `${name}-bin`, displayName: name.toUpperCase(), name }
+  const before = {
+    agent,
+    capabilities: ['observe'] as const,
+    executable: { present: false },
+    installedState: {
+      agentName: name,
+      command: `curl https://example.com/${name} | bash`,
+      installType: 'script' as const,
+    },
+    methods: [{ command: `curl https://example.com/${name} | bash`, type: 'script' as const }],
+    observation: {
+      drift: { kind: 'recorded-absent' as const },
+      kind: 'absent' as const,
+      targetId: name,
+    },
+  }
+  const planning = {
+    before,
+    category: 'stale-state' as const,
+    kind: 'blocked' as const,
+    reason: `${agent.displayName} has stale lifecycle evidence.`,
+  }
+  const target = { agentName: name, id: `target-${name}`, outcome: planning }
+  return { agent, result: { agentName: name, id: target.id, planning }, target }
 }
 
 function createBatchCommandManualBlockedTarget(name: string) {

--- a/test/services/lifecycle-updates.test.ts
+++ b/test/services/lifecycle-updates.test.ts
@@ -159,6 +159,55 @@ describe('registered-agent lifecycle update batch planning', () => {
     expect(unsafePlan.resolvedPlanId).not.toBe(manualPlan.resolvedPlanId)
   })
 
+  it('omits a catalog-only target when neither live nor persisted evidence says it is installed', async () => {
+    const harness = createBatchHarness(['genie'], { genie: { providerId: 'npm' } })
+    const ports: LifecycleUpdateBatchPlanningPorts = {
+      ...harness.ports,
+      observe: async () => ({
+        ...batchObservationResult('genie', { providerId: 'npm' }),
+        executable: { present: false },
+        observation: {
+          drift: { kind: 'indeterminate', reason: 'provider unavailable' },
+          kind: 'indeterminate',
+          reason: 'provider unavailable',
+          targetId: 'genie',
+        },
+      }),
+    }
+
+    const plan = await planRegisteredAgentUpdates(ports)
+
+    expect(plan.targets).toEqual([])
+    expect(plan.providerBuckets).toEqual([])
+  })
+
+  it('preserves stale persisted state as a non-automatic reconciliation target', async () => {
+    const harness = createBatchHarness(['jcode'], { jcode: { providerId: 'npm' } })
+    const ports: LifecycleUpdateBatchPlanningPorts = {
+      ...harness.ports,
+      observe: async () => ({
+        ...batchObservationResult('jcode', { providerId: 'npm' }),
+        executable: { present: false },
+        installedState: {
+          agentName: 'jcode',
+          command: 'curl https://example.com/jcode | bash',
+          installType: 'script',
+        },
+        observation: {
+          drift: { kind: 'recorded-absent' },
+          kind: 'absent',
+          targetId: 'jcode',
+        },
+      }),
+    }
+
+    const plan = await planRegisteredAgentUpdates(ports)
+
+    expect(plan.targets).toHaveLength(1)
+    expect(plan.targets[0]?.outcome).toMatchObject({ category: 'stale-state', kind: 'blocked' })
+    expect(plan.providerBuckets).toEqual([])
+  })
+
   it.each(providerOutcomeIdentityCases)(
     'changes resolved identity when provider outcome %s changes',
     async (_field, before, after) => {
@@ -550,6 +599,46 @@ describe('single-agent lifecycle update application service', () => {
     })
     expect(harness.writeReceipt).toHaveBeenCalledTimes(1)
   })
+
+  it('uses the recorded self-update command for a tracked script install', async () => {
+    const harness = createSelfUpdateHarness({ afterVersion: '2.0.0' })
+    const planned = await requirePlanned(harness.ports)
+
+    expect(planned).toMatchObject({
+      beforeVersion: '1.0.0',
+      commands: [['alpha', 'update']],
+      strategy: 'self-update',
+    })
+    const result = await executeSingleAgentLifecycleUpdate(planned, harness.ports)
+
+    expect(result).toMatchObject({ kind: 'updated', receipt: { version: '2.0.0' } })
+    expect(harness.executeSelfUpdate).toHaveBeenCalledOnce()
+    expect(harness.resolveLatestVersion).not.toHaveBeenCalled()
+    expect(harness.writeReceipt).toHaveBeenCalledOnce()
+  })
+
+  it('reports a successful self-update with an unchanged version as up-to-date', async () => {
+    const harness = createSelfUpdateHarness({ afterVersion: '1.0.0' })
+    const planned = await requirePlanned(harness.ports)
+
+    const result = await executeSingleAgentLifecycleUpdate(planned, harness.ports)
+
+    expect(result).toMatchObject({ kind: 'up-to-date', receipt: { version: '1.0.0' } })
+    expect(harness.writeReceipt).toHaveBeenCalledOnce()
+  })
+
+  it('does not persist a receipt when the tracked self-update command fails', async () => {
+    const harness = createSelfUpdateHarness({
+      afterVersion: '1.0.0',
+      executeOutcome: { kind: 'failed', reason: 'self update failed', retryable: false },
+    })
+    const planned = await requirePlanned(harness.ports)
+
+    const result = await executeSingleAgentLifecycleUpdate(planned, harness.ports)
+
+    expect(result).toMatchObject({ kind: 'provider-failed', providerOutcome: { kind: 'failed' } })
+    expect(harness.writeReceipt).not.toHaveBeenCalled()
+  })
 })
 
 async function requirePlanned(ports: LifecycleUpdateServicePorts): Promise<SingleAgentLifecycleUpdatePlan> {
@@ -625,6 +714,81 @@ function createHarness(
     writeReceipt,
   }
   return { observe, ports, resolveLatestVersion, update, writeReceipt }
+}
+
+function createSelfUpdateHarness(options: { afterVersion: string; executeOutcome?: ProviderOutcome<never> }) {
+  const target = {
+    binaryName: 'alpha',
+    effect: { command: 'curl https://example.com/alpha | bash', kind: 'shell-script' as const },
+    id: 'https://example.com/alpha',
+    kind: 'script' as const,
+  }
+  let version = '1.0.0'
+  const observe = vi.fn(async () => ({
+    agent: {
+      binaryName: 'alpha',
+      displayName: 'Alpha',
+      name: 'alpha',
+      selfUpdate: { command: ['alpha', 'update'] },
+    },
+    binding: { providerId: 'script' as const, target },
+    capabilities: ['observe'] as const,
+    executable: { path: '/bin/alpha', present: true, version },
+    installedState: {
+      agentName: 'alpha',
+      command: 'curl https://example.com/alpha | bash',
+      installType: 'script' as const,
+    },
+    methods: [
+      {
+        command: 'curl https://example.com/alpha | bash',
+        probes: ['executable-presence' as const],
+        type: 'script' as const,
+      },
+    ],
+    observation: {
+      drift: { kind: 'none' as const },
+      executablePath: '/bin/alpha',
+      kind: 'present' as const,
+      providerId: 'script',
+      providerTargetId: target.id,
+      providerTargetKind: 'script' as const,
+      targetId: 'alpha',
+      version,
+    },
+    persistedBinding: { providerId: 'script' as const, target },
+  }))
+  const executeSelfUpdate = vi.fn(async () => {
+    version = options.afterVersion
+    return (
+      options.executeOutcome ?? {
+        kind: 'success' as const,
+        value: { evidence: [], target },
+      }
+    )
+  })
+  const resolveLatestVersion = vi.fn()
+  const writeReceipt = vi.fn(async (_receipt: LifecycleReceipt) => undefined)
+  const ports: LifecycleUpdateServicePorts = {
+    clock: () => '2026-07-13T04:00:00.000Z',
+    dryRun: false,
+    executeSelfUpdate,
+    observe,
+    planLifecycleUpdate,
+    providerRegistry: {
+      get: () =>
+        ({
+          availability: vi.fn(),
+          id: 'script',
+          observe: vi.fn(),
+          resolveLatestVersion,
+        }) as unknown as ProviderAdapter,
+      getCapabilities: () => ['observe'],
+    },
+    signal: new AbortController().signal,
+    writeReceipt,
+  }
+  return { executeSelfUpdate, ports, resolveLatestVersion, writeReceipt }
 }
 
 function observationResult(options: { executableVersion?: string; observation?: LifecycleObservation } = {}) {


### PR DESCRIPTION
## Summary

Fix lifecycle update reconciliation so `update --all` ignores never-installed catalog entries, reports ghost state without failing the batch, and uses declared self-update commands for tracked script or binary installs such as Cursor CLI.

The change keeps PATH-only agents such as Hermes manual and untracked, preserves recorded install provenance, and verifies self-update results from a fresh observation before reporting success.

## Linked Artifacts

- Issue:
- ADR:
- OpenSpec: `openspec/changes/fix-agent-update-reconciliation`
- Discussion:

## Validation

- [x] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [x] `bun run test` (1614 passed, 1 skipped)
- [x] `bun run openspec:validate`
- [x] Source CLI dry-runs for `update cursor` and `update --all`

## Release Intent

- Release: patch - fixes incorrect batch failures and restores tracked self-update execution

## Release Summary

BEGIN_COMMIT_OVERRIDE
fix(update): reconcile tracked self-updates and stale agent state

Use declared self-update commands for tracked script and binary installs, omit never-installed catalog entries from batch updates, and surface stale lifecycle evidence as actionable non-fatal guidance.
END_COMMIT_OVERRIDE

## Docs Updated

- [ ] Not needed
- [ ] `docs/...`
- [x] `openspec/changes/fix-agent-update-reconciliation`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant OpenSpec proposal, design, delta spec, and tasks.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] The intended change set was clean after commit; a pre-existing local `.codegraph/.gitignore` edit remains excluded.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change remains active until merge and is queued for archive closure afterward.
- [x] Release is delegated to release automation as a patch.

## Notes

Please pay particular attention to the self-update verification boundary: a successful command is reported as `updated` only when the fresh version increases, `up-to-date` when unchanged, and failed when source or version evidence cannot be verified.
