### PR TITLE
chore(codegraph): tighten local ignore rules

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,20 +1,5 @@
-# CodeGraph data files
-# These are local to each machine and should not be committed
-
-# Database
-*.db
-*.db-wal
-*.db-shm
-
-# Cache
-cache/
-
-# Logs
-*.log
-
-# Hook markers
-.dirty
-
-# Process IDs and sockets
-*.pid
-*.sock
+# CodeGraph data files — local to each machine, not for committing.
+# Ignore everything in .codegraph/ except this file itself, so transient
+# files (the database, daemon.pid, sockets, logs) never show up in git.
+*
+!.gitignore


### PR DESCRIPTION
## Summary

Tighten `.codegraph/.gitignore` so all transient CodeGraph files are ignored while the ignore file itself remains tracked. This prevents local databases, caches, logs, sockets, and process files from appearing as workspace changes.

## Linked Artifacts

- Issue: Not applicable
- ADR: Not applicable
- OpenSpec: Not needed - mechanical repository maintenance with no product or process behavior change
- Discussion: Not applicable

## Validation

- [ ] `bun run memory:check`
- [x] `bun run lint`
- [x] `bun run format:check`
- [x] `bun run typecheck`
- [ ] `bun run test` (if behavior changed)
- [x] Not run, explained below

No CLI behavior changed; the test suite and memory check were not needed for this ignore-rule-only change.

## Release Intent

- Release: not applicable - docs/process/test-only change

## Release Summary

- Not applicable - this source PR does not produce a release entry.

## Docs Updated

- [x] Not needed
- [ ] `docs/...`
- [ ] `openspec/...`
- [ ] Follow-up issue or OpenSpec change created instead

## Scope Check

- [x] I did not add a new ad hoc root-level Markdown file.
- [x] I updated the relevant issue, ADR, spec, runbook, or captured the missing doc work as follow-up.
- [x] I did not silently expand project scope without recording it explicitly.

## Closure Check

- [x] Working tree was clean after commit.
- [x] Branch was pushed and this PR is the active delivery artifact.
- [x] OpenSpec change is not needed, still active until this merge, active across milestone merges by design, queued for agent-driven archive closure after completion, or already archived.
- [x] Release is not applicable, delegated to release automation, or verified.

## Notes

The change is intentionally limited to `.codegraph/.gitignore`.
